### PR TITLE
Add Modal remote backend support

### DIFF
--- a/docs/commands/templates.md
+++ b/docs/commands/templates.md
@@ -61,6 +61,7 @@ agentkernel ships with 26 built-in templates:
 | `daytona-remote` | Daytona | Managed `/workspace` sync on Daytona |
 | `runloop-remote` | Runloop | Managed `/workspace` sync on Runloop |
 | `e2b-remote` | E2B | Managed `/workspace` sync on E2B |
+| `modal-remote` | Modal | Managed `/workspace` sync on Modal |
 
 ## Examples
 
@@ -84,6 +85,7 @@ my-custom            local      ubuntu:24.04
 agentkernel sandbox create my-sandbox --template python
 agentkernel sandbox create ci-runner --template rust-ci -B docker
 agentkernel sandbox create remote-dev --template e2b-remote -B e2b
+agentkernel sandbox create remote-modal --template modal-remote -B modal
 agentkernel sandbox create remote-runloop --template runloop-remote -B runloop
 ```
 

--- a/docs/config/backends.md
+++ b/docs/config/backends.md
@@ -177,12 +177,13 @@ See the [Orchestration Guide](../operations/index.md) for full configuration and
 
 ## Remote Backends
 
-`daytona`, `runloop`, `e2b`, and `agentcomputer` use the shared remote sandbox substrate. They keep the same CLI and HTTP verbs as local backends, but route sandbox lifecycle, workspace sync, and service publishing through the remote bridge.
+`daytona`, `runloop`, `e2b`, `modal`, and `agentcomputer` use the shared remote sandbox substrate. They keep the same CLI and HTTP verbs as local backends, but route sandbox lifecycle, workspace sync, and service publishing through the remote bridge.
 
 ```bash
 agentkernel sandbox create my-sandbox --backend daytona
 agentkernel sandbox create my-sandbox --backend runloop
 agentkernel sandbox create my-sandbox --backend e2b
+agentkernel sandbox create my-sandbox --backend modal
 agentkernel sandbox create my-sandbox --backend agentcomputer
 ```
 
@@ -202,8 +203,9 @@ agentkernel sandbox create my-sandbox --backend agentcomputer
 - `daytona` is wired in the bundled bridge via `@daytonaio/sdk`
 - `runloop` is wired in the bundled bridge via `@runloop/api-client`
 - `e2b` is wired in the bundled bridge via the official `e2b` SDK
+- `modal` is wired in the bundled bridge via the official `modal` SDK
 - all shipped adapters support live lifecycle, `exec`, `attach`, file operations, managed `mount_cwd` sync, resolved endpoints, and workspace-level snapshot/restore
-- credentials can come from exported provider env vars or from `[remote.daytona]` / `[remote.runloop]` / `[remote.e2b]` in `agentkernel.toml`
+- credentials can come from exported provider env vars or from `[remote.daytona]` / `[remote.runloop]` / `[remote.e2b]` / `[remote.modal]` in `agentkernel.toml`
 - explicit `-c path/to/agentkernel.toml` is persisted with the sandbox so later `start`, `exec`, and snapshot flows can reconnect with the same remote config
 - set `[remote].bridge` when you run `agentkernel` outside the repository root and still want to use the bundled `scripts/remote-bridge.mjs`
 - the bundled bridge still supports `AGENTKERNEL_REMOTE_BRIDGE_MODE=mock` for local testing

--- a/docs/config/toml.md
+++ b/docs/config/toml.md
@@ -226,9 +226,9 @@ See the [Orchestration Guide](../operations/index.md) for detailed usage and dep
 
 ## [remote]
 
-Configuration for hosted remote backends (`daytona`, `runloop`, `e2b`, `agentcomputer`).
+Configuration for hosted remote backends (`daytona`, `runloop`, `e2b`, `modal`, `agentcomputer`).
 
-Current note: `daytona`, `runloop`, and `e2b` are the shipped live adapters today. The bundled
+Current note: `daytona`, `runloop`, `e2b`, and `modal` are the shipped live adapters today. The bundled
 bridge reads provider credentials and routing from `[remote.<provider>]`, or
 from exported provider environment variables when you prefer env-based setup.
 
@@ -250,6 +250,11 @@ api_key_env = "RUNLOOP_API_KEY"
 [remote.e2b]
 api_key_env = "E2B_API_KEY"
 
+[remote.modal]
+token_id_env = "MODAL_TOKEN_ID"
+token_secret_env = "MODAL_TOKEN_SECRET"
+project = "agentkernel"
+
 [remote.agentcomputer]
 api_key_env = "AGENTCOMPUTER_API_KEY"
 
@@ -270,13 +275,18 @@ NODE_ENV = "development"
 
 ### [remote.<provider>]
 
-Supported providers: `daytona`, `runloop`, `e2b`, `agentcomputer`.
+Supported providers: `daytona`, `runloop`, `e2b`, `modal`, `agentcomputer`.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `api_key` | string | none | Inline provider API key |
 | `api_key_env` | string | none | Environment variable containing the API key |
+| `token_id` | string | none | Inline provider token ID |
+| `token_id_env` | string | none | Environment variable containing the provider token ID |
+| `token_secret` | string | none | Inline provider token secret |
+| `token_secret_env` | string | none | Environment variable containing the provider token secret |
 | `base_url` | string | provider default | Override API base URL |
+| `environment` | string | provider default | Provider environment or workspace environment name |
 | `organization` | string | none | Provider organization or team |
 | `project` | string | none | Provider project/workspace name |
 | `region` | string | none | Default provider region |
@@ -287,6 +297,7 @@ For the bundled live adapters today:
 - `daytona` uses `api_key`, `api_key_env`, `base_url`, `organization`, and `region`
 - `runloop` uses `api_key` / `api_key_env` and optionally `base_url`
 - `e2b` uses `api_key` / `api_key_env` and optionally `base_url`
+- `modal` uses `token_id`, `token_id_env`, `token_secret`, `token_secret_env`, and optionally `base_url`, `environment`, `project`, and `region`
 - `agentcomputer` config can be declared now, but the bundled bridge does not ship its live adapter yet
 
 ### [remote.profiles.<name>]

--- a/docs/index.md
+++ b/docs/index.md
@@ -135,11 +135,12 @@ agentkernel covers local, cluster, and hosted backends behind the same CLI and H
 | Daytona | `daytona` | Hosted sandbox with managed `/workspace` sync |
 | Runloop | `runloop` | Hosted devbox with tunnels, attach, and snapshot/restore |
 | E2B | `e2b` | Hosted sandbox with file APIs, PTY attach, and snapshots |
+| Modal | `modal` | Hosted sandbox with tunnels, attach, and workspace snapshots |
 | Agent Computer | `agentcomputer` | Contract wired; live bundled adapter still pending |
 
 On Linux with KVM, you get Firecracker -- the same microVM technology that powers AWS Lambda and Fargate. On macOS 26+, Apple Containers provide native VM isolation. On older macOS or systems without KVM, Docker and Podman provide container-level isolation as a fallback. For team and cloud environments, deploy on [Kubernetes](operations/kubernetes.md) or [Nomad](operations/nomad.md) with warm pools, CRDs, and Helm/Nomad Pack support.
 
-For team and multi-tenant deployments, Kubernetes, Nomad, Daytona, Runloop, and E2B keep the same sandbox lifecycle and command surface while moving execution off your laptop. See the [Backends Guide](config/backends.md) for the full matrix and the [Remote Backends Guide](operations/remote.md) for hosted setup, templates, and examples.
+For team and multi-tenant deployments, Kubernetes, Nomad, Daytona, Runloop, E2B, and Modal keep the same sandbox lifecycle and command surface while moving execution off your laptop. See the [Backends Guide](config/backends.md) for the full matrix and the [Remote Backends Guide](operations/remote.md) for hosted setup, templates, and examples.
 
 ```bash
 # Run on Kubernetes
@@ -156,6 +157,9 @@ agentkernel sandbox create remote-runloop --backend runloop
 
 # Run on E2B
 agentkernel sandbox create remote-e2b --backend e2b
+
+# Run on Modal
+agentkernel sandbox create remote-modal --backend modal
 ```
 
 Cluster backends support warm pools for fast acquisition (~570ms one-shot latency) and scale to dozens of concurrent sandboxes per node. Hosted backends use the same sandbox lifecycle, with provider-side execution and managed `/workspace` sync.

--- a/docs/operations/remote.md
+++ b/docs/operations/remote.md
@@ -7,6 +7,7 @@ The bundled bridge currently ships live adapters for:
 - `daytona`
 - `runloop`
 - `e2b`
+- `modal`
 
 `agentcomputer` is parsed as a backend value and keeps the same contract shape, but the bundled live adapter is not landed yet.
 
@@ -17,7 +18,7 @@ npm install --prefix scripts
 node --version   # Node.js 20+
 ```
 
-Provider credentials can come from exported environment variables or from `api_key_env` names in `agentkernel.toml`.
+Provider credentials can come from exported environment variables or from `api_key_env` / `token_*_env` names in `agentkernel.toml`.
 
 ## Common Behavior
 
@@ -85,6 +86,39 @@ agentkernel exec my-e2b -- sh -lc 'python3 --version || node -v'
 agentkernel snapshot take my-e2b --name my-e2b-snap
 ```
 
+## Modal
+
+Example config:
+
+```toml
+[sandbox]
+name = "modal-demo"
+base_image = "base"
+
+[security]
+mount_cwd = true
+network = true
+
+[network]
+ports = ["3000"]
+
+[remote]
+bridge = "./scripts/remote-bridge.mjs"
+
+[remote.modal]
+token_id_env = "MODAL_TOKEN_ID"
+token_secret_env = "MODAL_TOKEN_SECRET"
+project = "agentkernel"
+```
+
+Run it:
+
+```bash
+agentkernel sandbox create my-modal --backend modal -c agentkernel.toml
+agentkernel exec my-modal -- sh -lc 'pwd && ls -la /workspace'
+agentkernel snapshot take my-modal --name my-modal-snap
+```
+
 ## Runloop
 
 Example config:
@@ -121,3 +155,4 @@ agentkernel snapshot take my-runloop --name my-runloop-snap
 - [examples/remote-daytona/README.md](../../examples/remote-daytona/README.md)
 - [examples/remote-runloop/README.md](../../examples/remote-runloop/README.md)
 - [examples/remote-e2b/README.md](../../examples/remote-e2b/README.md)
+- [examples/remote-modal/README.md](../../examples/remote-modal/README.md)

--- a/examples/README.md
+++ b/examples/README.md
@@ -186,6 +186,17 @@ agentkernel exec remote-e2b -- sh -lc 'python3 --version || node -v'
 
 **Features**: managed `/workspace` sync, file APIs, PTY attach, live snapshot/restore
 
+### Remote Modal
+Run a hosted sandbox through the bundled Modal bridge.
+
+```bash
+npm install --prefix scripts
+agentkernel sandbox create remote-modal --backend modal -c examples/remote-modal/agentkernel.toml
+agentkernel exec remote-modal -- sh -lc 'pwd && ls -la /workspace'
+```
+
+**Features**: managed `/workspace` sync, tunnel-backed endpoints, interactive attach, live snapshot/restore
+
 ### Enterprise Policies
 Centralized Cedar policy management with RBAC, MFA enforcement, and runtime restrictions. Requires `--features enterprise`.
 

--- a/examples/remote-daytona/agentkernel.toml
+++ b/examples/remote-daytona/agentkernel.toml
@@ -12,7 +12,7 @@ network = true
 ports = ["3000"]
 
 [remote]
-bridge = "./scripts/remote-bridge.mjs"
+bridge = "../../scripts/remote-bridge.mjs"
 
 [remote.daytona]
 api_key_env = "DAYTONA_API_KEY"

--- a/examples/remote-modal/README.md
+++ b/examples/remote-modal/README.md
@@ -1,0 +1,13 @@
+# Remote Modal Example
+
+```bash
+npm install --prefix scripts
+export MODAL_TOKEN_ID=...
+export MODAL_TOKEN_SECRET=...
+
+agentkernel sandbox create remote-modal --backend modal -c examples/remote-modal/agentkernel.toml
+agentkernel exec remote-modal -- sh -lc 'pwd && ls -la /workspace'
+agentkernel snapshot take remote-modal --name remote-modal-snap
+```
+
+The bundled Modal adapter supports lifecycle, `/workspace` sync, file APIs, interactive attach, tunnel-backed endpoints, and workspace snapshot restore.

--- a/examples/remote-modal/agentkernel.toml
+++ b/examples/remote-modal/agentkernel.toml
@@ -1,7 +1,7 @@
-# Remote E2B example
+# Remote Modal example
 
 [sandbox]
-name = "remote-e2b"
+name = "remote-modal"
 base_image = "base"
 
 [security]
@@ -14,5 +14,7 @@ ports = ["3000"]
 [remote]
 bridge = "../../scripts/remote-bridge.mjs"
 
-[remote.e2b]
-api_key_env = "E2B_API_KEY"
+[remote.modal]
+token_id_env = "MODAL_TOKEN_ID"
+token_secret_env = "MODAL_TOKEN_SECRET"
+project = "agentkernel"

--- a/examples/remote-runloop/agentkernel.toml
+++ b/examples/remote-runloop/agentkernel.toml
@@ -12,7 +12,7 @@ network = true
 ports = ["3000"]
 
 [remote]
-bridge = "./scripts/remote-bridge.mjs"
+bridge = "../../scripts/remote-bridge.mjs"
 
 [remote.runloop]
 api_key_env = "RUNLOOP_API_KEY"

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -8,7 +8,11 @@
       "dependencies": {
         "@daytonaio/sdk": "^0.158.0",
         "@runloop/api-client": "^1.14.1",
-        "e2b": "^2.18.0"
+        "e2b": "^2.18.0",
+        "modal": "^0.7.3"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -889,6 +893,84 @@
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.11.0.tgz",
       "integrity": "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@cbor-extract/cbor-extract-darwin-arm64": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-darwin-arm64/-/cbor-extract-darwin-arm64-2.2.2.tgz",
+      "integrity": "sha512-ZKZ/F8US7JR92J4DMct6cLW/Y66o2K576+zjlEN/MevH70bFIsB10wkZEQPLzl2oNh2SMGy55xpJ9JoBRl5DOA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-darwin-x64": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-darwin-x64/-/cbor-extract-darwin-x64-2.2.2.tgz",
+      "integrity": "sha512-32b1mgc+P61Js+KW9VZv/c+xRw5EfmOcPx990JbCBSkYJFY0l25VinvyyWfl+3KjibQmAcYwmyzKF9J4DyKP/Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-linux-arm": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-arm/-/cbor-extract-linux-arm-2.2.2.tgz",
+      "integrity": "sha512-tNg0za41TpQfkhWjptD+0gSD2fggMiDCSacuIeELyb2xZhr7PrhPe5h66Jc67B/5dmpIhI2QOUtv4SBsricyYQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-linux-arm64": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-arm64/-/cbor-extract-linux-arm64-2.2.2.tgz",
+      "integrity": "sha512-wfqgzqCAy/Vn8i6WVIh7qZd0DdBFaWBjPdB6ma+Wihcjv0gHqD/mw3ouVv7kbbUNrab6dKEx/w3xQZEdeXIlzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-linux-x64": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-x64/-/cbor-extract-linux-x64-2.2.2.tgz",
+      "integrity": "sha512-rpiLnVEsqtPJ+mXTdx1rfz4RtUGYIUg2rUAZgd1KjiC1SehYUSkJN7Yh+aVfSjvCGtVP0/bfkQkXpPXKbmSUaA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-win32-x64": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-win32-x64/-/cbor-extract-win32-x64-2.2.2.tgz",
+      "integrity": "sha512-dI+9P7cfWxkTQ+oE+7Aa6onEn92PHgfWXZivjNheCRmTBDBf2fx6RyTi0cmgpYLnD1KLZK9ZYrMxaPZ4oiXhGA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@connectrpc/connect": {
       "version": "2.0.0-rc.3",
@@ -2600,6 +2682,12 @@
         "node": ">=6.5"
       }
     },
+    "node_modules/abort-controller-x": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/abort-controller-x/-/abort-controller-x-0.4.3.tgz",
+      "integrity": "sha512-VtUwTNU8fpMwvWGn4xE93ywbogTYsuT+AUxAXOeelbXuQVIwNmC5YLeho9sH4vZ4ITW8414TTAOG1nW6uIVHCA==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2767,6 +2855,37 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/cbor-extract": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/cbor-extract/-/cbor-extract-2.2.2.tgz",
+      "integrity": "sha512-hlSxxI9XO2yQfe9g6msd3g4xCfDqK5T5P0fRMLuaLHhxn4ViPrm+a+MUfhrvH2W962RGxcBwEGzLQyjbDG1gng==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.1.1"
+      },
+      "bin": {
+        "download-cbor-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@cbor-extract/cbor-extract-darwin-arm64": "2.2.2",
+        "@cbor-extract/cbor-extract-darwin-x64": "2.2.2",
+        "@cbor-extract/cbor-extract-linux-arm": "2.2.2",
+        "@cbor-extract/cbor-extract-linux-arm64": "2.2.2",
+        "@cbor-extract/cbor-extract-linux-x64": "2.2.2",
+        "@cbor-extract/cbor-extract-win32-x64": "2.2.2"
+      }
+    },
+    "node_modules/cbor-x": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/cbor-x/-/cbor-x-1.6.4.tgz",
+      "integrity": "sha512-UGKHjp6RHC6QuZ2yy5LCKm7MojM4716DwoSaqwQpaH4DvZvbBTGcoDNTiG9Y2lByXZYFEs9WRkS5tLl96IrF1Q==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "cbor-extract": "^2.2.2"
+      }
+    },
     "node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -2882,6 +3001,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dockerfile-ast": {
@@ -3562,6 +3691,20 @@
         "node": ">= 18"
       }
     },
+    "node_modules/modal": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/modal/-/modal-0.7.3.tgz",
+      "integrity": "sha512-4CliqNF15sZPBGpSoCj5Y9fd8fTp1ONrBLIJiC4amm/Qzc1rn8CH45SVzSu+1DokHCIRiZqQ1xMhRKpDvDCkBw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cbor-x": "^1.6.0",
+        "long": "^5.3.1",
+        "nice-grpc": "^2.1.12",
+        "protobufjs": "^7.5.0",
+        "smol-toml": "^1.3.3",
+        "uuid": "^11.1.0"
+      }
+    },
     "node_modules/module-details-from-path": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
@@ -3573,6 +3716,26 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/nice-grpc": {
+      "version": "2.1.14",
+      "resolved": "https://registry.npmjs.org/nice-grpc/-/nice-grpc-2.1.14.tgz",
+      "integrity": "sha512-GK9pKNxlvnU5FAdaw7i2FFuR9CqBspcE+if2tqnKXBcE0R8525wj4BZvfcwj7FjvqbssqKxRHt2nwedalbJlww==",
+      "license": "MIT",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.14.0",
+        "abort-controller-x": "^0.4.0",
+        "nice-grpc-common": "^2.0.2"
+      }
+    },
+    "node_modules/nice-grpc-common": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/nice-grpc-common/-/nice-grpc-common-2.0.2.tgz",
+      "integrity": "sha512-7RNWbls5kAL1QVUOXvBsv1uO0wPQK3lHv+cY1gwkTzirnG1Nop4cBJZubpgziNbaVc/bl9QJcyvsf/NQxa3rjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ts-error": "^1.0.6"
+      }
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
@@ -3612,6 +3775,21 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.1.1.tgz",
+      "integrity": "sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
       }
     },
     "node_modules/openapi-fetch": {
@@ -3895,6 +4073,18 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/smol-toml": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
+    },
     "node_modules/stream-browserify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
@@ -3994,6 +4184,12 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
+    "node_modules/ts-error": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/ts-error/-/ts-error-1.0.6.tgz",
+      "integrity": "sha512-tLJxacIQUM82IR7JO1UUkKlYuUTmoY9HBJAmNWFzheSlDS5SPMcNIepejHJa4BpPQLAcbRhRf3GDJzyj6rbKvA==",
+      "license": "MIT"
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -4011,6 +4207,19 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
     },
     "node_modules/uuidv7": {
       "version": "1.2.1",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "@daytonaio/sdk": "^0.158.0",
     "@runloop/api-client": "^1.14.1",
-    "e2b": "^2.18.0"
+    "e2b": "^2.18.0",
+    "modal": "^0.7.3"
   }
 }

--- a/scripts/remote-bridge.mjs
+++ b/scripts/remote-bridge.mjs
@@ -33,6 +33,7 @@ try {
 let daytonaSdkPromise;
 let e2bSdkPromise;
 let runloopSdkPromise;
+let modalSdkPromise;
 
 // Maximum number of files per batch for provider SDK upload/download calls.
 const FILE_BATCH_SIZE = 32;
@@ -125,6 +126,8 @@ function scrubSecrets(text) {
     "DAYTONA_API_KEY",
     "RUNLOOP_API_KEY",
     "E2B_API_KEY",
+    "MODAL_TOKEN_ID",
+    "MODAL_TOKEN_SECRET",
     "AGENTKERNEL_API_KEY",
     "AGENTCOMPUTER_API_KEY",
   ];
@@ -163,6 +166,12 @@ function normalizeProviderEnvAliases() {
   ]);
   promoteEnvAlias("E2B_API_KEY", ["E2B_key", "e2b_api_key"]);
   promoteEnvAlias("RUNLOOP_API_KEY", ["runloop_api_key"]);
+  promoteEnvAlias("MODAL_TOKEN_ID", ["modal_token_id"]);
+  promoteEnvAlias("MODAL_TOKEN_SECRET", ["modal_token_secret"]);
+  promoteEnvAlias("MODAL_ENDPOINT", ["modal_endpoint"]);
+  promoteEnvAlias("MODAL_APP_NAME", ["modal_app_name"]);
+  promoteEnvAlias("MODAL_ENVIRONMENT", ["modal_environment"]);
+  promoteEnvAlias("MODAL_REGION", ["modal_region"]);
 }
 
 async function handleProviderRequest(providerName, providerRequest) {
@@ -337,6 +346,63 @@ async function handleProviderRequest(providerName, providerRequest) {
     }
   }
 
+  if (providerName === "modal") {
+    switch (providerRequest.operation) {
+      case "create":
+        respond(await createModalSandbox(providerRequest));
+        return;
+      case "resume":
+        respond(await resumeModalSandbox(providerRequest));
+        return;
+      case "status":
+        respond(await statusModalSandbox(providerRequest));
+        return;
+      case "stop":
+        respond(await stopModalSandbox(providerRequest));
+        return;
+      case "destroy":
+        respond(await destroyModalSandbox(providerRequest));
+        return;
+      case "exec":
+        respond(await execModalSandbox(providerRequest));
+        return;
+      case "attach":
+        process.exit(await attachModalSandbox(providerRequest));
+        return;
+      case "write_file":
+        respond(await writeModalFile(providerRequest));
+        return;
+      case "read_file":
+        respond(await readModalFile(providerRequest));
+        return;
+      case "remove_file":
+        respond(await removeModalFile(providerRequest));
+        return;
+      case "mkdir":
+        respond(await mkdirModal(providerRequest));
+        return;
+      case "sync_push":
+        respond(await syncPushModal(providerRequest));
+        return;
+      case "sync_pull":
+        respond(await syncPullModal(providerRequest));
+        return;
+      case "snapshot":
+        respond(await takeModalSnapshot(providerRequest));
+        return;
+      case "delete_snapshot":
+        respond(await deleteModalSnapshot(providerRequest));
+        return;
+      case "restore":
+        respond(await restoreModalSnapshot(providerRequest));
+        return;
+      default:
+        throw new Error(
+          `unsupported Modal bridge operation: ${providerRequest.operation}`,
+        );
+    }
+  }
+
   respond({
     success: false,
     error:
@@ -381,6 +447,18 @@ async function loadRunloopSdk() {
   return runloopSdkPromise;
 }
 
+async function loadModalSdk() {
+  if (!modalSdkPromise) {
+    modalSdkPromise = import("modal").catch((error) => {
+      throw new Error(
+        "Modal support requires 'modal'. Run 'npm install --prefix scripts' first. " +
+          `(${error.message})`,
+      );
+    });
+  }
+  return modalSdkPromise;
+}
+
 async function withDaytonaClient(fn) {
   const { Daytona } = await loadDaytonaSdk();
   const client = new Daytona({
@@ -407,6 +485,24 @@ async function withRunloopSdk(fn) {
     baseURL: process.env.RUNLOOP_BASE_URL || undefined,
   });
   return fn(sdk, { toFile });
+}
+
+async function withModalClient(fn) {
+  const { ModalClient } = await loadModalSdk();
+  const tokenId = process.env.MODAL_TOKEN_ID || undefined;
+  const tokenSecret = process.env.MODAL_TOKEN_SECRET || undefined;
+  const environment = process.env.MODAL_ENVIRONMENT || undefined;
+  const endpoint = process.env.MODAL_ENDPOINT || undefined;
+  const client =
+    tokenId || tokenSecret || environment || endpoint
+      ? new ModalClient({ tokenId, tokenSecret, environment, endpoint })
+      : new ModalClient();
+
+  try {
+    return await fn(client);
+  } finally {
+    client.close();
+  }
 }
 
 function daytonaEnvMap(values = {}) {
@@ -1420,6 +1516,731 @@ async function attachE2bSandbox(providerRequest) {
     }
     await pty.disconnect().catch(() => {});
   }
+}
+
+function modalWorkspacePath(providerRequest) {
+  return providerRequest.path || "/workspace";
+}
+
+function modalAppName(providerRequest) {
+  return (
+    providerRequest.remote_metadata?.modal_app_name ||
+    process.env.MODAL_APP_NAME ||
+    "agentkernel"
+  );
+}
+
+function modalEnvironment(providerRequest) {
+  return (
+    providerRequest.remote_metadata?.modal_environment ||
+    process.env.MODAL_ENVIRONMENT ||
+    undefined
+  );
+}
+
+function modalImageRef(providerRequest) {
+  const requested =
+    providerRequest.remote_metadata?.image_ref ||
+    providerRequest.image ||
+    providerRequest.profile ||
+    "alpine:3.20";
+  if (!requested || requested === "base" || requested === "default") {
+    return "alpine:3.20";
+  }
+  return requested;
+}
+
+function modalPublishedPorts(providerRequest) {
+  return (
+    providerRequest.remote_metadata?.published_ports?.split(",").filter(Boolean) ??
+    (providerRequest.ports || []).map(daytonaPortSpec)
+  );
+}
+
+function modalTunnelPorts(providerRequest) {
+  return modalPublishedPorts(providerRequest)
+    .map((spec) => {
+      const [portString, protocol = "tcp"] = spec.split("/");
+      return {
+        port: Number.parseInt(portString, 10),
+        protocol,
+      };
+    })
+    .filter(
+      ({ port, protocol }) =>
+        Number.isFinite(port) && String(protocol).toLowerCase() !== "udp",
+    );
+}
+
+function modalRegions() {
+  const raw = process.env.MODAL_REGION || "";
+  const regions = raw
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+  return regions.length ? regions : undefined;
+}
+
+function modalCreateParams(providerRequest) {
+  const encryptedPorts = modalTunnelPorts(providerRequest).map(({ port }) => port);
+  return {
+    name: providerRequest.sandbox_name,
+    env: daytonaEnvMap(providerRequest.env),
+    workdir: modalWorkspacePath(providerRequest),
+    cpu: providerRequest.vcpus || 1,
+    memoryMiB: providerRequest.memory_mb || 512,
+    timeoutMs: 24 * 60 * 60 * 1000,
+    idleTimeoutMs: 30 * 60 * 1000,
+    encryptedPorts: encryptedPorts.length ? encryptedPorts : undefined,
+    blockNetwork: providerRequest.network === false,
+    regions: modalRegions(),
+  };
+}
+
+function modalArchivePath(providerRequest) {
+  return `/tmp/agentkernel-${providerRequest.sandbox_name}-workspace.tgz`;
+}
+
+function modalRestoreMountPath(providerRequest) {
+  return `/tmp/agentkernel-${providerRequest.sandbox_name}-restore-${Date.now()}`;
+}
+
+function modalNamespace(providerRequest) {
+  return modalEnvironment(providerRequest) || modalAppName(providerRequest);
+}
+
+function modalStoppedResponse(providerRequest, remoteId) {
+  const remoteMetadata = {
+    ...(providerRequest.remote_metadata || {}),
+    modal_id: remoteId || providerRequest.remote_id || providerRequest.remote_metadata?.modal_id,
+    modal_app_name: modalAppName(providerRequest),
+    image_ref: modalImageRef(providerRequest),
+    profile_name:
+      providerRequest.profile ||
+      providerRequest.image ||
+      providerRequest.remote_metadata?.profile_name ||
+      "default",
+    published_ports:
+      providerRequest.remote_metadata?.published_ports ||
+      modalPublishedPorts(providerRequest).join(","),
+    last_known_status: "stopped",
+  };
+  const environment = modalEnvironment(providerRequest);
+  if (environment) {
+    remoteMetadata.modal_environment = environment;
+  }
+
+  return {
+    success: true,
+    remote_id:
+      remoteId ||
+      providerRequest.remote_id ||
+      providerRequest.remote_metadata?.modal_id ||
+      null,
+    remote_namespace: modalNamespace(providerRequest),
+    remote_metadata: remoteMetadata,
+    endpoints: [],
+    running: false,
+  };
+}
+
+function isModalNotFound(error) {
+  return (
+    error?.name === "NotFoundError" ||
+    error?.constructor?.name === "NotFoundError" ||
+    /not found/i.test(String(error?.message || ""))
+  );
+}
+
+async function getModalApp(modal, providerRequest, createIfMissing = true) {
+  return modal.apps.fromName(modalAppName(providerRequest), {
+    createIfMissing,
+    environment: modalEnvironment(providerRequest),
+  });
+}
+
+async function getModalImage(modal, providerRequest) {
+  const imageRef = modalImageRef(providerRequest);
+  if (imageRef.startsWith("im-")) {
+    return await modal.images.fromId(imageRef);
+  }
+  return modal.images.fromRegistry(imageRef);
+}
+
+async function getModalSandbox(modal, providerRequest) {
+  const remoteId =
+    providerRequest.remote_id || providerRequest.remote_metadata?.modal_id;
+  if (remoteId) {
+    return await modal.sandboxes.fromId(remoteId);
+  }
+
+  return await modal.sandboxes.fromName(
+    modalAppName(providerRequest),
+    providerRequest.sandbox_name,
+    { environment: modalEnvironment(providerRequest) },
+  );
+}
+
+async function modalPoll(sandbox) {
+  return await sandbox.poll();
+}
+
+async function ensureModalRunning(sandbox, providerRequest) {
+  const exitCode = await modalPoll(sandbox);
+  if (exitCode !== null) {
+    throw new Error(
+      `remote sandbox '${providerRequest.sandbox_name}' is not running`,
+    );
+  }
+}
+
+async function modalExec(sandbox, command, options = {}) {
+  const proc = await sandbox.exec(command, {
+    stdout: "pipe",
+    stderr: "pipe",
+    ...options,
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.readText(),
+    proc.stderr.readText(),
+    proc.wait(),
+  ]);
+  return { stdout, stderr, exitCode };
+}
+
+async function modalExecScript(sandbox, script, options = {}) {
+  return await modalExec(sandbox, ["sh", "-lc", script], options);
+}
+
+async function ensureModalWorkspace(sandbox, providerRequest) {
+  const workspacePath = modalWorkspacePath(providerRequest);
+  const result = await modalExecScript(
+    sandbox,
+    `mkdir -p -- ${daytonaShellQuote(workspacePath)}`,
+    { workdir: "/" },
+  );
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `failed to prepare Modal workspace: ${result.stderr || result.stdout}`,
+    );
+  }
+}
+
+async function readModalFileBuffer(sandbox, filePath) {
+  const file = await sandbox.open(filePath, "r");
+  try {
+    return Buffer.from(await file.read());
+  } finally {
+    await file.close().catch(() => {});
+  }
+}
+
+async function writeModalFileBuffer(sandbox, filePath, content) {
+  const file = await sandbox.open(filePath, "w");
+  try {
+    await file.write(content);
+  } finally {
+    await file.close().catch(() => {});
+  }
+}
+
+async function createModalWorkspaceArchive(sandbox, providerRequest) {
+  const archivePath = modalArchivePath(providerRequest);
+  const workspacePath = modalWorkspacePath(providerRequest);
+  const result = await modalExecScript(
+    sandbox,
+    [
+      `AK_ARCHIVE=${daytonaShellQuote(archivePath)}`,
+      `AK_WORKSPACE=${daytonaShellQuote(workspacePath)}`,
+      'mkdir -p "$(dirname "$AK_ARCHIVE")" "$AK_WORKSPACE"',
+      'tar -czf "$AK_ARCHIVE" -C "$AK_WORKSPACE" .',
+    ].join("\n"),
+    { workdir: "/" },
+  );
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `failed to create Modal workspace archive: ${result.stderr || result.stdout}`,
+    );
+  }
+  return archivePath;
+}
+
+async function downloadModalWorkspaceArchiveBuffer(sandbox, providerRequest) {
+  const archivePath = await createModalWorkspaceArchive(sandbox, providerRequest);
+  return await readModalFileBuffer(sandbox, archivePath);
+}
+
+async function hashModalWorkspace(sandbox, providerRequest, ignoreRules = []) {
+  const tmpRoot = await fs.mkdtemp(
+    path.join(bridgeTempRoot(), "agentkernel-modal-hash-"),
+  );
+  const archivePath = path.join(tmpRoot, "workspace.tgz");
+  const extractDir = path.join(tmpRoot, "workspace");
+  try {
+    await fs.writeFile(
+      archivePath,
+      await downloadModalWorkspaceArchiveBuffer(sandbox, providerRequest),
+    );
+    await extractLocalArchiveToDir(archivePath, extractDir);
+    return await hashTree(extractDir, ignoreRules);
+  } finally {
+    await fs.rm(tmpRoot, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+async function replaceModalWorkspace(sandbox, providerRequest, archivePath) {
+  const remoteArchivePath = modalArchivePath(providerRequest);
+  const workspacePath = modalWorkspacePath(providerRequest);
+  await writeModalFileBuffer(sandbox, remoteArchivePath, await fs.readFile(archivePath));
+  const result = await modalExecScript(
+    sandbox,
+    [
+      `AK_ARCHIVE=${daytonaShellQuote(remoteArchivePath)}`,
+      `AK_WORKSPACE=${daytonaShellQuote(workspacePath)}`,
+      'mkdir -p "$(dirname "$AK_ARCHIVE")" "$AK_WORKSPACE"',
+      '(cd "$AK_WORKSPACE" && find . -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +)',
+      'tar -xzf "$AK_ARCHIVE" -C "$AK_WORKSPACE"',
+      'rm -f -- "$AK_ARCHIVE"',
+    ].join("\n"),
+    { workdir: "/" },
+  );
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `failed to replace Modal workspace: ${result.stderr || result.stdout}`,
+    );
+  }
+}
+
+async function modalEndpoints(sandbox, providerRequest, running) {
+  if (!running) {
+    return [];
+  }
+
+  const requestedPorts = modalTunnelPorts(providerRequest);
+  if (requestedPorts.length === 0) {
+    return [];
+  }
+
+  try {
+    const tunnels = await sandbox.tunnels(20_000);
+    return requestedPorts
+      .map(({ port, protocol }) => {
+        const tunnel = tunnels[port];
+        if (!tunnel) {
+          return null;
+        }
+        return {
+          container_port: port,
+          protocol,
+          url: tunnel.url,
+        };
+      })
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+async function modalResponse(modal, sandbox, providerRequest, extra = {}) {
+  const { remote_metadata: _ignoredRemoteMetadata, ...rest } = extra;
+  const running = extra.running ?? (await modalPoll(sandbox)) === null;
+  const remoteMetadata = {
+    ...(providerRequest.remote_metadata || {}),
+    ...(extra.remote_metadata || {}),
+    modal_id: sandbox.sandboxId,
+    modal_app_name: modalAppName(providerRequest),
+    image_ref: modalImageRef(providerRequest),
+    profile_name:
+      providerRequest.profile ||
+      providerRequest.image ||
+      providerRequest.remote_metadata?.profile_name ||
+      "default",
+    published_ports:
+      providerRequest.remote_metadata?.published_ports ||
+      modalPublishedPorts(providerRequest).join(","),
+    last_known_status: running ? "running" : "stopped",
+  };
+  const environment = modalEnvironment(providerRequest);
+  if (environment) {
+    remoteMetadata.modal_environment = environment;
+  }
+
+  return {
+    success: true,
+    remote_id: sandbox.sandboxId,
+    remote_namespace: modalNamespace(providerRequest),
+    remote_metadata: remoteMetadata,
+    endpoints:
+      extra.endpoints ?? (await modalEndpoints(sandbox, providerRequest, running)),
+    running,
+    ...rest,
+  };
+}
+
+async function createModalSandbox(providerRequest) {
+  return withModalClient(async (modal) => {
+    const app = await getModalApp(modal, providerRequest, true);
+    const image = await getModalImage(modal, providerRequest);
+    const sandbox = await modal.sandboxes.create(
+      app,
+      image,
+      modalCreateParams(providerRequest),
+    );
+    await ensureModalWorkspace(sandbox, providerRequest);
+    return await modalResponse(modal, sandbox, providerRequest);
+  });
+}
+
+async function resumeModalSandbox(providerRequest) {
+  return withModalClient(async (modal) => {
+    try {
+      const existing = await getModalSandbox(modal, providerRequest);
+      if ((await modalPoll(existing)) === null) {
+        return await modalResponse(modal, existing, providerRequest);
+      }
+    } catch (error) {
+      if (!isModalNotFound(error)) {
+        throw error;
+      }
+    }
+
+    const app = await getModalApp(modal, providerRequest, true);
+    const image = await getModalImage(modal, providerRequest);
+    const sandbox = await modal.sandboxes.create(
+      app,
+      image,
+      modalCreateParams(providerRequest),
+    );
+    await ensureModalWorkspace(sandbox, providerRequest);
+    return await modalResponse(modal, sandbox, providerRequest);
+  });
+}
+
+async function statusModalSandbox(providerRequest) {
+  return withModalClient(async (modal) => {
+    const sandbox = await getModalSandbox(modal, providerRequest);
+    return await modalResponse(modal, sandbox, providerRequest);
+  });
+}
+
+async function stopModalSandbox(providerRequest) {
+  return withModalClient(async (modal) => {
+    const sandbox = await getModalSandbox(modal, providerRequest);
+    if ((await modalPoll(sandbox)) === null) {
+      await sandbox.terminate();
+    }
+    return modalStoppedResponse(providerRequest, sandbox.sandboxId);
+  });
+}
+
+async function destroyModalSandbox(providerRequest) {
+  return withModalClient(async (modal) => {
+    try {
+      const sandbox = await getModalSandbox(modal, providerRequest);
+      if ((await modalPoll(sandbox)) === null) {
+        await sandbox.terminate();
+      }
+      return modalStoppedResponse(providerRequest, sandbox.sandboxId);
+    } catch (error) {
+      if (!isModalNotFound(error)) {
+        throw error;
+      }
+      return modalStoppedResponse(providerRequest);
+    }
+  });
+}
+
+async function execModalSandbox(providerRequest) {
+  return withModalClient(async (modal) => {
+    const sandbox = await getModalSandbox(modal, providerRequest);
+    await ensureModalRunning(sandbox, providerRequest);
+    const result = await modalExec(sandbox, providerRequest.command || [], {
+      env: daytonaEnvMap(providerRequest.env),
+      workdir: providerRequest.workdir || "/workspace",
+    });
+    return await modalResponse(modal, sandbox, providerRequest, {
+      exit_code: result.exitCode,
+      stdout: result.stdout,
+      stderr: result.stderr,
+    });
+  });
+}
+
+async function writeModalFile(providerRequest) {
+  return withModalClient(async (modal) => {
+    const sandbox = await getModalSandbox(modal, providerRequest);
+    await ensureModalRunning(sandbox, providerRequest);
+    const target = providerRequest.path;
+    await modalExecScript(
+      sandbox,
+      `mkdir -p -- ${daytonaShellQuote(path.posix.dirname(target))}`,
+      { workdir: "/" },
+    );
+    await writeModalFileBuffer(
+      sandbox,
+      target,
+      Buffer.from(providerRequest.content_base64 || "", "base64"),
+    );
+    return await modalResponse(modal, sandbox, providerRequest);
+  });
+}
+
+async function readModalFile(providerRequest) {
+  return withModalClient(async (modal) => {
+    const sandbox = await getModalSandbox(modal, providerRequest);
+    await ensureModalRunning(sandbox, providerRequest);
+    const content = await readModalFileBuffer(sandbox, providerRequest.path);
+    return await modalResponse(modal, sandbox, providerRequest, {
+      content_base64: content.toString("base64"),
+    });
+  });
+}
+
+async function removeModalFile(providerRequest) {
+  return withModalClient(async (modal) => {
+    const sandbox = await getModalSandbox(modal, providerRequest);
+    await ensureModalRunning(sandbox, providerRequest);
+    await modalExecScript(
+      sandbox,
+      `rm -rf -- ${daytonaShellQuote(providerRequest.path)}`,
+      { workdir: "/" },
+    );
+    return await modalResponse(modal, sandbox, providerRequest);
+  });
+}
+
+async function mkdirModal(providerRequest) {
+  return withModalClient(async (modal) => {
+    const sandbox = await getModalSandbox(modal, providerRequest);
+    await ensureModalRunning(sandbox, providerRequest);
+    const flag = providerRequest.recursive ? "-p " : "";
+    await modalExecScript(
+      sandbox,
+      `mkdir ${flag}-- ${daytonaShellQuote(providerRequest.path)}`,
+      { workdir: "/" },
+    );
+    return await modalResponse(modal, sandbox, providerRequest);
+  });
+}
+
+async function syncPushModal(providerRequest) {
+  return withModalClient(async (modal) => {
+    const sandbox = await getModalSandbox(modal, providerRequest);
+    await ensureModalRunning(sandbox, providerRequest);
+
+    const localPath = providerRequest.local_path;
+    if (!localPath) {
+      throw new Error("sync_push requires local_path");
+    }
+
+    const ignoreRules = await loadIgnoreRules(localPath);
+    const remoteRevision = await hashModalWorkspace(
+      sandbox,
+      providerRequest,
+      ignoreRules,
+    );
+    if (
+      providerRequest.workspace_revision &&
+      remoteRevision !== providerRequest.workspace_revision
+    ) {
+      throw new Error("workspace sync conflict: remote workspace changed since last sync");
+    }
+
+    const { tmpRoot, archivePath } = await createLocalArchiveFromWorkspace(
+      localPath,
+      ignoreRules,
+    );
+    try {
+      await replaceModalWorkspace(sandbox, providerRequest, archivePath);
+    } finally {
+      await fs.rm(tmpRoot, { recursive: true, force: true }).catch(() => {});
+    }
+
+    const workspaceRevision = await hashTree(localPath, ignoreRules);
+    return await modalResponse(modal, sandbox, providerRequest, {
+      workspace_revision: workspaceRevision,
+    });
+  });
+}
+
+async function syncPullModal(providerRequest) {
+  return withModalClient(async (modal) => {
+    const sandbox = await getModalSandbox(modal, providerRequest);
+    await ensureModalRunning(sandbox, providerRequest);
+
+    const localPath = providerRequest.local_path;
+    if (!localPath) {
+      throw new Error("sync_pull requires local_path");
+    }
+
+    const ignoreRules = await loadIgnoreRules(localPath);
+    const localRevision = await hashTree(localPath, ignoreRules);
+    if (
+      providerRequest.workspace_revision &&
+      localRevision !== providerRequest.workspace_revision
+    ) {
+      throw new Error("workspace sync conflict: local workspace changed since last sync");
+    }
+
+    const tmpRoot = await fs.mkdtemp(
+      path.join(bridgeTempRoot(), "agentkernel-modal-pull-"),
+    );
+    const archivePath = path.join(tmpRoot, "workspace.tgz");
+    const extractDir = path.join(tmpRoot, "workspace");
+    try {
+      await fs.writeFile(
+        archivePath,
+        await downloadModalWorkspaceArchiveBuffer(sandbox, providerRequest),
+      );
+      await extractLocalArchiveToDir(archivePath, extractDir);
+      await mirrorDirectory(extractDir, localPath, ignoreRules);
+      const workspaceRevision = await hashTree(extractDir, ignoreRules);
+      return await modalResponse(modal, sandbox, providerRequest, {
+        workspace_revision: workspaceRevision,
+      });
+    } finally {
+      await fs.rm(tmpRoot, { recursive: true, force: true }).catch(() => {});
+    }
+  });
+}
+
+async function takeModalSnapshot(providerRequest) {
+  return withModalClient(async (modal) => {
+    const sandbox = await getModalSandbox(modal, providerRequest);
+    await ensureModalRunning(sandbox, providerRequest);
+    const image = await sandbox.snapshotDirectory(modalWorkspacePath(providerRequest));
+    const workspaceRevision = await hashModalWorkspace(
+      sandbox,
+      providerRequest,
+      [],
+    );
+    return await modalResponse(modal, sandbox, providerRequest, {
+      workspace_revision: workspaceRevision,
+      remote_metadata: {
+        snapshot_handle: image.imageId,
+      },
+    });
+  });
+}
+
+async function deleteModalSnapshot(providerRequest) {
+  return withModalClient(async (modal) => {
+    const snapshotHandle = providerRequest.snapshot_name;
+    if (!snapshotHandle) {
+      throw new Error("delete_snapshot requires snapshot_name");
+    }
+    await modal.images.delete(snapshotHandle);
+    return { success: true };
+  });
+}
+
+async function restoreModalSnapshot(providerRequest) {
+  return withModalClient(async (modal) => {
+    const snapshotHandle = providerRequest.snapshot_name;
+    if (!snapshotHandle) {
+      throw new Error("restore requires snapshot_name");
+    }
+
+    const sandbox = await getModalSandbox(modal, providerRequest);
+    await ensureModalRunning(sandbox, providerRequest);
+
+    const mountPath = modalRestoreMountPath(providerRequest);
+    const image = await modal.images.fromId(snapshotHandle);
+    const workspacePath = modalWorkspacePath(providerRequest);
+    await modalExecScript(
+      sandbox,
+      `rm -rf -- ${daytonaShellQuote(mountPath)} && mkdir -p -- ${daytonaShellQuote(mountPath)}`,
+      { workdir: "/" },
+    );
+    await sandbox.mountImage(mountPath, image);
+    const result = await modalExecScript(
+      sandbox,
+      [
+        `AK_RESTORE=${daytonaShellQuote(mountPath)}`,
+        `AK_WORKSPACE=${daytonaShellQuote(workspacePath)}`,
+        'mkdir -p "$AK_WORKSPACE"',
+        '(cd "$AK_WORKSPACE" && find . -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +)',
+        'cp -a "$AK_RESTORE"/. "$AK_WORKSPACE"/',
+      ].join("\n"),
+      { workdir: "/" },
+    );
+    if (result.exitCode !== 0) {
+      throw new Error(
+        `failed to restore Modal workspace snapshot: ${result.stderr || result.stdout}`,
+      );
+    }
+
+    const workspaceRevision = await hashModalWorkspace(
+      sandbox,
+      providerRequest,
+      [],
+    );
+    return await modalResponse(modal, sandbox, providerRequest, {
+      workspace_revision: workspaceRevision,
+    });
+  });
+}
+
+async function streamModalOutput(stream, writable) {
+  const reader = stream.getReader();
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) {
+        return;
+      }
+      if (typeof value === "string") {
+        writable.write(value);
+      } else if (value) {
+        writable.write(Buffer.from(value));
+      }
+    }
+  } finally {
+    reader.releaseLock?.();
+  }
+}
+
+async function attachModalSandbox(providerRequest) {
+  return withModalClient(async (modal) => {
+    const sandbox = await getModalSandbox(modal, providerRequest);
+    await ensureModalRunning(sandbox, providerRequest);
+
+    const shellProgram = providerRequest.shell || process.env.SHELL || "/bin/sh";
+    const proc = await sandbox.exec(
+      ["sh", "-lc", `exec ${daytonaShellQuote(shellProgram)} -li`],
+      {
+        env: daytonaEnvMap(providerRequest.env),
+        workdir: providerRequest.workdir || "/workspace",
+        pty: true,
+        stdout: "pipe",
+        stderr: "pipe",
+      },
+    );
+
+    const stdoutPromise = streamModalOutput(proc.stdout, process.stdout);
+    const stderrPromise = streamModalOutput(proc.stderr, process.stderr);
+    const onData = (chunk) => {
+      const text = Buffer.isBuffer(chunk) ? chunk.toString("utf8") : String(chunk);
+      void proc.stdin.writeText(text).catch(() => {});
+    };
+
+    if (process.stdin.isTTY) {
+      process.stdin.setRawMode(true);
+    }
+    process.stdin.resume();
+    process.stdin.on("data", onData);
+
+    try {
+      const exitCode = await proc.wait();
+      await Promise.allSettled([stdoutPromise, stderrPromise]);
+      return exitCode ?? 0;
+    } finally {
+      process.stdin.off("data", onData);
+      if (process.stdin.isTTY) {
+        process.stdin.setRawMode(false);
+      }
+    }
+  });
 }
 
 function runloopRunning(status) {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -69,6 +69,8 @@ pub enum BackendType {
     Runloop,
     /// E2B hosted sandboxes
     E2B,
+    /// Modal hosted sandboxes
+    Modal,
     /// Agent Computer hosted machines
     AgentComputer,
 }
@@ -86,6 +88,7 @@ impl fmt::Display for BackendType {
             BackendType::Daytona => write!(f, "daytona"),
             BackendType::Runloop => write!(f, "runloop"),
             BackendType::E2B => write!(f, "e2b"),
+            BackendType::Modal => write!(f, "modal"),
             BackendType::AgentComputer => write!(f, "agentcomputer"),
         }
     }
@@ -106,9 +109,10 @@ impl std::str::FromStr for BackendType {
             "daytona" => Ok(BackendType::Daytona),
             "runloop" => Ok(BackendType::Runloop),
             "e2b" => Ok(BackendType::E2B),
+            "modal" => Ok(BackendType::Modal),
             "agentcomputer" | "agent-computer" => Ok(BackendType::AgentComputer),
             _ => Err(format!(
-                "Unknown backend '{}'. Valid options: docker, podman, firecracker, apple, hyperlight, kubernetes, nomad, daytona, runloop, e2b, agentcomputer",
+                "Unknown backend '{}'. Valid options: docker, podman, firecracker, apple, hyperlight, kubernetes, nomad, daytona, runloop, e2b, modal, agentcomputer",
                 s
             )),
         }
@@ -122,6 +126,7 @@ impl BackendType {
             BackendType::Daytona
                 | BackendType::Runloop
                 | BackendType::E2B
+                | BackendType::Modal
                 | BackendType::AgentComputer
         )
     }
@@ -727,6 +732,7 @@ pub fn backend_available(backend: BackendType) -> bool {
         BackendType::Daytona
         | BackendType::Runloop
         | BackendType::E2B
+        | BackendType::Modal
         | BackendType::AgentComputer => remote_bridge_available(),
     }
 }
@@ -805,6 +811,11 @@ pub fn create_sandbox_with_state(
             name,
             remote.unwrap_or_default(),
         ))),
+        BackendType::Modal => Ok(Box::new(RemoteSandbox::new(
+            RemoteProvider::Modal,
+            name,
+            remote.unwrap_or_default(),
+        ))),
         BackendType::AgentComputer => Ok(Box::new(RemoteSandbox::new(
             RemoteProvider::AgentComputer,
             name,
@@ -831,6 +842,7 @@ mod tests {
         assert_eq!(format!("{}", BackendType::Daytona), "daytona");
         assert_eq!(format!("{}", BackendType::Runloop), "runloop");
         assert_eq!(format!("{}", BackendType::E2B), "e2b");
+        assert_eq!(format!("{}", BackendType::Modal), "modal");
         assert_eq!(format!("{}", BackendType::AgentComputer), "agentcomputer");
     }
 
@@ -871,6 +883,7 @@ mod tests {
             BackendType::Runloop
         );
         assert_eq!("e2b".parse::<BackendType>().unwrap(), BackendType::E2B);
+        assert_eq!("modal".parse::<BackendType>().unwrap(), BackendType::Modal);
         assert_eq!(
             "agentcomputer".parse::<BackendType>().unwrap(),
             BackendType::AgentComputer

--- a/src/backend/remote.rs
+++ b/src/backend/remote.rs
@@ -19,6 +19,7 @@ pub enum RemoteProvider {
     Daytona,
     Runloop,
     E2B,
+    Modal,
     AgentComputer,
 }
 
@@ -28,6 +29,7 @@ impl RemoteProvider {
             Self::Daytona => BackendType::Daytona,
             Self::Runloop => BackendType::Runloop,
             Self::E2B => BackendType::E2B,
+            Self::Modal => BackendType::Modal,
             Self::AgentComputer => BackendType::AgentComputer,
         }
     }
@@ -37,6 +39,7 @@ impl RemoteProvider {
             Self::Daytona => "daytona",
             Self::Runloop => "runloop",
             Self::E2B => "e2b",
+            Self::Modal => "modal",
             Self::AgentComputer => "agentcomputer",
         }
     }
@@ -46,6 +49,7 @@ impl RemoteProvider {
             "daytona" => Some(Self::Daytona),
             "runloop" => Some(Self::Runloop),
             "e2b" => Some(Self::E2B),
+            "modal" => Some(Self::Modal),
             "agentcomputer" => Some(Self::AgentComputer),
             _ => None,
         }
@@ -311,6 +315,7 @@ fn provider_bridge_env(provider: RemoteProvider, config: &Config) -> HashMap<Str
         RemoteProvider::Daytona => &config.remote.daytona,
         RemoteProvider::Runloop => &config.remote.runloop,
         RemoteProvider::E2B => &config.remote.e2b,
+        RemoteProvider::Modal => &config.remote.modal,
         RemoteProvider::AgentComputer => &config.remote.agentcomputer,
     };
 
@@ -318,6 +323,7 @@ fn provider_bridge_env(provider: RemoteProvider, config: &Config) -> HashMap<Str
         RemoteProvider::Daytona => daytona_bridge_env(provider_config),
         RemoteProvider::Runloop => runloop_bridge_env(provider_config),
         RemoteProvider::E2B => e2b_bridge_env(provider_config),
+        RemoteProvider::Modal => modal_bridge_env(provider_config),
         RemoteProvider::AgentComputer => HashMap::new(),
     }
 }
@@ -367,6 +373,31 @@ fn runloop_bridge_env(config: &RemoteProviderConfig) -> HashMap<String, String> 
     env
 }
 
+fn modal_bridge_env(config: &RemoteProviderConfig) -> HashMap<String, String> {
+    let mut env = HashMap::new();
+
+    if let Some(token_id) = resolve_provider_token_id(config) {
+        env.insert("MODAL_TOKEN_ID".to_string(), token_id);
+    }
+    if let Some(token_secret) = resolve_provider_token_secret(config) {
+        env.insert("MODAL_TOKEN_SECRET".to_string(), token_secret);
+    }
+    if let Some(base_url) = &config.base_url {
+        env.insert("MODAL_ENDPOINT".to_string(), base_url.clone());
+    }
+    if let Some(environment) = &config.environment {
+        env.insert("MODAL_ENVIRONMENT".to_string(), environment.clone());
+    }
+    if let Some(project) = &config.project {
+        env.insert("MODAL_APP_NAME".to_string(), project.clone());
+    }
+    if let Some(region) = &config.region {
+        env.insert("MODAL_REGION".to_string(), region.clone());
+    }
+
+    env
+}
+
 fn resolve_provider_secret(config: &RemoteProviderConfig) -> Option<String> {
     if let Some(api_key) = &config.api_key {
         return Some(api_key.clone());
@@ -374,6 +405,28 @@ fn resolve_provider_secret(config: &RemoteProviderConfig) -> Option<String> {
 
     config
         .api_key_env
+        .as_ref()
+        .and_then(|key| std::env::var(key).ok())
+}
+
+fn resolve_provider_token_id(config: &RemoteProviderConfig) -> Option<String> {
+    if let Some(token_id) = &config.token_id {
+        return Some(token_id.clone());
+    }
+
+    config
+        .token_id_env
+        .as_ref()
+        .and_then(|key| std::env::var(key).ok())
+}
+
+fn resolve_provider_token_secret(config: &RemoteProviderConfig) -> Option<String> {
+    if let Some(token_secret) = &config.token_secret {
+        return Some(token_secret.clone());
+    }
+
+    config
+        .token_secret_env
         .as_ref()
         .and_then(|key| std::env::var(key).ok())
 }
@@ -539,6 +592,8 @@ impl RemoteSandbox {
         }
         if !response.endpoints.is_empty() {
             self.endpoints = response.endpoints.clone();
+        } else if response.running == Some(false) {
+            self.endpoints.clear();
         }
         if let Some(running) = response.running {
             self.running = running;
@@ -879,6 +934,7 @@ mod tests {
         assert_eq!(RemoteProvider::Daytona.backend_type(), BackendType::Daytona);
         assert_eq!(RemoteProvider::Runloop.backend_type(), BackendType::Runloop);
         assert_eq!(RemoteProvider::E2B.backend_type(), BackendType::E2B);
+        assert_eq!(RemoteProvider::Modal.backend_type(), BackendType::Modal);
         assert_eq!(
             RemoteProvider::AgentComputer.backend_type(),
             BackendType::AgentComputer
@@ -991,5 +1047,41 @@ mod tests {
             env.get("RUNLOOP_BASE_URL"),
             Some(&"https://api.runloop.invalid".to_string())
         );
+    }
+
+    #[test]
+    fn test_modal_bridge_env_from_config() {
+        let config = Config::from_str(
+            r#"
+            [sandbox]
+            name = "remote-app"
+
+            [remote.modal]
+            token_id = "modal-token-id"
+            token_secret = "modal-token-secret"
+            base_url = "https://modal.invalid"
+            environment = "main"
+            project = "agentkernel"
+            region = "us-east-1"
+        "#,
+        )
+        .unwrap();
+
+        let env = provider_bridge_env(RemoteProvider::Modal, &config);
+        assert_eq!(
+            env.get("MODAL_TOKEN_ID"),
+            Some(&"modal-token-id".to_string())
+        );
+        assert_eq!(
+            env.get("MODAL_TOKEN_SECRET"),
+            Some(&"modal-token-secret".to_string())
+        );
+        assert_eq!(
+            env.get("MODAL_ENDPOINT"),
+            Some(&"https://modal.invalid".to_string())
+        );
+        assert_eq!(env.get("MODAL_ENVIRONMENT"), Some(&"main".to_string()));
+        assert_eq!(env.get("MODAL_APP_NAME"), Some(&"agentkernel".to_string()));
+        assert_eq!(env.get("MODAL_REGION"), Some(&"us-east-1".to_string()));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -163,6 +163,8 @@ pub struct RemoteConfig {
     pub runloop: RemoteProviderConfig,
     #[serde(default, rename = "e2b")]
     pub e2b: RemoteProviderConfig,
+    #[serde(default)]
+    pub modal: RemoteProviderConfig,
     #[serde(default, rename = "agentcomputer")]
     pub agentcomputer: RemoteProviderConfig,
     #[serde(default)]
@@ -176,7 +178,17 @@ pub struct RemoteProviderConfig {
     #[serde(default)]
     pub api_key_env: Option<String>,
     #[serde(default)]
+    pub token_id: Option<String>,
+    #[serde(default)]
+    pub token_id_env: Option<String>,
+    #[serde(default)]
+    pub token_secret: Option<String>,
+    #[serde(default)]
+    pub token_secret_env: Option<String>,
+    #[serde(default)]
     pub base_url: Option<String>,
+    #[serde(default)]
+    pub environment: Option<String>,
     #[serde(default)]
     pub organization: Option<String>,
     #[serde(default)]
@@ -783,6 +795,7 @@ impl Config {
             ("daytona", &self.remote.daytona),
             ("runloop", &self.remote.runloop),
             ("e2b", &self.remote.e2b),
+            ("modal", &self.remote.modal),
             ("agentcomputer", &self.remote.agentcomputer),
         ];
         for (name, provider) in &remote_providers {
@@ -791,6 +804,14 @@ impl Config {
                     "Remote provider '[remote.{}]' has 'api_key' set directly in the config \
                      file. This risks committing secrets to version control. \
                      Use 'api_key_env' to reference an environment variable instead.",
+                    name
+                ));
+            }
+            if provider.token_id.is_some() || provider.token_secret.is_some() {
+                warnings.push(format!(
+                    "Remote provider '[remote.{}]' has Modal-style token fields set directly in the \
+                     config file. This risks committing secrets to version control. \
+                     Use 'token_id_env' and 'token_secret_env' instead.",
                     name
                 ));
             }
@@ -953,6 +974,11 @@ mod tests {
             api_key_env = "DAYTONA_API_KEY"
             organization = "acme"
 
+            [remote.modal]
+            token_id_env = "MODAL_TOKEN_ID"
+            token_secret_env = "MODAL_TOKEN_SECRET"
+            project = "agentkernel"
+
             [remote.profiles.node-dev]
             image = "node:22"
             workspace_dir = "/workspace"
@@ -967,6 +993,15 @@ mod tests {
             config.remote.daytona.api_key_env.as_deref(),
             Some("DAYTONA_API_KEY")
         );
+        assert_eq!(
+            config.remote.modal.token_id_env.as_deref(),
+            Some("MODAL_TOKEN_ID")
+        );
+        assert_eq!(
+            config.remote.modal.token_secret_env.as_deref(),
+            Some("MODAL_TOKEN_SECRET")
+        );
+        assert_eq!(config.remote.modal.project.as_deref(), Some("agentkernel"));
         let profile = config.remote.profiles.get("node-dev").unwrap();
         assert_eq!(profile.image.as_deref(), Some("node:22"));
         assert_eq!(profile.workspace_dir.as_deref(), Some("/workspace"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,7 +109,7 @@ enum Commands {
         /// Use container pool for faster execution (skips create/destroy overhead)
         #[arg(short = 'F', long)]
         fast: bool,
-        /// Backend to use: docker, podman, firecracker, apple, hyperlight, kubernetes, nomad, daytona, runloop, e2b, agentcomputer (default: auto-detect)
+        /// Backend to use: docker, podman, firecracker, apple, hyperlight, kubernetes, nomad, daytona, runloop, e2b, modal, agentcomputer (default: auto-detect)
         #[arg(short = 'B', long)]
         backend: Option<String>,
         /// Template to use (built-in name, local name, github:owner/repo/path, or file path)
@@ -444,7 +444,7 @@ enum SandboxAction {
         /// Project directory to mount into sandbox
         #[arg(short, long)]
         dir: Option<PathBuf>,
-        /// Backend to use: docker, podman, firecracker, apple, hyperlight, kubernetes, nomad, daytona, runloop, e2b, agentcomputer (default: auto-detect)
+        /// Backend to use: docker, podman, firecracker, apple, hyperlight, kubernetes, nomad, daytona, runloop, e2b, modal, agentcomputer (default: auto-detect)
         #[arg(short = 'B', long)]
         backend: Option<String>,
         /// Template to use (built-in name, local name, github:owner/repo/path, or file path)
@@ -491,7 +491,7 @@ enum SandboxAction {
     Start {
         /// Name of the sandbox to start
         name: String,
-        /// Backend to use: docker, podman, firecracker, apple, hyperlight, kubernetes, nomad, daytona, runloop, e2b, agentcomputer (default: auto-detect)
+        /// Backend to use: docker, podman, firecracker, apple, hyperlight, kubernetes, nomad, daytona, runloop, e2b, modal, agentcomputer (default: auto-detect)
         #[arg(short = 'B', long)]
         backend: Option<String>,
     },

--- a/src/vmm.rs
+++ b/src/vmm.rs
@@ -3191,14 +3191,13 @@ mod tests {
     #[test]
     fn test_normalize_persisted_path_makes_relative_absolute() {
         let current = std::env::current_dir().unwrap();
+        let expected = std::fs::canonicalize(current.join("examples/remote-modal"))
+            .unwrap_or_else(|_| current.join("examples/remote-modal"));
         let normalized = normalize_persisted_path(Some("examples/remote-modal".to_string()))
             .unwrap()
             .unwrap();
         assert!(std::path::Path::new(&normalized).is_absolute());
-        assert_eq!(
-            std::path::PathBuf::from(normalized),
-            current.join("examples/remote-modal")
-        );
+        assert_eq!(std::path::PathBuf::from(normalized), expected);
     }
 
     #[test]

--- a/templates/modal-remote.toml
+++ b/templates/modal-remote.toml
@@ -1,0 +1,30 @@
+# Modal remote sandbox template
+
+[sandbox]
+name = "modal-remote"
+base_image = "base"
+
+[security]
+profile = "moderate"
+mount_cwd = true
+network = true
+
+[network]
+ports = ["3000"]
+
+[remote]
+bridge = "./scripts/remote-bridge.mjs"
+
+[remote.modal]
+token_id_env = "MODAL_TOKEN_ID"
+token_secret_env = "MODAL_TOKEN_SECRET"
+project = "agentkernel"
+
+[template]
+description = "Remote Modal sandbox with managed /workspace sync"
+category = "Remote"
+help_text = """
+How to use: create with --backend modal.
+Example command: agentkernel sandbox create my-modal --template modal-remote --backend modal
+Provider auth: export MODAL_TOKEN_ID and MODAL_TOKEN_SECRET before starting the sandbox.
+"""


### PR DESCRIPTION
## Summary
- add a live Modal remote backend adapter to the shared remote bridge
- wire Modal through backend/config plumbing and fix remote path persistence for workspace sync
- add Modal docs, templates, and runnable examples while fixing remote example bridge paths

## Verification
- cargo test --quiet
- node --check scripts/remote-bridge.mjs
- live Modal smoke through agentkernel: create/start, managed /workspace sync, exec, snapshot, restore, restored exec
