### PR TITLE
Persist explicit remote sandbox workspace paths

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1028,7 +1028,7 @@ memory_mb = 512
                 name,
                 agent,
                 config,
-                dir: _,
+                dir,
                 backend,
                 template: tmpl,
                 ttl,
@@ -1119,7 +1119,8 @@ memory_mb = 512
                 let stored_config_path = config
                     .as_ref()
                     .map(|path| path.to_string_lossy().to_string());
-                let workspace_root = config_base_dir.clone().unwrap_or(std::env::current_dir()?);
+                let workspace_root =
+                    resolve_workspace_root(config_base_dir.as_deref(), dir.as_deref())?;
 
                 // Validate config and print warnings
                 for warning in cfg.validate() {
@@ -4942,6 +4943,41 @@ fn parse_ttl(s: &str) -> Result<u64> {
     Ok(value * multiplier)
 }
 
+fn resolve_workspace_root(config_base_dir: Option<&Path>, dir: Option<&Path>) -> Result<PathBuf> {
+    if let Some(dir) = dir {
+        let workspace = if dir.is_absolute() {
+            dir.to_path_buf()
+        } else {
+            std::env::current_dir()?.join(dir)
+        };
+        if !workspace.exists() {
+            bail!(
+                "Workspace directory '{}' does not exist",
+                workspace.display()
+            );
+        }
+        if !workspace.is_dir() {
+            bail!(
+                "Workspace path '{}' is not a directory",
+                workspace.display()
+            );
+        }
+        return Ok(workspace.canonicalize().unwrap_or(workspace));
+    }
+
+    let workspace = if let Some(config_base_dir) = config_base_dir {
+        if config_base_dir.is_absolute() {
+            config_base_dir.to_path_buf()
+        } else {
+            std::env::current_dir()?.join(config_base_dir)
+        }
+    } else {
+        std::env::current_dir()?
+    };
+
+    Ok(workspace.canonicalize().unwrap_or(workspace))
+}
+
 fn extract_template_help_text(content: &str) -> Option<String> {
     let value: toml::Value = toml::from_str(content).ok()?;
     value
@@ -5018,5 +5054,42 @@ async fn delegate_start_to_server(host: &str, port: u16, name: &str) -> Result<(
             .map(|c| String::from_utf8_lossy(&c.to_bytes()).to_string())
             .unwrap_or_default();
         bail!("Server returned {} when starting sandbox: {}", status, body);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_workspace_root;
+    use tempfile::TempDir;
+
+    #[test]
+    fn resolve_workspace_root_prefers_explicit_dir() {
+        let temp_dir = TempDir::new().unwrap();
+        let workspace = temp_dir.path().join("workspace");
+        std::fs::create_dir_all(&workspace).unwrap();
+
+        let resolved = resolve_workspace_root(None, Some(&workspace)).unwrap();
+        let expected = workspace.canonicalize().unwrap_or(workspace);
+        assert_eq!(resolved, expected);
+    }
+
+    #[test]
+    fn resolve_workspace_root_uses_config_base_dir() {
+        let temp_dir = TempDir::new().unwrap();
+        let config_dir = temp_dir.path().join("config");
+        std::fs::create_dir_all(&config_dir).unwrap();
+
+        let resolved = resolve_workspace_root(Some(&config_dir), None).unwrap();
+        let expected = config_dir.canonicalize().unwrap_or(config_dir);
+        assert_eq!(resolved, expected);
+    }
+
+    #[test]
+    fn resolve_workspace_root_rejects_missing_explicit_dir() {
+        let temp_dir = TempDir::new().unwrap();
+        let missing = temp_dir.path().join("missing");
+
+        let error = resolve_workspace_root(None, Some(&missing)).unwrap_err();
+        assert!(error.to_string().contains("Workspace directory"));
     }
 }

--- a/src/vmm.rs
+++ b/src/vmm.rs
@@ -257,10 +257,35 @@ impl SandboxState {
             remote_metadata: self.remote_metadata.clone(),
             workspace_revision: self.workspace_revision.clone(),
             endpoints: self.endpoints.clone(),
-            local_workspace: self.work_dir.clone(),
-            config_path: self.config_path.clone(),
+            local_workspace: normalize_persisted_path(self.work_dir.clone())
+                .ok()
+                .flatten(),
+            config_path: normalize_persisted_path(self.config_path.clone())
+                .ok()
+                .flatten(),
         }
     }
+}
+
+fn normalize_persisted_path(value: Option<String>) -> Result<Option<String>> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+
+    let path = PathBuf::from(&value);
+    let absolute = if path.is_absolute() {
+        path
+    } else {
+        std::env::current_dir()?.join(path)
+    };
+
+    Ok(Some(
+        absolute
+            .canonicalize()
+            .unwrap_or(absolute)
+            .to_string_lossy()
+            .to_string(),
+    ))
 }
 
 /// Status of a detached command
@@ -934,6 +959,7 @@ impl VmManager {
     }
 
     pub fn set_work_dir(&mut self, name: &str, work_dir: Option<String>) -> Result<()> {
+        let work_dir = normalize_persisted_path(work_dir)?;
         {
             let state = self
                 .sandboxes
@@ -950,6 +976,7 @@ impl VmManager {
     }
 
     pub fn set_config_path(&mut self, name: &str, config_path: Option<String>) -> Result<()> {
+        let config_path = normalize_persisted_path(config_path)?;
         {
             let state = self
                 .sandboxes
@@ -3159,6 +3186,29 @@ mod tests {
         assert_eq!(state.vcpus, 4);
         assert_eq!(state.memory_mb, 2048);
         assert_eq!(state.vsock_cid, 10);
+    }
+
+    #[test]
+    fn test_normalize_persisted_path_makes_relative_absolute() {
+        let current = std::env::current_dir().unwrap();
+        let normalized = normalize_persisted_path(Some("examples/remote-modal".to_string()))
+            .unwrap()
+            .unwrap();
+        assert!(std::path::Path::new(&normalized).is_absolute());
+        assert_eq!(
+            std::path::PathBuf::from(normalized),
+            current.join("examples/remote-modal")
+        );
+    }
+
+    #[test]
+    fn test_normalize_persisted_path_preserves_absolute() {
+        let temp_dir = TempDir::new().unwrap();
+        let absolute = temp_dir.path().join("agentkernel.toml");
+        let normalized = normalize_persisted_path(Some(absolute.to_string_lossy().to_string()))
+            .unwrap()
+            .unwrap();
+        assert_eq!(std::path::PathBuf::from(normalized), absolute);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- persist remote sandbox work and config paths as normalized absolute paths
- honor \ when choosing the managed remote workspace root
- add regression coverage for path normalization and explicit workspace resolution

## Testing
- cargo test --quiet
