### PR TITLE
Prepare v0.19.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentkernel"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentkernel"
-version = "0.18.1"
+version = "0.19.0"
 edition = "2024"
 description = "Run AI coding agents in secure, isolated microVMs"
 authors = ["Paul Thrasher <thrashr888@gmail.com>"]

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentkernel-desktop",
-  "version": "0.1.0",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentkernel-desktop",
-      "version": "0.1.0",
+      "version": "0.19.0",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentkernel-desktop",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.19.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agentkernel-desktop"
-version = "0.14.2"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agentkernel-desktop"
-version = "0.14.2"
+version = "0.19.0"
 description = "Desktop control plane for agentkernel"
 authors = ["Paul Thrasher <thrashr888@gmail.com>"]
 license = "MIT"

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "AgentKernel",
-  "version": "0.1.0",
+  "version": "0.19.0",
   "identifier": "com.agentkernel.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/deploy/helm/agentkernel/Chart.yaml
+++ b/deploy/helm/agentkernel/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentkernel
 description: Agent sandbox orchestration for AI coding agents
 type: application
-version: 0.6.0
-appVersion: "0.6.0"
+version: 0.19.0
+appVersion: "0.19.0"
 maintainers:
   - name: Paul Thrasher
     email: thrashr888@gmail.com

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,10 @@ See [GitHub Releases](https://github.com/thrashr888/agentkernel/releases) for do
 
 ## Unreleased
 
+## [v0.19.0](https://github.com/thrashr888/agentkernel/releases/tag/v0.19.0) — Agent Sandbox Expansion
+
+_August 2026_
+
 ### Added
 
 - **`opencode attach` support** — `opencode attach http://localhost:18888/opencode` now works; agentkernel provisions a sandbox from the `opencode-sandbox` template, starts `opencode serve` inside it, and proxies the full OpenCode protocol (sessions, messages, SSE events) through to it; first connect ~8s, instant after that


### PR DESCRIPTION
## Summary
- align CLI, desktop, JavaScript, and Helm chart metadata to `v0.19.0`
- promote the accumulated Unreleased notes into the v0.19.0 changelog section
- include the fully validated Dependabot patch set now on `main`

## Validation
- `cargo test --quiet`
- `npm ci --cache /private/tmp/agentkernel-main-verify.2oNhha/.npm-cache && npm run build` (from `app/`)
- `git diff --check`

The release workflow will validate the cross-platform binaries, desktop artifacts, crates.io, Helm, and Homebrew publishing after the release tag is created.