### PR TITLE
Avoid implicit Dockerfile builds in command runs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,21 @@
+# Keep the build context limited to inputs copied by the root Dockerfile.
+**
+!Cargo.toml
+!Cargo.lock
+!src/
+!src/**
+!tests/
+!tests/**
+!guest-agent/
+!guest-agent/**
+!claude-plugin/
+!claude-plugin/**
+!plugins/
+!plugins/**
+!templates/
+!templates/**
+!images/
+!images/build/
+!images/build/**
+!images/kernel/
+!images/kernel/microvm.config

--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ agentkernel run go build               # Uses golang:1.23-alpine
 # Override with explicit image
 agentkernel run --image ubuntu:24.04 apt-get --version
 
+# Explicitly build and use the current project's Dockerfile
+agentkernel run --build -- npm test
+
 # Keep the sandbox after execution for debugging
 agentkernel run --keep npm test
 
@@ -79,6 +82,8 @@ agentkernel automatically selects the right Docker image based on:
 2. **Project files** - Detects from files in your directory
 3. **Procfile** - Parses Heroku-style Procfiles
 4. **Config file** - Uses `agentkernel.toml` if present
+
+Command-driven runs do not implicitly build a Dockerfile found in the working directory. Use `--build`, or select a Dockerfile through a config or template, when you want a project image build.
 
 ### Supported Languages
 

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -14,6 +14,7 @@ agentkernel run [OPTIONS] <COMMAND>...
 | Option | Description |
 |--------|-------------|
 | `-i, --image <IMAGE>` | Docker image to use (auto-detected if not specified) |
+| `--build` | Build and use the current project's Dockerfile. Conflicts with `--image` and `--fast`. |
 | `-p, --profile <PROFILE>` | Security profile: `permissive`, `moderate`, `restrictive` |
 | `-k, --keep` | Keep the sandbox after execution (for debugging) |
 | `-F, --fast` | Use container pool for faster startup (default: true) |
@@ -54,6 +55,16 @@ agentkernel run --image python:3.11-alpine python3 --version
 # Use Ubuntu
 agentkernel run --image ubuntu:24.04 cat /etc/os-release
 ```
+
+### Build the project image
+
+Bare `run` commands select an image from the command or project files and do not implicitly build an ambient Dockerfile. Request the project build when you want it:
+
+```bash
+agentkernel run --build -- npm test
+```
+
+An explicit config or template keeps its configured Dockerfile build behavior.
 
 ### Security profiles
 
@@ -132,7 +143,7 @@ The `run` command automatically selects an appropriate Docker image based on you
 | `ruby`, `gem`, `bundle` | `ruby:3.3-alpine` |
 | Others | `alpine:3.20` |
 
-Override with `--image` when needed.
+Override with `--image` when needed, or pass `--build` to build the current project's Dockerfile first.
 
 ## Exit Codes
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2222,28 +2222,29 @@ memory_mb = 512
             // For `run`, command detection has higher priority than project files
             // because user is explicitly specifying what to run
             let explicit_image = image.is_some();
-            let (docker_image, cfg_for_build) = if let Some(img) = image {
-                (img, None)
+            let (docker_image, cfg_for_build, honor_config_dockerfile) = if let Some(img) = image {
+                (img, None, false)
             } else if let Some(ref config_path) = config {
                 let cfg = Config::from_file(config_path)?;
-                (cfg.docker_image(), Some(cfg))
+                (cfg.docker_image(), Some(cfg), true)
             } else if let Some(ref tmpl_name) = tmpl {
                 let resolved = template::resolve(tmpl_name)?;
                 eprintln!("Using template '{}' ({})", resolved.name, resolved.source);
                 let cfg = resolved.parse()?;
-                (cfg.docker_image(), Some(cfg))
+                (cfg.docker_image(), Some(cfg), true)
             } else if let Some(img) = languages::detect_from_command(&command) {
                 // Command-based detection first for `run`
-                (img, None)
+                (img, None, false)
             } else {
                 // Try current directory config
                 let default_config = PathBuf::from("agentkernel.toml");
                 if default_config.exists() {
                     let cfg = Config::from_file(&default_config)?;
-                    (cfg.docker_image(), Some(cfg))
+                    let has_build_settings = config_has_build_settings(&cfg);
+                    (cfg.docker_image(), Some(cfg), has_build_settings)
                 } else {
                     // Fall back to project file detection or default
-                    (languages::detect_image(&command), None)
+                    (languages::detect_image(&command), None, false)
                 }
             };
 
@@ -2260,6 +2261,7 @@ memory_mb = 512
             let should_build_image = should_build_run_image(
                 explicit_image,
                 build_image,
+                honor_config_dockerfile,
                 cfg_for_build.as_ref(),
                 &current_dir,
             );
@@ -5002,16 +5004,29 @@ fn resolve_workspace_root(config_base_dir: Option<&Path>, dir: Option<&Path>) ->
 fn should_build_run_image(
     explicit_image: bool,
     build_requested: bool,
+    honor_config_dockerfile: bool,
     config: Option<&Config>,
     current_dir: &Path,
 ) -> bool {
     if explicit_image {
         return false;
     }
-    if let Some(config) = config {
-        return config.requires_build(current_dir);
-    }
-    build_requested && languages::detect_dockerfile(current_dir).is_some()
+
+    let dockerfile_available = config
+        .map(|config| config.requires_build(current_dir))
+        .unwrap_or_else(|| languages::detect_dockerfile(current_dir).is_some());
+
+    (build_requested || honor_config_dockerfile) && dockerfile_available
+}
+
+/// Whether an implicitly loaded project config contains intentional build
+/// settings, rather than merely sharing a directory with a Dockerfile.
+fn config_has_build_settings(config: &Config) -> bool {
+    config.build.dockerfile.is_some()
+        || config.build.context.is_some()
+        || config.build.target.is_some()
+        || !config.build.args.is_empty()
+        || config.build.no_cache
 }
 
 fn extract_template_help_text(content: &str) -> Option<String> {
@@ -5095,7 +5110,7 @@ async fn delegate_start_to_server(host: &str, port: u16, name: &str) -> Result<(
 
 #[cfg(test)]
 mod tests {
-    use super::{resolve_workspace_root, should_build_run_image};
+    use super::{config_has_build_settings, resolve_workspace_root, should_build_run_image};
     use crate::config::Config;
     use tempfile::TempDir;
 
@@ -5140,24 +5155,68 @@ mod tests {
     fn command_run_skips_ambient_dockerfile() {
         let project = project_with_dockerfile();
 
-        assert!(!should_build_run_image(false, false, None, project.path()));
+        assert!(!should_build_run_image(
+            false,
+            false,
+            false,
+            None,
+            project.path()
+        ));
     }
 
     #[test]
     fn build_flag_enables_ambient_dockerfile() {
         let project = project_with_dockerfile();
 
-        assert!(should_build_run_image(false, true, None, project.path()));
+        assert!(should_build_run_image(
+            false,
+            true,
+            false,
+            None,
+            project.path()
+        ));
     }
 
     #[test]
-    fn configured_run_preserves_dockerfile_build() {
+    fn explicitly_selected_config_preserves_dockerfile_build() {
         let project = project_with_dockerfile();
         let config = Config::minimal("test-project", "claude");
 
         assert!(should_build_run_image(
             false,
             false,
+            true,
+            Some(&config),
+            project.path()
+        ));
+    }
+
+    #[test]
+    fn implicitly_loaded_config_skips_ambient_dockerfile() {
+        let project = project_with_dockerfile();
+        let config = Config::minimal("test-project", "claude");
+
+        assert!(!config_has_build_settings(&config));
+        assert!(!should_build_run_image(
+            false,
+            false,
+            config_has_build_settings(&config),
+            Some(&config),
+            project.path()
+        ));
+    }
+
+    #[test]
+    fn implicit_config_with_build_settings_preserves_dockerfile_build() {
+        let project = project_with_dockerfile();
+        let mut config = Config::minimal("test-project", "claude");
+        config.build.context = Some(".".to_string());
+
+        assert!(config_has_build_settings(&config));
+        assert!(should_build_run_image(
+            false,
+            false,
+            config_has_build_settings(&config),
             Some(&config),
             project.path()
         ));
@@ -5169,6 +5228,7 @@ mod tests {
         let config = Config::minimal("test-project", "claude");
 
         assert!(!should_build_run_image(
+            true,
             true,
             true,
             Some(&config),

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,6 +100,9 @@ enum Commands {
         /// Docker image to use (overrides config)
         #[arg(short, long)]
         image: Option<String>,
+        /// Build the current project's Dockerfile before running
+        #[arg(long, conflicts_with_all = ["image", "fast"])]
+        build: bool,
         /// Security profile: permissive, moderate (default), restrictive
         #[arg(short, long, default_value = "moderate")]
         profile: String,
@@ -2056,6 +2059,7 @@ memory_mb = 512
             config,
             keep,
             image,
+            build: build_image,
             profile,
             no_network,
             fast,
@@ -2170,7 +2174,7 @@ memory_mb = 512
 
             // Daemon path: try daemon VM pool first (single round-trip)
             // Skip is_available() check - just try and fall back on error
-            if !keep {
+            if !keep && !build_image {
                 let daemon_client = daemon::DaemonClient::new();
 
                 // Determine runtime from image/config
@@ -2214,7 +2218,7 @@ memory_mb = 512
                 // Daemon not available or failed, fall through to ephemeral mode
             }
 
-            // Determine Docker image: --image > --config > --template > Dockerfile > command > ./agentkernel.toml > project files > default
+            // Determine Docker image: --image > --config > --template > command > ./agentkernel.toml > project files > default
             // For `run`, command detection has higher priority than project files
             // because user is explicitly specifying what to run
             let explicit_image = image.is_some();
@@ -2243,26 +2247,35 @@ memory_mb = 512
                 }
             };
 
-            // Check for Dockerfile and build if present
+            // Resolve whether this invocation intentionally selects a Dockerfile build
             let current_dir = std::env::current_dir()?;
             let is_firecracker_backend = backend
                 .as_ref()
                 .is_some_and(|b| b == "firecracker" || b == "fc");
 
-            // Build from Dockerfile if configured or auto-detected
-            let docker_image = if explicit_image {
-                docker_image
-            } else if let Some(ref cfg) = cfg_for_build {
-                // Use config's build settings
-                if cfg.requires_build(&current_dir) {
+            // Build only when configuration selected a Dockerfile or the user
+            // explicitly requested an ambient Dockerfile with --build. A plain
+            // command-driven run must not turn into a potentially multi-minute
+            // project image build just because the working directory has one.
+            let should_build_image = should_build_run_image(
+                explicit_image,
+                build_image,
+                cfg_for_build.as_ref(),
+                &current_dir,
+            );
+            if build_image && !should_build_image {
+                bail!(
+                    "--build requested but no Dockerfile was found in {}",
+                    current_dir.display()
+                );
+            }
+
+            let docker_image = if should_build_image {
+                if let Some(ref cfg) = cfg_for_build {
+                    // Use config's build settings
                     let project_name = &cfg.sandbox.name;
                     build::build_or_use_image(project_name, &docker_image, &current_dir, cfg)?
                 } else {
-                    docker_image
-                }
-            } else {
-                // Auto-detect Dockerfile in current directory
-                if languages::detect_dockerfile(&current_dir).is_some() {
                     let project_name = current_dir
                         .file_name()
                         .map(|n| n.to_string_lossy().to_string())
@@ -2274,9 +2287,9 @@ memory_mb = 512
                         &current_dir,
                         &default_cfg,
                     )?
-                } else {
-                    docker_image
                 }
+            } else {
+                docker_image
             };
 
             // For Firecracker backend with custom images, convert to rootfs
@@ -4981,6 +4994,26 @@ fn resolve_workspace_root(config_base_dir: Option<&Path>, dir: Option<&Path>) ->
     Ok(workspace.canonicalize().unwrap_or(workspace))
 }
 
+/// Decide whether `run` should build a project image before execution.
+///
+/// Explicit images always win. Config and template runs preserve their
+/// Dockerfile behavior, while command-driven runs require an explicit
+/// `--build` before an ambient Dockerfile is considered.
+fn should_build_run_image(
+    explicit_image: bool,
+    build_requested: bool,
+    config: Option<&Config>,
+    current_dir: &Path,
+) -> bool {
+    if explicit_image {
+        return false;
+    }
+    if let Some(config) = config {
+        return config.requires_build(current_dir);
+    }
+    build_requested && languages::detect_dockerfile(current_dir).is_some()
+}
+
 fn extract_template_help_text(content: &str) -> Option<String> {
     let value: toml::Value = toml::from_str(content).ok()?;
     value
@@ -5062,8 +5095,15 @@ async fn delegate_start_to_server(host: &str, port: u16, name: &str) -> Result<(
 
 #[cfg(test)]
 mod tests {
-    use super::resolve_workspace_root;
+    use super::{resolve_workspace_root, should_build_run_image};
+    use crate::config::Config;
     use tempfile::TempDir;
+
+    fn project_with_dockerfile() -> TempDir {
+        let temp_dir = TempDir::new().unwrap();
+        std::fs::write(temp_dir.path().join("Dockerfile"), "FROM alpine:3.20\n").unwrap();
+        temp_dir
+    }
 
     #[test]
     fn resolve_workspace_root_prefers_explicit_dir() {
@@ -5094,5 +5134,45 @@ mod tests {
 
         let error = resolve_workspace_root(None, Some(&missing)).unwrap_err();
         assert!(error.to_string().contains("Workspace directory"));
+    }
+
+    #[test]
+    fn command_run_skips_ambient_dockerfile() {
+        let project = project_with_dockerfile();
+
+        assert!(!should_build_run_image(false, false, None, project.path()));
+    }
+
+    #[test]
+    fn build_flag_enables_ambient_dockerfile() {
+        let project = project_with_dockerfile();
+
+        assert!(should_build_run_image(false, true, None, project.path()));
+    }
+
+    #[test]
+    fn configured_run_preserves_dockerfile_build() {
+        let project = project_with_dockerfile();
+        let config = Config::minimal("test-project", "claude");
+
+        assert!(should_build_run_image(
+            false,
+            false,
+            Some(&config),
+            project.path()
+        ));
+    }
+
+    #[test]
+    fn explicit_image_bypasses_dockerfile_build() {
+        let project = project_with_dockerfile();
+        let config = Config::minimal("test-project", "claude");
+
+        assert!(!should_build_run_image(
+            true,
+            true,
+            Some(&config),
+            project.path()
+        ));
     }
 }

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -91,6 +91,18 @@ fn test_run_help() {
     let (exit_code, stdout, _stderr) = run_cmd(&["run", "--help"]);
     assert_eq!(exit_code, 0);
     assert!(stdout.contains("Run a command in a temporary sandbox"));
+    assert!(stdout.contains("--build"));
+}
+
+#[test]
+fn test_run_build_conflicts_with_explicit_image() {
+    let (exit_code, _stdout, stderr) =
+        run_cmd(&["run", "--build", "--image", "alpine:3.20", "echo", "hello"]);
+    assert_ne!(exit_code, 0);
+    assert!(
+        stderr.contains("cannot be used with"),
+        "stderr was: {stderr}"
+    );
 }
 
 #[test]

--- a/tests/file_operations_test.rs
+++ b/tests/file_operations_test.rs
@@ -491,6 +491,10 @@ fn test_run_with_file_creation() {
     ]);
     assert_eq!(exit_code, 0, "Run with file failed: {}", stderr);
     assert!(
+        !stderr.contains("Building image from"),
+        "Command-driven run unexpectedly built the ambient Dockerfile: {stderr}"
+    );
+    assert!(
         stdout.contains("ephemeral"),
         "Expected output not found: {}",
         stdout
@@ -506,7 +510,7 @@ fn test_run_file_isolation() {
     }
 
     // Create a file in one run
-    let (exit_code, _, _) = run_cmd(&[
+    let (exit_code, _, first_stderr) = run_cmd(&[
         "run",
         "--backend",
         "docker",
@@ -516,9 +520,13 @@ fn test_run_file_isolation() {
         "echo 'secret' > /tmp/isolated.txt",
     ]);
     assert_eq!(exit_code, 0);
+    assert!(
+        !first_stderr.contains("Building image from"),
+        "Command-driven run unexpectedly built the ambient Dockerfile: {first_stderr}"
+    );
 
     // Try to read it in another run - should fail since sandboxes are isolated
-    let (exit_code, _stdout, _stderr) = run_cmd(&[
+    let (exit_code, _stdout, second_stderr) = run_cmd(&[
         "run",
         "--backend",
         "docker",
@@ -529,4 +537,8 @@ fn test_run_file_isolation() {
 
     // Should fail because each run gets a fresh sandbox
     assert_ne!(exit_code, 0, "File should not persist across runs");
+    assert!(
+        !second_stderr.contains("Building image from"),
+        "Command-driven run unexpectedly built the ambient Dockerfile: {second_stderr}"
+    );
 }


### PR DESCRIPTION
## What changed

- stop bare `agentkernel run` commands from implicitly building an ambient Dockerfile
- distinguish an ambient `agentkernel.toml` from intentional build settings
- add an explicit `--build` switch while preserving explicitly selected config/template builds and `--image` precedence
- add regression coverage to the two previously slow Docker integration paths
- add a root `.dockerignore` allowlist and document the new behavior

## Why

In the main-branch baseline, `file_operations_test` took 544.85 seconds while `sandbox_lifecycle_test` took 3.08 seconds. Two command-driven ephemeral runs were triggering the repository's release Dockerfile build even though they could use a command-selected or default runtime image.

## Measured impact

- `file_operations_test`: **544.85s → 12.87s** (**97.6% faster**, 8m52s saved)
- Docker Integration job: **10m12s → 1m23s** (**86.4% faster**, 8m49s saved)
- intentional project-build context in this worktree: **~6.0 GB → ~2.8 MB**, excluding `target/` and unrelated files

Measured in [CI run 30764407109](https://github.com/thrashr888/agentkernel/actions/runs/30764407109) against [main baseline 30733080503](https://github.com/thrashr888/agentkernel/actions/runs/30733080503).

## Root cause

The run path treated any Dockerfile in the working directory as an implicit request to build. An implicitly loaded project config could also re-enable that build for commands which fell back to the default image.

## Checks

- `cargo test`
- `cargo fmt --all -- --check`
- focused CLI and Dockerfile-intent tests
- Docker integration: 12 file-operation tests and 10 lifecycle tests passed
- repository-pinned Rust 1.89 Clippy passed in CI
- `git diff --check`

Beads: closes `agentkernel-6vtg`. Follow-up `agentkernel-3hzx` tracks context-aware, single-flight custom-image caching.