### PR TITLE
chore: upgrade remote provider SDKs

### DIFF
--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -7,12 +7,12 @@
       "name": "agentkernel-remote-bridge",
       "dependencies": {
         "@daytona/sdk": "^0.205.1",
-        "@runloop/api-client": "^1.14.1",
-        "e2b": "^2.18.0",
-        "modal": "^0.7.3"
+        "@runloop/api-client": "^1.29.0",
+        "e2b": "^2.45.0",
+        "modal": "^0.9.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=20.18.1 <21 || >=22"
       }
     },
     "node_modules/@aws-sdk/checksums": {
@@ -344,9 +344,9 @@
       }
     },
     "node_modules/@bufbuild/protobuf": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.11.0.tgz",
-      "integrity": "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.14.0.tgz",
+      "integrity": "sha512-C3UGsiCwSprE2NKIIFA3hCDlpXTMCAXRZuEVp88L1GY36Y41+rYL5fryE+nOFhp4p4JPQvdV8PQ4DWgHgeTE+w==",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@cbor-extract/cbor-extract-darwin-arm64": {
@@ -428,22 +428,22 @@
       ]
     },
     "node_modules/@connectrpc/connect": {
-      "version": "2.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.0.0-rc.3.tgz",
-      "integrity": "sha512-ARBt64yEyKbanyRETTjcjJuHr2YXorzQo0etyS5+P6oSeW8xEuzajA9g+zDnMcj1hlX2dQE93foIWQGfpru7gQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.2.tgz",
+      "integrity": "sha512-MXkBijtcX09R10Eb6sFeIetc6w6746eio6xtfuyVOH7oQAacT1X0GzMIQFux6Qy8cq3W/T5qX5Bei8YbFtmRGA==",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@bufbuild/protobuf": "^2.2.0"
+        "@bufbuild/protobuf": "^2.7.0"
       }
     },
     "node_modules/@connectrpc/connect-web": {
-      "version": "2.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@connectrpc/connect-web/-/connect-web-2.0.0-rc.3.tgz",
-      "integrity": "sha512-w88P8Lsn5CCsA7MFRl2e6oLY4J/5toiNtJns/YJrlyQaWOy3RO8pDgkz+iIkG98RPMhj2thuBvsd3Cn4DKKCkw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-web/-/connect-web-2.1.2.tgz",
+      "integrity": "sha512-1tfaK85MU+gJjwwmL31d2rzdf0XCYX99chZf63uG89SGBUd4XuZ4ZzhGo2u79TPXOE6nLIZQ2okrpyey42PYdg==",
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@bufbuild/protobuf": "^2.2.0",
-        "@connectrpc/connect": "2.0.0-rc.3"
+        "@bufbuild/protobuf": "^2.7.0",
+        "@connectrpc/connect": "2.1.2"
       }
     },
     "node_modules/@daytona/sdk": {
@@ -1037,15 +1037,6 @@
       "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
       "license": "ISC"
     },
-    "node_modules/@isaacs/cliui": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
-      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
@@ -1245,9 +1236,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@runloop/api-client": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@runloop/api-client/-/api-client-1.14.1.tgz",
-      "integrity": "sha512-DYqNuj/zHTF3IohkSS/ZaDeIdtyUSarTiB+uWDKqTSWNyljEg0RcDzki0s6HTM1AUxS0RL/PkrXRYh95ADtZrw==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@runloop/api-client/-/api-client-1.29.0.tgz",
+      "integrity": "sha512-kdwqOpenrZETIzrHYeQHqZ1eXgdwgzTLuGZlLXtIvVi1uilkO/2LiMp9xYQekeZpfOw08Y8nHi7rdCmfIJmUrg==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^18.11.18",
@@ -1668,20 +1659,6 @@
       "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
       "license": "MIT"
     },
-    "node_modules/cross-spawn": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1758,24 +1735,28 @@
       }
     },
     "node_modules/e2b": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/e2b/-/e2b-2.18.0.tgz",
-      "integrity": "sha512-umWvNhKx3dWUfzcLPLO5Ep1qB5cTLuJlAlnxfKVUnOwx3yaO+H1PaAE2fihT4etEu3BNs3pHvdwa1VM+uMxe0w==",
+      "version": "2.45.0",
+      "resolved": "https://registry.npmjs.org/e2b/-/e2b-2.45.0.tgz",
+      "integrity": "sha512-9DjhV+4xeS8/N7fQf6xz0y1apUS3CN+kOwAADzPlUEGGcgC2g5sPLExHh+GA2V1LcZZIOs387PN1DFpgAGGOhw==",
       "license": "MIT",
       "dependencies": {
-        "@bufbuild/protobuf": "^2.6.2",
-        "@connectrpc/connect": "2.0.0-rc.3",
-        "@connectrpc/connect-web": "2.0.0-rc.3",
+        "@bufbuild/protobuf": "^2.12.1",
+        "@connectrpc/connect": "^2.1.2",
+        "@connectrpc/connect-web": "^2.1.2",
         "chalk": "^5.3.0",
         "compare-versions": "^6.1.0",
         "dockerfile-ast": "^0.7.1",
-        "glob": "^11.1.0",
+        "glob": "^13.0.6",
         "openapi-fetch": "^0.14.1",
         "platform": "^1.3.6",
-        "tar": "^7.5.11"
+        "tar": "^7.5.19",
+        "undici": "^7.29.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=20.18.1 <21 || >=22"
+      },
+      "optionalDependencies": {
+        "undici8": "npm:undici@8.10.0"
       }
     },
     "node_modules/emoji-regex": {
@@ -1953,22 +1934,6 @@
         }
       }
     },
-    "node_modules/foreground-child": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "license": "ISC",
-      "dependencies": {
-        "cross-spawn": "^7.0.6",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/form-data": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
@@ -2066,24 +2031,17 @@
       }
     },
     "node_modules/glob": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
-      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "foreground-child": "^3.3.1",
-        "jackspeak": "^4.1.1",
-        "minimatch": "^10.1.1",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^2.0.0"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -2265,12 +2223,6 @@
         "node": ">=0.12.0"
       }
     },
-    "node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "license": "ISC"
-    },
     "node_modules/isomorphic-ws": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
@@ -2278,21 +2230,6 @@
       "license": "MIT",
       "peerDependencies": {
         "ws": "*"
-      }
-    },
-    "node_modules/jackspeak": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
-      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^9.0.0"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/lodash.camelcase": {
@@ -2308,9 +2245,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/lru-cache": {
-      "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -2369,12 +2306,12 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -2405,9 +2342,9 @@
       }
     },
     "node_modules/modal": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/modal/-/modal-0.7.3.tgz",
-      "integrity": "sha512-4CliqNF15sZPBGpSoCj5Y9fd8fTp1ONrBLIJiC4amm/Qzc1rn8CH45SVzSu+1DokHCIRiZqQ1xMhRKpDvDCkBw==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/modal/-/modal-0.9.0.tgz",
+      "integrity": "sha512-kCXcdJkhbJorf/q/6T9Wdlg6in9JmRnCNQnV6rVBMyeqNV/iXI6BYk4IzY4cvZ6dbauNeDMjk/Q08cbxvoIaXg==",
       "license": "Apache-2.0",
       "dependencies": {
         "cbor-x": "^1.6.0",
@@ -2520,12 +2457,6 @@
       "integrity": "sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==",
       "license": "MIT"
     },
-    "node_modules/package-json-from-dist": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "license": "BlueOak-1.0.0"
-    },
     "node_modules/parse-passwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
@@ -2533,15 +2464,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/path-scurry": {
@@ -2725,27 +2647,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "license": "MIT",
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/shell-quote": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
@@ -2756,18 +2657,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/smol-toml": {
@@ -2909,11 +2798,31 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
+    },
+    "node_modules/undici8": {
+      "name": "undici",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=22.19.0"
+      }
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -2978,21 +2887,6 @@
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
-      }
-    },
-    "node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/wrap-ansi": {

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -3,15 +3,15 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": ">=20"
+    "node": ">=20.18.1 <21 || >=22"
   },
   "scripts": {
     "test": "node --check remote-bridge.mjs && node --test test/*.test.mjs"
   },
   "dependencies": {
     "@daytona/sdk": "^0.205.1",
-    "@runloop/api-client": "^1.14.1",
-    "e2b": "^2.18.0",
-    "modal": "^0.7.3"
+    "@runloop/api-client": "^1.29.0",
+    "e2b": "^2.45.0",
+    "modal": "^0.9.0"
   }
 }

--- a/scripts/remote-bridge.mjs
+++ b/scripts/remote-bridge.mjs
@@ -1724,21 +1724,11 @@ async function ensureModalWorkspace(sandbox, providerRequest) {
 }
 
 async function readModalFileBuffer(sandbox, filePath) {
-  const file = await sandbox.open(filePath, "r");
-  try {
-    return Buffer.from(await file.read());
-  } finally {
-    await file.close().catch(() => {});
-  }
+  return Buffer.from(await sandbox.filesystem.readBytes(filePath));
 }
 
 async function writeModalFileBuffer(sandbox, filePath, content) {
-  const file = await sandbox.open(filePath, "w");
-  try {
-    await file.write(content);
-  } finally {
-    await file.close().catch(() => {});
-  }
+  await sandbox.filesystem.writeBytes(content, filePath);
 }
 
 async function createModalWorkspaceArchive(sandbox, providerRequest) {

--- a/scripts/test/provider-sdks.test.mjs
+++ b/scripts/test/provider-sdks.test.mjs
@@ -1,0 +1,183 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  Devbox,
+  DevboxCmdOps,
+  DevboxFileOps,
+  DevboxOps,
+  RunloopSDK,
+  Snapshot,
+  SnapshotOps,
+  toFile,
+} from "@runloop/api-client";
+import { FileType, Sandbox as E2bSandbox } from "e2b";
+import {
+  AppService,
+  ContainerProcess,
+  ImageService,
+  ModalClient,
+  Sandbox as ModalSandbox,
+  SandboxFilesystem,
+  SandboxService,
+} from "modal";
+
+function assertMethods(type, methods) {
+  assert.equal(typeof type, "function");
+  for (const method of methods) {
+    assert.equal(
+      typeof type.prototype[method],
+      "function",
+      `${type.name}.${String(method)} must remain callable`,
+    );
+  }
+}
+
+test("Runloop SDK preserves the bridge API", () => {
+  assertMethods(DevboxOps, ["create", "fromId"]);
+  assertMethods(Devbox, [
+    "awaitRunning",
+    "getInfo",
+    "getTunnelUrl",
+    "resume",
+    "shutdown",
+    "snapshotDisk",
+    "suspend",
+  ]);
+  assertMethods(DevboxCmdOps, ["exec", "execAsync"]);
+  assertMethods(DevboxFileOps, ["download", "upload"]);
+  assertMethods(SnapshotOps, ["fromId"]);
+  assertMethods(Snapshot, ["createDevbox", "delete"]);
+  assert.equal(typeof toFile, "function");
+
+  const sdk = new RunloopSDK({ bearerToken: "contract-test" });
+  assert.equal(typeof sdk.devbox.create, "function");
+  assert.equal(typeof sdk.snapshot.fromId, "function");
+  assert.equal(typeof sdk.api.devboxes.executions.sendStdIn, "function");
+});
+
+test("E2B SDK preserves the bridge API", () => {
+  for (const method of [
+    "connect",
+    "create",
+    "deleteSnapshot",
+    "getFullInfo",
+    "kill",
+    "pause",
+  ]) {
+    assert.equal(typeof E2bSandbox[method], "function");
+  }
+  assertMethods(E2bSandbox, ["createSnapshot", "kill"]);
+  assert.deepEqual(
+    [FileType.FILE, FileType.DIR, FileType.SYMLINK],
+    ["file", "dir", "symlink"],
+  );
+});
+
+test("Modal SDK preserves the adapted bridge API", () => {
+  assertMethods(ModalClient, ["close"]);
+  assertMethods(AppService, ["fromName"]);
+  assertMethods(ImageService, ["delete", "fromId", "fromRegistry"]);
+  assertMethods(SandboxService, ["create", "fromId", "fromName"]);
+  assertMethods(ModalSandbox, [
+    "exec",
+    "mountImage",
+    "poll",
+    "snapshotDirectory",
+    "terminate",
+    "tunnels",
+    "unmountImage",
+  ]);
+  assertMethods(SandboxFilesystem, ["readBytes", "writeBytes"]);
+  assertMethods(ContainerProcess, ["wait"]);
+  assert.equal(
+    typeof Object.getOwnPropertyDescriptor(
+      ModalSandbox.prototype,
+      "filesystem",
+    )?.get,
+    "function",
+  );
+});
+
+const bridgePath = fileURLToPath(new URL("../remote-bridge.mjs", import.meta.url));
+
+function runMockBridge(provider, request, tempRoot) {
+  const payload = Buffer.from(JSON.stringify(request)).toString("base64");
+  const result = spawnSync(process.execPath, [bridgePath, provider, payload], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      AGENTKERNEL_REMOTE_BRIDGE_MODE: "mock",
+      AGENTKERNEL_REMOTE_TMPDIR: tempRoot,
+    },
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const outputLines = result.stdout.trim().split("\n");
+  assert.equal(outputLines.length, 1, "bridge must emit exactly one JSON line");
+  return JSON.parse(outputLines[0]);
+}
+
+test("provider JSON-over-stdio bridge contract remains stable", async () => {
+  const tempRoot = await fs.mkdtemp(
+    path.join(os.tmpdir(), "agentkernel-provider-contract-"),
+  );
+  try {
+    for (const provider of ["runloop", "e2b", "modal"]) {
+      const sandboxName = `${provider}-sdk-contract`;
+      const request = { sandbox_name: sandboxName };
+      const created = runMockBridge(
+        provider,
+        { ...request, operation: "create", ports: [] },
+        tempRoot,
+      );
+      assert.equal(created.success, true);
+      assert.equal(created.running, true);
+
+      const content = Buffer.from(`${provider}-ok`).toString("base64");
+      runMockBridge(
+        provider,
+        {
+          ...request,
+          operation: "write_file",
+          path: "/workspace/provider.txt",
+          content_base64: content,
+        },
+        tempRoot,
+      );
+      const read = runMockBridge(
+        provider,
+        { ...request, operation: "read_file", path: "/workspace/provider.txt" },
+        tempRoot,
+      );
+      assert.equal(read.content_base64, content);
+
+      const status = runMockBridge(
+        provider,
+        { ...request, operation: "status" },
+        tempRoot,
+      );
+      assert.equal(status.remote_id, created.remote_id);
+      assert.equal(status.running, true);
+
+      const stopped = runMockBridge(
+        provider,
+        { ...request, operation: "stop" },
+        tempRoot,
+      );
+      assert.equal(stopped.running, false);
+      const destroyed = runMockBridge(
+        provider,
+        { ...request, operation: "destroy" },
+        tempRoot,
+      );
+      assert.equal(destroyed.remote_id, created.remote_id);
+    }
+  } finally {
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- upgrade @runloop/api-client from 1.14.1 to 1.29.0
- upgrade e2b from 2.18.0 to 2.45.0 and align the scripts Node floor with its supported runtime range
- upgrade modal from 0.7.3 to 0.9.0
- adapt Modal file transfer from removed sandbox.open calls to the supported sandbox.filesystem byte APIs
- add deterministic SDK surface and JSON-over-stdio bridge contract tests, wired into the Scripts CI lane

This is an independent provider dependency lane based directly on the Apple Container modernization branch. The Daytona package migration remains isolated in PR #110.

## Validation
- clean npm ci
- npm test (4 passed)
- npm audit --audit-level=high (0 vulnerabilities)
- cargo test backend::remote --lib (6 passed)
- npm outdated confirms only the separately handled Daytona package remains
- git diff --check

The provider protocol test uses mock mode only. No live Runloop, E2B, or Modal resources were created or mutated.