### PR TITLE
Modernize bundled agent images and CLIs

### DIFF
--- a/app/src-tauri/src/commands/agents.rs
+++ b/app/src-tauri/src/commands/agents.rs
@@ -13,19 +13,27 @@ pub async fn list_agents(state: State<'_, AppState>) -> Result<Vec<AgentInfo>, S
 #[tauri::command(rename_all = "snake_case")]
 pub async fn install_agent(name: String) -> Result<String, String> {
     let (cmd, args): (&str, Vec<&str>) = match name.as_str() {
-        "claude" => ("npm", vec!["install", "-g", "@anthropic-ai/claude-code"]),
-        "gemini" => ("npm", vec!["install", "-g", "@anthropic-ai/gemini-cli"]),
-        "codex" => ("npm", vec!["install", "-g", "@openai/codex"]),
-        "opencode" => ("cargo", vec!["install", "opencode"]),
-        "amp" => ("npm", vec!["install", "-g", "@sourcegraph/amp"]),
+        "claude" => (
+            "npm",
+            vec!["install", "-g", "@anthropic-ai/claude-code@2.1.239"],
+        ),
+        "gemini" => ("npm", vec!["install", "-g", "@google/gemini-cli@0.56.0"]),
+        "codex" => ("npm", vec!["install", "-g", "@openai/codex@0.149.0"]),
+        "opencode" => ("npm", vec!["install", "-g", "opencode-ai@1.18.21"]),
+        "amp" => (
+            "npm",
+            vec![
+                "install",
+                "-g",
+                "--allow-scripts=@ampcode/cli",
+                "@ampcode/cli@0.0.1787342526-gc11bfb",
+            ],
+        ),
         "pi" => (
             "npm",
-            vec!["install", "-g", "@mariozechner/pi-coding-agent"],
+            vec!["install", "-g", "@earendil-works/pi-coding-agent@0.84.2"],
         ),
-        "copilot" => (
-            "npm",
-            vec!["install", "-g", "@githubnext/github-copilot-cli"],
-        ),
+        "copilot" => ("npm", vec!["install", "-g", "@github/copilot@1.0.80"]),
         _ => return Err(format!("Unknown agent: {}", name)),
     };
 

--- a/app/src-tauri/src/commands/sandboxes.rs
+++ b/app/src-tauri/src/commands/sandboxes.rs
@@ -150,8 +150,14 @@ pub async fn quickstart_agent(
                 ("OPENAI_API_KEY", "api.openai.com"),
             ],
         ),
-        "copilot" => ("github-copilot", &[("GITHUB_TOKEN", "api.github.com")]),
+        "copilot" => ("copilot", &[("GITHUB_TOKEN", "api.github.com")]),
         _ => return Err(format!("Unknown agent: {}", agent)),
+    };
+    // Amp and Copilot publish glibc-native packages; the other npm agents are
+    // verified on Alpine 3.24. This only affects newly created sandboxes.
+    let image = match agent.as_str() {
+        "amp" | "copilot" => "node:24-bookworm-slim",
+        _ => "node:24-alpine3.24",
     };
 
     // Build secret bindings from host env vars (format: KEY=value:host)
@@ -165,7 +171,7 @@ pub async fn quickstart_agent(
     // Create sandbox with agent field + secret bindings for LLM proxy
     let req = CreateSandboxRequest {
         name: sandbox_name.clone(),
-        image: Some("node:22-alpine".to_string()),
+        image: Some(image.to_string()),
         vcpus: Some(2),
         memory_mb: Some(1024),
         ports: vec![],

--- a/app/src/pages/Plugins.tsx
+++ b/app/src/pages/Plugins.tsx
@@ -15,13 +15,14 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { toast } from "@/components/ui/use-toast";
 
 const INSTALL_COMMANDS: Record<string, string> = {
-  claude: "npm install -g @anthropic-ai/claude-code",
-  gemini: "npm install -g @anthropic-ai/gemini-cli",
-  codex: "npm install -g @openai/codex",
-  opencode: "cargo install opencode",
-  amp: "npm install -g @sourcegraph/amp",
-  pi: "npm install -g @mariozechner/pi-coding-agent",
-  copilot: "npm install -g @githubnext/github-copilot-cli",
+  claude: "npm install -g @anthropic-ai/claude-code@2.1.239",
+  gemini: "npm install -g @google/gemini-cli@0.56.0",
+  codex: "npm install -g @openai/codex@0.149.0",
+  opencode: "npm install -g opencode-ai@1.18.21",
+  amp:
+    "npm install -g --allow-scripts=@ampcode/cli @ampcode/cli@0.0.1787342526-gc11bfb",
+  pi: "npm install -g @earendil-works/pi-coding-agent@0.84.2",
+  copilot: "npm install -g @github/copilot@1.0.80",
 };
 
 export function Plugins() {

--- a/docs/agents/amp.md
+++ b/docs/agents/amp.md
@@ -94,8 +94,8 @@ mount_cwd = true    # Mount project directory
 
 The sandbox image includes:
 
-- **Node.js 22** — Runtime for Amp
-- **Amp CLI** — `@sourcegraph/amp`
+- **Node.js 24 LTS** — Runtime for Amp
+- **Amp CLI** — `@ampcode/cli`
 - **Git** — Version control
 - **Python 3** — For Python projects
 - **ripgrep** — Fast code search
@@ -107,16 +107,19 @@ The sandbox image includes:
 Create a custom Dockerfile based on the example:
 
 ```dockerfile
-FROM node:22-alpine
+FROM node:24-bookworm-slim
 
 # Base tools
-RUN apk add --no-cache git bash python3 ripgrep fd jq
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git bash python3 ripgrep fd-find jq \
+    && rm -rf /var/lib/apt/lists/*
 
 # Amp CLI
-RUN npm install -g @sourcegraph/amp
+RUN npm install -g --allow-scripts=@ampcode/cli @ampcode/cli@0.0.1787342526-gc11bfb
 
 # Your additions
-RUN apk add --no-cache rust cargo
+RUN apt-get update && apt-get install -y --no-install-recommends rustc cargo \
+    && rm -rf /var/lib/apt/lists/*
 
 # Setup
 WORKDIR /workspace

--- a/docs/agents/claude.md
+++ b/docs/agents/claude.md
@@ -104,7 +104,7 @@ mount_cwd = true    # Mount project directory
 
 The Claude Code image includes:
 
-- **Node.js 22** - Runtime for Claude Code
+- **Node.js 24 LTS** - Runtime for Claude Code
 - **Claude Code CLI** - `@anthropic-ai/claude-code`
 - **Git** - Version control
 - **Python 3** - For Python projects
@@ -143,13 +143,13 @@ This is safe inside agentkernel because the sandbox provides isolation.
 Create a custom Dockerfile based on the example:
 
 ```dockerfile
-FROM node:22-alpine
+FROM node:24-alpine3.24
 
 # Base tools
 RUN apk add --no-cache git bash python3 ripgrep fd jq
 
 # Claude Code CLI
-RUN npm install -g @anthropic-ai/claude-code
+RUN npm install -g @anthropic-ai/claude-code@2.1.239
 
 # Your additions
 RUN apk add --no-cache rust cargo

--- a/docs/agents/codex.md
+++ b/docs/agents/codex.md
@@ -90,7 +90,7 @@ mount_cwd = true    # Mount project directory
 
 The Codex image includes:
 
-- **Node.js 22** - Runtime
+- **Node.js 24 LTS** - Runtime
 - **Codex CLI** - `@openai/codex`
 - **Git** - Version control
 - **Python 3** - For Python projects

--- a/docs/agents/copilot.md
+++ b/docs/agents/copilot.md
@@ -16,7 +16,7 @@ agentkernel serve                 # or run manually in a terminal
 agentkernel plugin install copilot
 
 # 3. Launch Copilot CLI — it picks up .mcp.json automatically
-github-copilot
+copilot
 ```
 
 ## MCP Integration
@@ -45,7 +45,7 @@ agentkernel attach copilot-dev -e GITHUB_TOKEN=$GITHUB_TOKEN
 
 # One-off command
 agentkernel exec copilot-dev -e GITHUB_TOKEN=$GITHUB_TOKEN -- \
-  github-copilot "Explain this code"
+  copilot "Explain this code"
 ```
 
 ## Sandbox-Based Workflow
@@ -63,7 +63,7 @@ agentkernel sandbox start copilot-dev
 agentkernel attach copilot-dev -e GITHUB_TOKEN=$GITHUB_TOKEN
 
 # Inside the sandbox:
-github-copilot
+copilot
 ```
 
 ## Configuration
@@ -103,8 +103,8 @@ mount_cwd = true    # Mount project directory
 
 The sandbox image includes:
 
-- **Node.js 22** — Runtime for Copilot CLI
-- **Copilot CLI** — `@githubnext/github-copilot-cli`
+- **Node.js 24 LTS** — Runtime for Copilot CLI
+- **Copilot CLI** — `@github/copilot`
 - **Git** — Version control
 - **Python 3** — For Python projects
 - **ripgrep** — Fast code search
@@ -116,16 +116,19 @@ The sandbox image includes:
 Create a custom Dockerfile based on the example:
 
 ```dockerfile
-FROM node:22-alpine
+FROM node:24-bookworm-slim
 
 # Base tools
-RUN apk add --no-cache git bash python3 ripgrep fd jq
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git bash python3 ripgrep fd-find jq \
+    && rm -rf /var/lib/apt/lists/*
 
 # Copilot CLI
-RUN npm install -g @githubnext/github-copilot-cli
+RUN npm install -g @github/copilot@1.0.80
 
 # Your additions
-RUN apk add --no-cache rust cargo
+RUN apt-get update && apt-get install -y --no-install-recommends rustc cargo \
+    && rm -rf /var/lib/apt/lists/*
 
 # Setup
 WORKDIR /workspace

--- a/docs/agents/gemini.md
+++ b/docs/agents/gemini.md
@@ -119,7 +119,7 @@ mount_cwd = true    # Mount project directory
 
 The Gemini image includes:
 
-- **Node.js 22** - Runtime
+- **Node.js 24 LTS** - Runtime
 - **Gemini CLI** - `@google/gemini-cli`
 - **Git** - Version control
 - **Python 3** - For Python projects

--- a/docs/agents/hermes.md
+++ b/docs/agents/hermes.md
@@ -120,7 +120,7 @@ mount_cwd = true
 The sandbox image includes:
 
 - **Python 3.11** - Runtime for Hermes
-- **Node.js 22** - For browser automation tools
+- **Node.js 24 LTS** - For browser automation tools
 - **Hermes Agent** - Full install with 40+ tools
 - **mini-swe-agent** - Terminal tool backend
 - **Git** - Version control
@@ -132,21 +132,22 @@ The sandbox image includes:
 Create a custom Dockerfile based on the example:
 
 ```dockerfile
-FROM nikolaik/python-nodejs:python3.11-nodejs22
+FROM node:24-bookworm-slim
 
 # Base tools
-RUN apt-get update && apt-get install -y --no-install-recommends git bash ripgrep jq
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git bash python3 python3-venv ripgrep jq
 
 # Hermes Agent
-RUN git clone --depth 1 https://github.com/NousResearch/hermes-agent.git /opt/hermes-agent \
-    && cd /opt/hermes-agent \
-    && git submodule update --init --depth 1 \
-    && pip install -e ".[all]" \
-    && pip install -e "./mini-swe-agent" \
-    && npm install
+RUN git init /opt/hermes-agent \
+    && git -C /opt/hermes-agent remote add origin https://github.com/NousResearch/hermes-agent.git \
+    && git -C /opt/hermes-agent fetch --depth 1 origin fc7523ca31eeb6eff9114afe384c2cf6380359df \
+    && git -C /opt/hermes-agent checkout --detach FETCH_HEAD \
+    && python3 -m venv /opt/hermes-venv \
+    && /opt/hermes-venv/bin/pip install -e "/opt/hermes-agent[all]"
 
 # Your additions
-RUN pip install your-custom-packages
+RUN /opt/hermes-venv/bin/pip install your-custom-packages
 
 WORKDIR /workspace
 ```

--- a/docs/agents/index.md
+++ b/docs/agents/index.md
@@ -10,7 +10,7 @@ agentkernel provides pre-configured Docker images for popular AI coding agents. 
 | [Claude Code](claude.md) | `claude` | `ANTHROPIC_API_KEY` |
 | [OpenAI Codex](codex.md) | `codex` | `OPENAI_API_KEY` |
 | [Google Gemini](gemini.md) | `gemini` | `GEMINI_API_KEY` |
-| [GitHub Copilot](copilot.md) | `github-copilot` | `GITHUB_TOKEN` |
+| [GitHub Copilot](copilot.md) | `copilot` | `GITHUB_TOKEN` |
 | [Amp](amp.md) | `amp` | `ANTHROPIC_API_KEY` |
 | [Pi](pi.md) | `pi` | `ANTHROPIC_API_KEY` or `OPENAI_API_KEY` |
 | [OpenCode](opencode.md) | `opencode` | Provider-specific |
@@ -41,7 +41,7 @@ agentkernel exec my-agent -e ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY -- claude -p "
 
 All agent images include:
 
-- **Node.js 22** - Runtime for agent CLIs
+- **Node.js 24 LTS** - Runtime for agent CLIs
 - **Git** - Version control
 - **Python 3** - For Python projects
 - **ripgrep** - Fast code search

--- a/docs/agents/opencode.md
+++ b/docs/agents/opencode.md
@@ -100,12 +100,11 @@ The built-in `opencode-sandbox` template:
 ```toml
 [sandbox]
 name = "opencode-sandbox"
-base_image = "node:22-alpine"
+base_image = "node:24-alpine3.24"
 init_script = """
 set -e
 apk add --no-cache git bash curl python3 ripgrep fd jq
-curl -fsSL https://opencode.ai/install | bash
-export PATH="$HOME/.opencode/bin:$PATH"
+npm install -g opencode-ai@1.18.21
 """
 
 [agent]
@@ -137,8 +136,8 @@ OpenCode itself supports multiple LLM providers. Pass your provider's API key as
 
 The sandbox comes with:
 
-- **Node.js 22** — Runtime
-- **OpenCode CLI** — installed via `opencode.ai/install`
+- **Node.js 24 LTS** — Runtime
+- **OpenCode CLI** — `opencode-ai@1.18.21`
 - **Git** — Version control
 - **Python 3** — For Python projects
 - **ripgrep** — Fast code search

--- a/docs/agents/pi.md
+++ b/docs/agents/pi.md
@@ -1,7 +1,7 @@
 
 # Pi
 
-Run [pi-coding-agent](https://github.com/badlogic/pi-mono) with agentkernel for isolated code execution.
+Run [Pi coding agent](https://github.com/earendil-works/pi) with agentkernel for isolated code execution.
 
 ## Quick Start
 
@@ -169,8 +169,8 @@ Pi itself supports multiple LLM providers. Pass your provider's API key as usual
 
 The sandbox image includes:
 
-- **Node.js 22** — Runtime for Pi
-- **Pi CLI** — `@mariozechner/pi-coding-agent`
+- **Node.js 24 LTS** — Runtime for Pi
+- **Pi CLI** — `@earendil-works/pi-coding-agent`
 - **Git** — Version control
 - **Python 3** — For Python projects
 - **ripgrep** — Fast code search
@@ -182,13 +182,13 @@ The sandbox image includes:
 Create a custom Dockerfile based on the example:
 
 ```dockerfile
-FROM node:22-alpine
+FROM node:24-alpine3.24
 
 # Base tools
 RUN apk add --no-cache git bash python3 ripgrep fd jq
 
 # Pi CLI
-RUN npm install -g @mariozechner/pi-coding-agent
+RUN npm install -g @earendil-works/pi-coding-agent@0.84.2
 
 # Your additions
 RUN apk add --no-cache rust cargo

--- a/docs/agents/symphony.md
+++ b/docs/agents/symphony.md
@@ -148,8 +148,8 @@ When started with `--port`, Symphony exposes a dashboard and API:
 The sandbox image includes:
 
 - **Elixir 1.19** with **OTP 28** - Runtime for Symphony
-- **Node.js 22** - For Codex CLI
-- **Codex CLI** - `@openai/codex` (coding agent)
+- **Node.js 24 LTS** - For Codex CLI
+- **Codex CLI** - `@openai/codex@0.149.0` (coding agent)
 - **Git** - Version control
 - **bash** - Shell
 
@@ -163,17 +163,20 @@ FROM elixir:1.19-otp-28-slim
 # Base tools + Node.js
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git bash ca-certificates gnupg curl \
-    && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
     && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*
 
 # Codex CLI
-RUN npm install -g @openai/codex
+RUN npm install -g @openai/codex@0.149.0
 
 # Symphony
 RUN mix local.hex --force && mix local.rebar --force
-RUN git clone --depth 1 https://github.com/openai/symphony.git /opt/symphony \
-    && cd /opt/symphony/elixir && mix deps.get && mix compile
+RUN git init /opt/symphony \
+    && git -C /opt/symphony remote add origin https://github.com/openai/symphony.git \
+    && git -C /opt/symphony fetch --depth 1 origin 8001b52e3062495a16e520e4ceaf8f9de868c4d0 \
+    && git -C /opt/symphony checkout --detach FETCH_HEAD \
+    && cd /opt/symphony/elixir && MIX_ENV=prod mix setup && MIX_ENV=prod mix build
 
 # Your additions
 RUN npm install -g your-custom-tools

--- a/docs/commands/templates.md
+++ b/docs/commands/templates.md
@@ -39,12 +39,14 @@ agentkernel ships with 26 built-in templates:
 
 | Template | Image | Use Case |
 |----------|-------|----------|
-| `amp-sandbox` | `node:22-alpine` | Amp (Sourcegraph) agent |
-| `claude-sandbox` | `node:22-alpine` | Claude Code agent |
-| `codex-sandbox` | `node:22-alpine` | Codex agent |
-| `gemini-sandbox` | `python:3.12-alpine` | Gemini CLI agent |
-| `opencode-sandbox` | `golang:1.23-alpine` | OpenCode agent |
-| `pi-sandbox` | `node:22-alpine` | Pi coding agent |
+| `amp-sandbox` | `node:24-bookworm-slim` | Amp agent |
+| `claude-sandbox` | `node:24-alpine3.24` | Claude Code agent |
+| `codex-sandbox` | `node:24-alpine3.24` | Codex agent |
+| `copilot-sandbox` | `node:24-bookworm-slim` | GitHub Copilot CLI agent |
+| `gemini-sandbox` | `node:24-alpine3.24` | Gemini CLI agent |
+| `opencode-sandbox` | `node:24-alpine3.24` | OpenCode agent |
+| `pi-sandbox` | `node:24-alpine3.24` | Pi coding agent |
+| `symphony-sandbox` | `elixir:1.19-otp-28-slim` | Symphony orchestration agent |
 
 ### Dev Tools
 

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -36,7 +36,7 @@ No separate `docker build` step needed - agentkernel automatically builds from t
 ## Common Features
 
 All agent images include:
-- **Node.js 22** - Runtime for agent CLIs
+- **Node.js 24 LTS** - Runtime for agent CLIs
 - **Git** - Version control
 - **Python 3** - For Python projects
 - **ripgrep** - Fast search (used by agents)
@@ -50,6 +50,20 @@ All images:
 - Run as non-root user `developer`
 - Have workspace isolated at `/workspace`
 - Respect agentkernel security profiles
+
+## Tested versions
+
+[`tested-versions.json`](tested-versions.json) records the exact CLI versions or
+immutable source commits used by every image. To build and smoke all images:
+
+```bash
+scripts/smoke-agent-images.sh
+```
+
+Pass one or more directory names to test a subset, or use `--no-build` to smoke
+already-built local tags. The smoke checks are deliberately offline: they verify
+the executable and version/help output, Node and Alpine versions, non-root user,
+and writable workspace without requiring agent credentials.
 
 ## Customizing
 

--- a/examples/agents/amp/Dockerfile
+++ b/examples/agents/amp/Dockerfile
@@ -11,30 +11,35 @@
 # Environment variables:
 #   ANTHROPIC_API_KEY - Required for Amp to work
 
-FROM node:22-alpine
+# Amp publishes glibc Linux binaries, so use the maintained Node 24 Debian
+# variant instead of Alpine/musl.
+FROM node:24-bookworm-slim
+
+ARG AMP_VERSION=0.0.1787342526-gc11bfb
 
 # Install essential tools
-RUN apk add --no-cache \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     curl \
     bash \
     openssh-client \
     python3 \
-    py3-pip \
+    python3-pip \
     ripgrep \
-    fd \
+    fd-find \
     jq \
-    && rm -rf /var/cache/apk/*
+    && ln -s /usr/bin/fdfind /usr/local/bin/fd \
+    && rm -rf /var/lib/apt/lists/*
 
-# Install Amp CLI globally
-RUN npm install -g @sourcegraph/amp
+# Amp's supported npm package moved from @sourcegraph/amp to @ampcode/cli.
+RUN npm install -g --allow-scripts=@ampcode/cli "@ampcode/cli@${AMP_VERSION}"
 
 # Create workspace directory
 RUN mkdir -p /workspace
 WORKDIR /workspace
 
 # Set up a non-root user for better security
-RUN adduser -D -h /home/developer developer \
+RUN useradd -m -d /home/developer -s /bin/bash developer \
     && chown -R developer:developer /workspace
 
 # Switch to non-root user

--- a/examples/agents/amp/README.md
+++ b/examples/agents/amp/README.md
@@ -24,8 +24,8 @@ amp
 
 ## What's Included
 
-- **Node.js 22** - Runtime for Amp
-- **Amp CLI** - `@sourcegraph/amp`
+- **Node.js 24 LTS** - Runtime for Amp
+- **Amp CLI** - `@ampcode/cli`
 - **Git** - Version control
 - **Python 3** - For Python projects
 - **ripgrep** - Fast search

--- a/examples/agents/claude-code/Dockerfile
+++ b/examples/agents/claude-code/Dockerfile
@@ -13,7 +13,9 @@
 # Environment variables:
 #   ANTHROPIC_API_KEY - Required for Claude Code to work
 
-FROM node:22-alpine
+FROM node:24-alpine3.24
+
+ARG CLAUDE_CODE_VERSION=2.1.239
 
 # Install essential tools
 RUN apk add --no-cache \
@@ -29,7 +31,7 @@ RUN apk add --no-cache \
     && rm -rf /var/cache/apk/*
 
 # Install Claude Code CLI globally
-RUN npm install -g @anthropic-ai/claude-code
+RUN npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"
 
 # Create workspace directory
 RUN mkdir -p /workspace

--- a/examples/agents/claude-code/README.md
+++ b/examples/agents/claude-code/README.md
@@ -39,7 +39,7 @@ agentkernel exec my-project -- env ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY claude
 
 ## What's Included
 
-- **Node.js 22** - Runtime for Claude Code
+- **Node.js 24 LTS** - Runtime for Claude Code
 - **Claude Code CLI** - `@anthropic-ai/claude-code`
 - **Git** - Version control
 - **Python 3** - For Python projects

--- a/examples/agents/codex/Dockerfile
+++ b/examples/agents/codex/Dockerfile
@@ -11,7 +11,9 @@
 # Environment variables:
 #   OPENAI_API_KEY - Required for Codex to work
 
-FROM node:22-alpine
+FROM node:24-alpine3.24
+
+ARG CODEX_VERSION=0.149.0
 
 # Install essential tools
 RUN apk add --no-cache \
@@ -27,7 +29,7 @@ RUN apk add --no-cache \
     && rm -rf /var/cache/apk/*
 
 # Install OpenAI Codex CLI globally
-RUN npm install -g @openai/codex
+RUN npm install -g "@openai/codex@${CODEX_VERSION}"
 
 # Create workspace directory
 RUN mkdir -p /workspace

--- a/examples/agents/codex/README.md
+++ b/examples/agents/codex/README.md
@@ -27,7 +27,7 @@ codex
 
 ## What's Included
 
-- **Node.js 22** - Runtime for Codex
+- **Node.js 24 LTS** - Runtime for Codex
 - **Codex CLI** - `@openai/codex`
 - **Git** - Version control
 - **Python 3** - For Python projects

--- a/examples/agents/copilot/Dockerfile
+++ b/examples/agents/copilot/Dockerfile
@@ -13,30 +13,36 @@
 # Environment variables:
 #   GITHUB_TOKEN - Required for Copilot CLI to work
 
-FROM node:22-alpine
+# Copilot's current native musl artifact aborts during startup on Alpine 3.24,
+# so use the maintained Node 24 Debian variant for this image.
+FROM node:24-bookworm-slim
+
+ARG COPILOT_CLI_VERSION=1.0.80
 
 # Install essential tools
-RUN apk add --no-cache \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     curl \
     bash \
     openssh-client \
     python3 \
-    py3-pip \
+    python3-pip \
     ripgrep \
-    fd \
+    fd-find \
     jq \
-    && rm -rf /var/cache/apk/*
+    && ln -s /usr/bin/fdfind /usr/local/bin/fd \
+    && rm -rf /var/lib/apt/lists/*
 
-# Install Copilot CLI globally
-RUN npm install -g @githubnext/github-copilot-cli
+# Install the supported GitHub Copilot CLI package. The old
+# @githubnext/github-copilot-cli package is discontinued.
+RUN npm install -g "@github/copilot@${COPILOT_CLI_VERSION}"
 
 # Create workspace directory
 RUN mkdir -p /workspace
 WORKDIR /workspace
 
 # Set up a non-root user for better security
-RUN adduser -D -h /home/developer developer \
+RUN useradd -m -d /home/developer -s /bin/bash developer \
     && chown -R developer:developer /workspace
 
 # Switch to non-root user

--- a/examples/agents/copilot/README.md
+++ b/examples/agents/copilot/README.md
@@ -13,7 +13,7 @@ agentkernel sandbox start my-project
 agentkernel attach my-project
 
 # Inside the sandbox, run Copilot CLI
-github-copilot
+copilot
 ```
 
 The Dockerfile is built automatically when you use the config file.
@@ -34,13 +34,13 @@ export GITHUB_TOKEN=ghp_...
 agentkernel sandbox create my-project --image agentkernel/copilot
 
 # Option 2: Pass via exec
-agentkernel exec my-project -- env GITHUB_TOKEN=$GITHUB_TOKEN github-copilot
+agentkernel exec my-project -- env GITHUB_TOKEN=$GITHUB_TOKEN copilot
 ```
 
 ## What's Included
 
-- **Node.js 22** - Runtime for Copilot CLI
-- **Copilot CLI** - `@githubnext/github-copilot-cli`
+- **Node.js 24 LTS** - Runtime for Copilot CLI
+- **Copilot CLI** - `@github/copilot`
 - **Git** - Version control
 - **Python 3** - For Python projects
 - **ripgrep** - Fast search

--- a/examples/agents/gemini/Dockerfile
+++ b/examples/agents/gemini/Dockerfile
@@ -11,7 +11,9 @@
 # Environment variables:
 #   GEMINI_API_KEY - Required for Gemini to work
 
-FROM node:22-alpine
+FROM node:24-alpine3.24
+
+ARG GEMINI_CLI_VERSION=0.56.0
 
 # Install essential tools
 RUN apk add --no-cache \
@@ -27,7 +29,7 @@ RUN apk add --no-cache \
     && rm -rf /var/cache/apk/*
 
 # Install Google Gemini CLI globally
-RUN npm install -g @google/gemini-cli
+RUN npm install -g "@google/gemini-cli@${GEMINI_CLI_VERSION}"
 
 # Create workspace directory
 RUN mkdir -p /workspace

--- a/examples/agents/gemini/README.md
+++ b/examples/agents/gemini/README.md
@@ -27,7 +27,7 @@ gemini
 
 ## What's Included
 
-- **Node.js 22** - Runtime for Gemini CLI
+- **Node.js 24 LTS** - Runtime for Gemini CLI
 - **Gemini CLI** - `@google/gemini-cli`
 - **Git** - Version control
 - **Python 3** - For Python projects

--- a/examples/agents/hermes/Dockerfile
+++ b/examples/agents/hermes/Dockerfile
@@ -12,7 +12,10 @@
 #   OPENROUTER_API_KEY - Recommended (access to all models via OpenRouter)
 #   ANTHROPIC_API_KEY  - Alternative (direct Anthropic access)
 
-FROM nikolaik/python-nodejs:python3.11-nodejs22
+FROM node:24-bookworm-slim
+
+ARG HERMES_VERSION=0.20.5
+ARG HERMES_COMMIT=fc7523ca31eeb6eff9114afe384c2cf6380359df
 
 # Install essential tools
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -20,17 +23,24 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     bash \
     openssh-client \
+    python3 \
+    python3-pip \
+    python3-venv \
     ripgrep \
     jq \
     && rm -rf /var/lib/apt/lists/*
 
-# Clone and install Hermes Agent
-RUN git clone --depth 1 https://github.com/NousResearch/hermes-agent.git /opt/hermes-agent \
-    && cd /opt/hermes-agent \
-    && git submodule update --init --depth 1 \
-    && pip install --no-cache-dir -e ".[all]" \
-    && pip install --no-cache-dir -e "./mini-swe-agent" \
-    && npm install
+# Install the tested Hermes release from an immutable upstream commit. Keep its
+# Python environment outside the checkout, matching upstream's guidance.
+RUN git init /opt/hermes-agent \
+    && git -C /opt/hermes-agent remote add origin https://github.com/NousResearch/hermes-agent.git \
+    && git -C /opt/hermes-agent fetch --depth 1 origin "${HERMES_COMMIT}" \
+    && git -C /opt/hermes-agent checkout --detach FETCH_HEAD \
+    && test "$(python3 -c 'import tomllib; print(tomllib.load(open("/opt/hermes-agent/pyproject.toml", "rb"))["project"]["version"])')" = "${HERMES_VERSION}" \
+    && python3 -m venv /opt/hermes-venv \
+    && /opt/hermes-venv/bin/pip install --no-cache-dir --upgrade pip \
+    && /opt/hermes-venv/bin/pip install --no-cache-dir -e "/opt/hermes-agent[all]" \
+    && ln -s /opt/hermes-venv/bin/hermes /usr/local/bin/hermes
 
 # Create workspace directory
 RUN mkdir -p /workspace

--- a/examples/agents/hermes/README.md
+++ b/examples/agents/hermes/README.md
@@ -28,7 +28,7 @@ Hermes supports multiple LLM providers via LiteLLM. Provide at least one API key
 ## What's Included
 
 - **Python 3.11** - Runtime for Hermes
-- **Node.js 22** - For browser automation tools
+- **Node.js 24 LTS** - For browser automation tools
 - **Hermes Agent** - Full install from source with all tools
 - **mini-swe-agent** - Terminal tool backend
 - **Git** - Version control

--- a/examples/agents/opencode/Dockerfile
+++ b/examples/agents/opencode/Dockerfile
@@ -11,7 +11,9 @@
 # Environment variables:
 #   Set your LLM provider's API key as needed (e.g. ANTHROPIC_API_KEY, OPENAI_API_KEY)
 
-FROM node:22-alpine
+FROM node:24-alpine3.24
+
+ARG OPENCODE_VERSION=1.18.21
 
 # Install essential tools
 RUN apk add --no-cache \
@@ -26,8 +28,9 @@ RUN apk add --no-cache \
     jq \
     && rm -rf /var/cache/apk/*
 
-# Install OpenCode CLI
-RUN curl -fsSL https://opencode.ai/install | bash
+# Install OpenCode into npm's system-wide prefix so the non-root runtime user
+# can discover the executable without inheriting root's home directory.
+RUN npm install -g "opencode-ai@${OPENCODE_VERSION}"
 
 # Create workspace directory
 RUN mkdir -p /workspace
@@ -40,10 +43,9 @@ RUN adduser -D -h /home/developer developer \
 # Switch to non-root user
 USER developer
 
-# Set up shell and PATH for opencode
+# Set up shell
 ENV SHELL=/bin/bash
 ENV HOME=/home/developer
-ENV PATH="/root/.opencode/bin:$PATH"
 
 # Keep container running (for attach/exec)
 CMD ["tail", "-f", "/dev/null"]

--- a/examples/agents/opencode/README.md
+++ b/examples/agents/opencode/README.md
@@ -29,7 +29,7 @@ OpenCode supports multiple LLM providers. Pass whichever key your provider requi
 
 ## What's Included
 
-- **Node.js 22** — Runtime for OpenCode
+- **Node.js 24 LTS** — Runtime for OpenCode
 - **OpenCode CLI** — `opencode`
 - **Git** — Version control
 - **Python 3** — For Python projects

--- a/examples/agents/pi/Dockerfile
+++ b/examples/agents/pi/Dockerfile
@@ -11,7 +11,9 @@
 # Environment variables:
 #   ANTHROPIC_API_KEY or OPENAI_API_KEY - Required for Pi to work
 
-FROM node:22-alpine
+FROM node:24-alpine3.24
+
+ARG PI_VERSION=0.84.2
 
 # Install essential tools
 RUN apk add --no-cache \
@@ -26,8 +28,8 @@ RUN apk add --no-cache \
     jq \
     && rm -rf /var/cache/apk/*
 
-# Install Pi CLI globally
-RUN npm install -g @mariozechner/pi-coding-agent
+# Pi's supported package moved from @mariozechner to @earendil-works.
+RUN npm install -g "@earendil-works/pi-coding-agent@${PI_VERSION}"
 
 # Create workspace directory
 RUN mkdir -p /workspace

--- a/examples/agents/pi/README.md
+++ b/examples/agents/pi/README.md
@@ -27,8 +27,8 @@ Pi supports multiple LLM providers. Provide at least one API key.
 
 ## What's Included
 
-- **Node.js 22** - Runtime for Pi
-- **Pi CLI** - `@mariozechner/pi-coding-agent`
+- **Node.js 24 LTS** - Runtime for Pi
+- **Pi CLI** - `@earendil-works/pi-coding-agent`
 - **Git** - Version control
 - **Python 3** - For Python projects
 - **ripgrep** - Fast search

--- a/examples/agents/symphony/Dockerfile
+++ b/examples/agents/symphony/Dockerfile
@@ -14,6 +14,10 @@
 
 FROM elixir:1.19-otp-28-slim
 
+ARG CODEX_VERSION=0.149.0
+ARG SYMPHONY_VERSION=0.0.2
+ARG SYMPHONY_COMMIT=8001b52e3062495a16e520e4ceaf8f9de868c4d0
+
 # Install essential tools and Node.js
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
@@ -22,21 +26,27 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     gnupg \
     openssh-client \
-    && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 
 # Install OpenAI Codex CLI
-RUN npm install -g @openai/codex
+RUN npm install -g "@openai/codex@${CODEX_VERSION}"
 
 # Install hex and rebar
 RUN mix local.hex --force && mix local.rebar --force
 
-# Clone and build Symphony
-RUN git clone --depth 1 https://github.com/openai/symphony.git /opt/symphony \
+# Clone and build the tested Symphony reference implementation from an
+# immutable upstream commit, then expose the escript on the system PATH.
+RUN git init /opt/symphony \
+    && git -C /opt/symphony remote add origin https://github.com/openai/symphony.git \
+    && git -C /opt/symphony fetch --depth 1 origin "${SYMPHONY_COMMIT}" \
+    && git -C /opt/symphony checkout --detach FETCH_HEAD \
+    && test "$(sed -n 's/.*version: \"\([^\"]*\)\".*/\1/p' /opt/symphony/elixir/mix.exs | head -n 1)" = "${SYMPHONY_VERSION}" \
     && cd /opt/symphony/elixir \
-    && mix deps.get \
-    && mix compile
+    && MIX_ENV=prod mix setup \
+    && MIX_ENV=prod mix build \
+    && ln -s /opt/symphony/elixir/bin/symphony /usr/local/bin/symphony
 
 # Create workspace directory
 RUN mkdir -p /workspace

--- a/examples/agents/symphony/README.md
+++ b/examples/agents/symphony/README.md
@@ -26,7 +26,7 @@ cd /opt/symphony/elixir && mix run -- /workspace/WORKFLOW.md --port 4000
 ## What's Included
 
 - **Elixir 1.19** with **OTP 28** - Runtime for Symphony
-- **Node.js 22** - For Codex CLI
+- **Node.js 24 LTS** - For Codex CLI
 - **Codex CLI** - `@openai/codex` (the coding agent Symphony spawns)
 - **Git** - Version control
 - **bash** - Shell

--- a/examples/agents/tested-versions.json
+++ b/examples/agents/tested-versions.json
@@ -1,0 +1,116 @@
+{
+  "schema_version": 1,
+  "tested_at": "2026-08-21",
+  "defaults": {
+    "runtime_user": "developer",
+    "workspace": "/workspace"
+  },
+  "base_images": {
+    "node_alpine": {
+      "image": "node:24-alpine3.24",
+      "node_major": "24",
+      "alpine_major_minor": "3.24"
+    },
+    "node_debian": {
+      "image": "node:24-bookworm-slim",
+      "node_major": "24"
+    },
+    "elixir_debian": {
+      "image": "elixir:1.19-otp-28-slim",
+      "node_major": "24"
+    }
+  },
+  "agents": [
+    {
+      "id": "codex",
+      "package": "@openai/codex",
+      "version": "0.149.0",
+      "source": "https://github.com/openai/codex",
+      "base": "node_alpine",
+      "executable": "codex",
+      "smoke_arg": "--version",
+      "expected_output": "0.149.0"
+    },
+    {
+      "id": "claude-code",
+      "package": "@anthropic-ai/claude-code",
+      "version": "2.1.239",
+      "source": "https://docs.anthropic.com/en/docs/claude-code/getting-started",
+      "base": "node_alpine",
+      "executable": "claude",
+      "smoke_arg": "--version",
+      "expected_output": "2.1.239"
+    },
+    {
+      "id": "gemini",
+      "package": "@google/gemini-cli",
+      "version": "0.56.0",
+      "source": "https://github.com/google-gemini/gemini-cli",
+      "base": "node_alpine",
+      "executable": "gemini",
+      "smoke_arg": "--version",
+      "expected_output": "0.56.0"
+    },
+    {
+      "id": "copilot",
+      "package": "@github/copilot",
+      "version": "1.0.80",
+      "source": "https://github.com/github/copilot-cli",
+      "base": "node_debian",
+      "executable": "copilot",
+      "smoke_arg": "--version",
+      "expected_output": "1.0.80"
+    },
+    {
+      "id": "opencode",
+      "package": "opencode-ai",
+      "version": "1.18.21",
+      "source": "https://github.com/anomalyco/opencode",
+      "base": "node_alpine",
+      "executable": "opencode",
+      "smoke_arg": "--version",
+      "expected_output": "1.18.21"
+    },
+    {
+      "id": "amp",
+      "package": "@ampcode/cli",
+      "version": "0.0.1787342526-gc11bfb",
+      "source": "https://ampcode.com/news/npm-package-changes",
+      "base": "node_debian",
+      "executable": "amp",
+      "smoke_arg": "--version",
+      "expected_output": "c11bfb"
+    },
+    {
+      "id": "pi",
+      "package": "@earendil-works/pi-coding-agent",
+      "version": "0.84.2",
+      "source": "https://github.com/earendil-works/pi",
+      "base": "node_alpine",
+      "executable": "pi",
+      "smoke_arg": "--version",
+      "expected_output": "0.84.2"
+    },
+    {
+      "id": "hermes",
+      "version": "0.20.5",
+      "source": "https://github.com/NousResearch/hermes-agent",
+      "source_ref": "fc7523ca31eeb6eff9114afe384c2cf6380359df",
+      "base": "node_debian",
+      "executable": "hermes",
+      "smoke_arg": "--version",
+      "expected_output": "0.20.5"
+    },
+    {
+      "id": "symphony",
+      "version": "0.0.2",
+      "source": "https://github.com/openai/symphony",
+      "source_ref": "8001b52e3062495a16e520e4ceaf8f9de868c4d0",
+      "base": "elixir_debian",
+      "executable": "symphony",
+      "smoke_arg": "--help",
+      "expected_exit": 1,
+      "expected_output": "Usage"
+    }
+  ]
+}

--- a/packages/pi-agentkernel/README.md
+++ b/packages/pi-agentkernel/README.md
@@ -1,6 +1,6 @@
 # pi-agentkernel
 
-Route [Pi coding agent](https://github.com/badlogic/pi-mono) commands through [agentkernel](https://github.com/thrashr888/agentkernel) microVM sandboxes.
+Route [Pi coding agent](https://github.com/earendil-works/pi) commands through [agentkernel](https://github.com/thrashr888/agentkernel) microVM sandboxes.
 
 ## Install
 
@@ -44,7 +44,7 @@ This extension overrides Pi's built-in `bash` tool so every shell command runs i
 ## Requirements
 
 - [agentkernel](https://github.com/thrashr888/agentkernel) running locally or remotely
-- Pi v0.49.0 or later
+- Pi v0.84.2 or later
 
 ## License
 

--- a/packages/pi-agentkernel/index.ts
+++ b/packages/pi-agentkernel/index.ts
@@ -8,7 +8,7 @@
  * Install: agentkernel plugin install pi
  * Or manually copy this directory into your project's .pi/extensions/
  */
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 
 interface SandboxInfo {
@@ -79,7 +79,7 @@ export default function (pi: ExtensionAPI) {
     try {
       await request<SandboxInfo>("POST", "/sandboxes", {
         name,
-        image: "node:22-alpine",
+        image: "node:24-alpine3.24",
       });
       sandboxName = name;
       sandboxReady = true;
@@ -137,6 +137,7 @@ export default function (pi: ExtensionAPI) {
           content: [
             { type: "text", text: result.stdout + result.stderr },
           ],
+          details: { sandbox: "local", sandboxed: false },
         };
       }
 
@@ -149,6 +150,7 @@ export default function (pi: ExtensionAPI) {
                 text: `Running in sandbox ${sandboxName}...`,
               },
             ],
+            details: { sandbox: sandboxName, sandboxed: true },
           });
         }
 
@@ -166,6 +168,11 @@ export default function (pi: ExtensionAPI) {
         if (signal?.aborted) {
           return {
             content: [{ type: "text", text: "Command cancelled." }],
+            details: {
+              sandbox: sandboxName,
+              sandboxed: sandboxReady,
+              error: true,
+            },
           };
         }
         const message =
@@ -177,7 +184,11 @@ export default function (pi: ExtensionAPI) {
               text: `Sandbox error: ${message}`,
             },
           ],
-          details: { error: true },
+          details: {
+            sandbox: sandboxName ?? "unavailable",
+            sandboxed: sandboxReady,
+            error: true,
+          },
         };
       }
     },
@@ -196,7 +207,7 @@ export default function (pi: ExtensionAPI) {
       image: Type.Optional(
         Type.String({
           description:
-            "Container image (default: alpine:3.24). Examples: python:3.12-alpine, node:22-alpine",
+            "Container image (default: alpine:3.24). Examples: python:3.13-alpine, node:24-alpine3.24",
         }),
       ),
     }),
@@ -209,12 +220,16 @@ export default function (pi: ExtensionAPI) {
       try {
         const result = await request<RunOutput>("POST", "/run", {
           command: ["sh", "-c", command],
-          image,
+          image: image ?? "alpine:3.24",
           fast: true,
         });
         return {
           content: [{ type: "text", text: result.output }],
-          details: { sandbox: "one-shot", image: image ?? "alpine:3.24" },
+          details: {
+            sandbox: "one-shot",
+            image: image ?? "alpine:3.24",
+            error: false,
+          },
         };
       } catch (err: unknown) {
         const message =
@@ -223,7 +238,11 @@ export default function (pi: ExtensionAPI) {
           content: [
             { type: "text", text: `Sandbox error: ${message}` },
           ],
-          details: { error: true },
+          details: {
+            sandbox: "one-shot",
+            image: image ?? "alpine:3.24",
+            error: true,
+          },
         };
       }
     },

--- a/packages/pi-agentkernel/package.json
+++ b/packages/pi-agentkernel/package.json
@@ -28,7 +28,7 @@
     "README.md"
   ],
   "peerDependencies": {
-    "@mariozechner/pi-coding-agent": ">=0.49.0"
+    "@earendil-works/pi-coding-agent": ">=0.84.2 <1"
   },
   "pi": {
     "extensions": [

--- a/scripts/smoke-agent-images.sh
+++ b/scripts/smoke-agent-images.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+manifest="$repo_root/examples/agents/tested-versions.json"
+build=true
+
+if [[ "${1:-}" == "--no-build" ]]; then
+  build=false
+  shift
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required to read $manifest" >&2
+  exit 1
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "docker is required to build and smoke agent images" >&2
+  exit 1
+fi
+
+if [[ "$#" -gt 0 ]]; then
+  agent_ids=$(printf '%s\n' "$@")
+else
+  agent_ids=$(jq -r '.agents[].id' "$manifest")
+fi
+
+while IFS= read -r agent_id; do
+  [[ -n "$agent_id" ]] || continue
+
+  if ! jq -e --arg id "$agent_id" '.agents[] | select(.id == $id)' "$manifest" >/dev/null; then
+    echo "unknown agent: $agent_id" >&2
+    exit 1
+  fi
+
+  version=$(jq -r --arg id "$agent_id" '.agents[] | select(.id == $id) | .version' "$manifest")
+  executable=$(jq -r --arg id "$agent_id" '.agents[] | select(.id == $id) | .executable' "$manifest")
+  smoke_arg=$(jq -r --arg id "$agent_id" '.agents[] | select(.id == $id) | .smoke_arg' "$manifest")
+  expected_exit=$(jq -r --arg id "$agent_id" '.agents[] | select(.id == $id) | .expected_exit // 0' "$manifest")
+  expected_output=$(jq -r --arg id "$agent_id" '.agents[] | select(.id == $id) | .expected_output' "$manifest")
+  base=$(jq -r --arg id "$agent_id" '.agents[] | select(.id == $id) | .base' "$manifest")
+  runtime_user=$(jq -r '.defaults.runtime_user' "$manifest")
+  workspace=$(jq -r '.defaults.workspace' "$manifest")
+  node_major=$(jq -r --arg base "$base" '.base_images[$base].node_major // ""' "$manifest")
+  alpine_major_minor=$(jq -r --arg base "$base" '.base_images[$base].alpine_major_minor // ""' "$manifest")
+  image="agentkernel-smoke/${agent_id}:${version}"
+  context="$repo_root/examples/agents/$agent_id"
+
+  if [[ "$build" == true ]]; then
+    docker build --pull --tag "$image" "$context"
+  fi
+
+  docker run --rm --entrypoint /bin/sh "$image" -lc '
+    test "$(id -un)" = "$1"
+    test "$PWD" = "$2"
+    test -w "$2"
+    command -v "$3" >/dev/null
+    test "$(node -p "process.versions.node.split(\".\")[0]")" = "$4"
+    if [ -n "$5" ]; then
+      test "$(cut -d. -f1,2 /etc/alpine-release)" = "$5"
+    fi
+    probe="$2/.agentkernel-smoke-write"
+    : > "$probe"
+    rm "$probe"
+  ' _ "$runtime_user" "$workspace" "$executable" "$node_major" "$alpine_major_minor"
+
+  set +e
+  smoke_output=$(docker run --rm "$image" "$executable" "$smoke_arg" 2>&1)
+  smoke_exit=$?
+  set -e
+  if [[ "$smoke_exit" -ne "$expected_exit" ]]; then
+    echo "$agent_id smoke exited $smoke_exit; expected $expected_exit" >&2
+    echo "$smoke_output" >&2
+    exit 1
+  fi
+  if [[ "$smoke_output" != *"$expected_output"* ]]; then
+    echo "$agent_id smoke output did not contain expected text: $expected_output" >&2
+    echo "$smoke_output" >&2
+    exit 1
+  fi
+  echo "$agent_id $version: ok"
+done <<< "$agent_ids"

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -165,7 +165,7 @@ impl Agent for ClaudeAgent {
     }
 
     fn install_instructions(&self) -> &'static str {
-        "Install Claude Code: npm install -g @anthropic-ai/claude-code"
+        "Install Claude Code: npm install -g @anthropic-ai/claude-code@2.1.239"
     }
 }
 
@@ -208,7 +208,7 @@ impl Agent for GeminiAgent {
     }
 
     fn install_instructions(&self) -> &'static str {
-        "Install Gemini CLI: pip install google-generativeai"
+        "Install Gemini CLI: npm install -g @google/gemini-cli@0.56.0"
     }
 }
 
@@ -251,7 +251,7 @@ impl Agent for CodexAgent {
     }
 
     fn install_instructions(&self) -> &'static str {
-        "Install Codex CLI: npm install -g @openai/codex"
+        "Install Codex CLI: npm install -g @openai/codex@0.149.0"
     }
 }
 
@@ -295,7 +295,7 @@ impl Agent for OpenCodeAgent {
     }
 
     fn install_instructions(&self) -> &'static str {
-        "Install OpenCode: cargo install opencode"
+        "Install OpenCode: npm install -g opencode-ai@1.18.21"
     }
 }
 
@@ -338,7 +338,7 @@ impl Agent for AmpAgent {
     }
 
     fn install_instructions(&self) -> &'static str {
-        "Install Amp: npm install -g @sourcegraph/amp"
+        "Install Amp: npm install -g --allow-scripts=@ampcode/cli @ampcode/cli@0.0.1787342526-gc11bfb"
     }
 }
 
@@ -382,7 +382,7 @@ impl Agent for PiAgent {
     }
 
     fn install_instructions(&self) -> &'static str {
-        "Install Pi: npm install -g @mariozechner/pi-coding-agent"
+        "Install Pi: npm install -g @earendil-works/pi-coding-agent@0.84.2"
     }
 }
 

--- a/src/opencode.rs
+++ b/src/opencode.rs
@@ -418,7 +418,10 @@ mod tests {
         let cfg = resolved.unwrap().parse();
         assert!(cfg.is_ok(), "template should parse");
         let cfg = cfg.unwrap();
-        assert_eq!(cfg.sandbox.base_image, Some("node:22-alpine".to_string()));
+        assert_eq!(
+            cfg.sandbox.base_image,
+            Some("node:24-alpine3.24".to_string())
+        );
         assert!(cfg.sandbox.init_script.is_some());
     }
 }

--- a/src/vmm.rs
+++ b/src/vmm.rs
@@ -2003,13 +2003,15 @@ impl VmManager {
         // Auto-install agent CLI if specified in sandbox state
         if let Some(ref agent) = state.agent {
             let install_cmd = match agent.as_str() {
-                "claude" => Some("npm install -g @anthropic-ai/claude-code"),
-                "gemini" => Some("npm install -g @google/gemini-cli"),
-                "codex" => Some("npm install -g @openai/codex"),
-                "opencode" => Some("npm install -g opencode"),
-                "amp" => Some("npm install -g @sourcegraph/amp"),
-                "pi" => Some("npm install -g @mariozechner/pi-coding-agent"),
-                "copilot" => Some("npm install -g @githubnext/github-copilot-cli"),
+                "claude" => Some("npm install -g @anthropic-ai/claude-code@2.1.239"),
+                "gemini" => Some("npm install -g @google/gemini-cli@0.56.0"),
+                "codex" => Some("npm install -g @openai/codex@0.149.0"),
+                "opencode" => Some("npm install -g opencode-ai@1.18.21"),
+                "amp" => Some(
+                    "npm install -g --allow-scripts=@ampcode/cli @ampcode/cli@0.0.1787342526-gc11bfb",
+                ),
+                "pi" => Some("npm install -g @earendil-works/pi-coding-agent@0.84.2"),
+                "copilot" => Some("npm install -g @github/copilot@1.0.80"),
                 _ => None,
             };
             if let Some(cmd) = install_cmd {

--- a/templates/amp-sandbox.toml
+++ b/templates/amp-sandbox.toml
@@ -3,10 +3,10 @@
 
 [sandbox]
 name = "amp-sandbox"
-base_image = "node:22-alpine"
+base_image = "node:24-bookworm-slim"
 init_script = """
 set -e
-npm install -g @sourcegraph/amp
+npm install -g --allow-scripts=@ampcode/cli @ampcode/cli@0.0.1787342526-gc11bfb
 """
 
 [agent]
@@ -27,7 +27,7 @@ profile = "moderate"
 allow = ["api.anthropic.com", "sourcegraph.com"]
 
 [template]
-description = "Amp (Sourcegraph) agent sandbox"
+description = "Amp agent sandbox"
 category = "Agent Sandboxes"
 help_text = """
 How to use: Start the sandbox and run your workflow inside /workspace.

--- a/templates/claude-sandbox.toml
+++ b/templates/claude-sandbox.toml
@@ -3,10 +3,10 @@
 
 [sandbox]
 name = "claude-sandbox"
-base_image = "node:22-alpine"
+base_image = "node:24-alpine3.24"
 init_script = """
 set -e
-npm install -g @anthropic-ai/claude-code
+npm install -g @anthropic-ai/claude-code@2.1.239
 """
 
 [agent]

--- a/templates/codex-sandbox.toml
+++ b/templates/codex-sandbox.toml
@@ -3,10 +3,10 @@
 
 [sandbox]
 name = "codex-sandbox"
-base_image = "node:22-alpine"
+base_image = "node:24-alpine3.24"
 init_script = """
 set -e
-npm install -g @openai/codex
+npm install -g @openai/codex@0.149.0
 """
 
 [agent]

--- a/templates/copilot-sandbox.toml
+++ b/templates/copilot-sandbox.toml
@@ -3,7 +3,7 @@
 
 [sandbox]
 name = "copilot-sandbox"
-base_image = "node:22-alpine"
+base_image = "node:24-bookworm-slim"
 
 [agent]
 preferred = "copilot"
@@ -28,6 +28,6 @@ category = "Agent Sandboxes"
 help_text = """
 How to use: Start the sandbox and run your workflow inside /workspace.
 Example command: ls -la /workspace
-Binaries available: node, npm, npx
+Binaries available: node, npm, npx, copilot
 Services and ports: No long-running service is configured by default; only explicitly mapped ports are exposed.
 """

--- a/templates/gemini-sandbox.toml
+++ b/templates/gemini-sandbox.toml
@@ -3,10 +3,10 @@
 
 [sandbox]
 name = "gemini-sandbox"
-base_image = "node:22-alpine"
+base_image = "node:24-alpine3.24"
 init_script = """
 set -e
-npm install -g @google/gemini-cli
+npm install -g @google/gemini-cli@0.56.0
 """
 
 [agent]

--- a/templates/opencode-sandbox.toml
+++ b/templates/opencode-sandbox.toml
@@ -3,12 +3,11 @@
 
 [sandbox]
 name = "opencode-sandbox"
-base_image = "node:22-alpine"
+base_image = "node:24-alpine3.24"
 init_script = """
 set -e
 apk add --no-cache git bash curl python3 ripgrep fd jq
-curl -fsSL https://opencode.ai/install | bash
-export PATH="$HOME/.opencode/bin:$PATH"
+npm install -g opencode-ai@1.18.21
 """
 
 [agent]

--- a/templates/pi-sandbox.toml
+++ b/templates/pi-sandbox.toml
@@ -3,10 +3,10 @@
 
 [sandbox]
 name = "pi-sandbox"
-base_image = "node:22-alpine"
+base_image = "node:24-alpine3.24"
 init_script = """
 set -e
-npm install -g @mariozechner/pi-coding-agent
+npm install -g @earendil-works/pi-coding-agent@0.84.2
 """
 
 [agent]

--- a/templates/symphony-sandbox.toml
+++ b/templates/symphony-sandbox.toml
@@ -8,14 +8,17 @@ base_image = "elixir:1.19-otp-28-slim"
 init_script = """
 set -e
 apt-get update && apt-get install -y --no-install-recommends git curl bash ca-certificates gnupg && rm -rf /var/lib/apt/lists/*
-curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
+curl -fsSL https://deb.nodesource.com/setup_24.x | bash -
 apt-get install -y --no-install-recommends nodejs && rm -rf /var/lib/apt/lists/*
-npm install -g @openai/codex
-git clone --depth 1 https://github.com/openai/symphony.git /opt/symphony
+npm install -g @openai/codex@0.149.0
+git init /opt/symphony
+git -C /opt/symphony remote add origin https://github.com/openai/symphony.git
+git -C /opt/symphony fetch --depth 1 origin 8001b52e3062495a16e520e4ceaf8f9de868c4d0
+git -C /opt/symphony checkout --detach FETCH_HEAD
 cd /opt/symphony/elixir
 mix local.hex --force && mix local.rebar --force
-mix deps.get
-mix compile
+MIX_ENV=prod mix setup
+MIX_ENV=prod mix build
 """
 
 [resources]


### PR DESCRIPTION
## Summary
- move bundled agent images and recommended templates to maintained Node 24 / Alpine 3.24 bases, using Debian glibc images where current Amp and Copilot native packages require them
- pin tested current CLI versions for Codex, Claude, Gemini, Copilot, OpenCode, Amp, and Pi, plus immutable upstream commits for Hermes and Symphony
- replace discontinued Copilot, Amp, and Pi npm packages and fix OpenCode install-user/PATH behavior
- add a machine-readable tested-version manifest and build/smoke automation for executable discovery, version/help output, runtime user, Node/Alpine versions, and writable workspace
- align bundled CLI/desktop install metadata and new-sandbox executable/base selection without changing persisted user-selected images
- migrate `pi-agentkernel` to the maintained Pi peer and its required typed tool-result details

## Integrated base
This branch is rebased directly onto the latest `codex/apple-container-1-2-modernization` after the final core dependency graph, Vite 8, TypeScript 7, Tailwind 4, Tauri, and Alpine 3.24 default changes merged. The final diff contains only the intended agent image, catalog/install metadata, documentation, templates, smoke automation, and Pi integration changes; it does not modify the app lockfile or core dependency graph.

## Validation
- root Rust 1.89 `cargo fmt --all -- --check`
- root Rust 1.89 locked all-targets check and CI-equivalent strict Clippy
- focused agent catalog, template, OpenCode, and Alpine default tests: 17 passed
- desktop `npm ci && npm run build` (Vite 8.2.2, TypeScript 7.0.2, Tailwind 4.3.3)
- Tauri Rust 1.89 format, locked all-targets check, strict Clippy, and tests
- `pi-agentkernel` strict TypeScript 7 typecheck against `@earendil-works/pi-coding-agent@0.84.2`
- `npm pack --dry-run` package contents smoke
- JSON manifest, Dockerfile/base/version mapping, shell syntax, and diff whitespace checks
- all nine Dockerfiles, the tested-version manifest, and smoke script are byte-identical to the previously built branch versions
- all nine prior local image tags/digests remain present; `scripts/smoke-agent-images.sh --no-build` passed Codex, Claude, Gemini, Copilot, OpenCode, Amp, Pi, Hermes, and Symphony

## Notes
- Image rebuilds were not repeated after rebase because the image inputs are byte-identical and all nine prior digests passed the complete offline smoke suite.
- Live-auth agent sessions are intentionally not run; the smoke suite is credential-free.
- Symphony 0.0.2 at the pinned current upstream commit builds and smokes successfully, but Hex reports advisories in Symphony upstream's locked dependency graph. This PR does not rewrite an upstream application lockfile.
- CLI pins are necessarily duplicated across the tested manifest, Dockerfiles, bundled templates, and core/app install catalogs. A follow-up should centralize generated catalog metadata; this PR does not add plugin-management UX.
- No agent was deferred.

Tracks `agentkernel-zvvh.4`.
