### PR TITLE
Modernize guest-agent Rust dependencies

### DIFF
--- a/guest-agent/Cargo.lock
+++ b/guest-agent/Cargo.lock
@@ -9,7 +9,7 @@ dependencies = [
  "anyhow",
  "base64",
  "libc",
- "nix 0.29.0",
+ "nix",
  "serde",
  "serde_json",
  "tokio",
@@ -19,39 +19,39 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base64"
-version = "0.22.1"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cfg-if"
@@ -61,9 +61,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "errno"
@@ -72,14 +72,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -92,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -102,15 +102,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -119,38 +119,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -160,49 +160,48 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasip2",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memoffset"
@@ -215,32 +214,20 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
 name = "nix"
-version = "0.29.0"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
-dependencies = [
- "bitflags",
- "cfg-if",
- "cfg_aliases",
- "libc",
-]
-
-[[package]]
-name = "nix"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -251,57 +238,51 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.105"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.43"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -309,29 +290,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -352,25 +333,36 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -379,9 +371,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -390,25 +382,25 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "tokio-vsock"
-version = "0.6.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad311033c354453d61b537cc239d8d7cc8e3d59c9eda2e8611a8b26e71f0e945"
+checksum = "8b319ef9394889dab2e1b4f0085b45ba11d0c79dc9d1a9d1afc057d009d0f1c7"
 dependencies = [
  "bytes",
  "futures",
@@ -419,15 +411,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "uuid"
-version = "1.19.0"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
+checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
 dependencies = [
  "getrandom",
  "js-sys",
@@ -436,12 +428,12 @@ dependencies = [
 
 [[package]]
 name = "vsock"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2da6e4ac76cd19635dce0f98985378bb62f8044ee2ff80abd2a7334b920ed63"
+checksum = "6ba782755fc073877e567c2253c0be48e4aa9a254c232d36d3985dfae0bd5205"
 dependencies = [
  "libc",
- "nix 0.30.1",
+ "nix",
 ]
 
 [[package]]
@@ -451,19 +443,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -474,9 +457,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -484,22 +467,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
@@ -512,15 +495,6 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -529,78 +503,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-
-[[package]]
 name = "zmij"
-version = "1.0.15"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f63c051f4fe3c1509da62131a678643c5b6fbdc9273b2b79d4378ebda003d2"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/guest-agent/Cargo.toml
+++ b/guest-agent/Cargo.toml
@@ -2,6 +2,7 @@
 name = "agentkernel-guest"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.89"
 description = "Guest agent for agentkernel microVMs"
 authors = ["Paul Thrasher <thrashr888@gmail.com>"]
 license = "MIT"
@@ -12,13 +13,13 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0"
-base64 = "0.22"
+base64 = "0.23"
 libc = "0.2"
-nix = { version = "0.29", features = ["fs", "process", "signal", "term"] }
+nix = { version = "0.31", features = ["fs", "process", "signal", "term"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.0", features = ["rt", "io-util", "sync", "process", "time", "macros", "fs", "signal"] }
-tokio-vsock = "0.6"
+tokio-vsock = "0.7"
 uuid = { version = "1.0", features = ["v4"] }
 
 [profile.release]

--- a/guest-agent/README.md
+++ b/guest-agent/README.md
@@ -4,6 +4,8 @@ Lightweight agent that runs inside microVMs to handle commands from the host.
 
 ## Building
 
+Rust 1.89 or newer is required.
+
 ### Native (for testing)
 
 ```bash
@@ -34,12 +36,12 @@ The resulting binary will be in:
 
 ```bash
 # Build for x86_64
-docker run --rm -v "$PWD":/app -w /app rust:alpine \
-  sh -c "rustup target add x86_64-unknown-linux-musl && cargo build --release --target x86_64-unknown-linux-musl"
+docker run --rm --platform linux/amd64 -v "$PWD":/app -w /app rust:1.89-alpine3.22 \
+  sh -c "apk add --no-cache musl-dev && cargo build --release --locked --target x86_64-unknown-linux-musl"
 
 # Build for aarch64
-docker run --rm -v "$PWD":/app -w /app rust:alpine \
-  sh -c "rustup target add aarch64-unknown-linux-musl && cargo build --release --target aarch64-unknown-linux-musl"
+docker run --rm --platform linux/arm64 -v "$PWD":/app -w /app rust:1.89-alpine3.22 \
+  sh -c "apk add --no-cache musl-dev && cargo build --release --locked --target aarch64-unknown-linux-musl"
 ```
 
 ## Protocol

--- a/guest-agent/src/main.rs
+++ b/guest-agent/src/main.rs
@@ -292,7 +292,9 @@ async fn handle_request(
                     eprintln!("Shell session started: {}", session_id);
                     AgentResponse::shell_started(&request.id, session_id)
                 }
-                Err(e) => AgentResponse::error(&request.id, &format!("Failed to start shell: {}", e)),
+                Err(e) => {
+                    AgentResponse::error(&request.id, &format!("Failed to start shell: {}", e))
+                }
             }
         }
 
@@ -314,7 +316,9 @@ async fn handle_request(
 
             match session_manager.write_to_session(&session_id, &input).await {
                 Ok(()) => AgentResponse::success(&request.id),
-                Err(e) => AgentResponse::error(&request.id, &format!("Failed to write to session: {}", e)),
+                Err(e) => {
+                    AgentResponse::error(&request.id, &format!("Failed to write to session: {}", e))
+                }
             }
         }
 
@@ -326,9 +330,14 @@ async fn handle_request(
             let rows = request.rows.unwrap_or(24);
             let cols = request.cols.unwrap_or(80);
 
-            match session_manager.resize_session(&session_id, rows, cols).await {
+            match session_manager
+                .resize_session(&session_id, rows, cols)
+                .await
+            {
                 Ok(()) => AgentResponse::success(&request.id),
-                Err(e) => AgentResponse::error(&request.id, &format!("Failed to resize session: {}", e)),
+                Err(e) => {
+                    AgentResponse::error(&request.id, &format!("Failed to resize session: {}", e))
+                }
             }
         }
 
@@ -340,10 +349,15 @@ async fn handle_request(
 
             match session_manager.close_session(&session_id).await {
                 Ok(exit_code) => {
-                    eprintln!("Shell session closed: {} (exit: {:?})", session_id, exit_code);
+                    eprintln!(
+                        "Shell session closed: {} (exit: {:?})",
+                        session_id, exit_code
+                    );
                     AgentResponse::shell_exited(&request.id, &session_id, exit_code.unwrap_or(-1))
                 }
-                Err(e) => AgentResponse::error(&request.id, &format!("Failed to close session: {}", e)),
+                Err(e) => {
+                    AgentResponse::error(&request.id, &format!("Failed to close session: {}", e))
+                }
             }
         }
 
@@ -551,7 +565,7 @@ async fn main() -> Result<()> {
     let session_manager = Arc::new(SessionManager::new());
 
     let addr = VsockAddr::new(VMADDR_CID_ANY, AGENT_PORT);
-    let mut listener = VsockListener::bind(addr).context("Failed to bind vsock listener")?;
+    let listener = VsockListener::bind(addr).context("Failed to bind vsock listener")?;
 
     eprintln!("Agent ready (with PTY support)");
 
@@ -570,5 +584,39 @@ async fn main() -> Result<()> {
                 eprintln!("Accept error: {}", e);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod protocol_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn shell_messages_keep_the_existing_wire_shape() {
+        let request: AgentRequest = serde_json::from_value(json!({
+            "id": "request-1",
+            "type": "shell_resize",
+            "session_id": "session-1",
+            "rows": 40,
+            "cols": 120
+        }))
+        .expect("shell resize request should deserialize");
+        assert!(matches!(request.request_type, RequestType::ShellResize));
+        assert_eq!(request.session_id.as_deref(), Some("session-1"));
+        assert_eq!(request.rows, Some(40));
+        assert_eq!(request.cols, Some(120));
+
+        let response =
+            AgentResponse::shell_output("request-1", "session-1", "aGVsbG8=".to_string());
+        assert_eq!(
+            serde_json::to_value(response).expect("shell output should serialize"),
+            json!({
+                "id": "request-1",
+                "session_id": "session-1",
+                "output_base64": "aGVsbG8=",
+                "shell_event": "output"
+            })
+        );
     }
 }

--- a/guest-agent/src/pty.rs
+++ b/guest-agent/src/pty.rs
@@ -4,14 +4,14 @@
 //! inside the guest VM. Uses `openpty()` for PTY creation and `fork()`/`exec()`
 //! for process spawning.
 
-use anyhow::{Context, Result, bail};
+use anyhow::{bail, Context, Result};
 use nix::pty::{openpty, OpenptyResult};
-use nix::sys::signal::{Signal, kill};
-use nix::sys::wait::{WaitStatus, waitpid, WaitPidFlag};
-use nix::unistd::{ForkResult, Pid, close, dup2, fork, setsid};
+use nix::sys::signal::{kill, Signal};
+use nix::sys::wait::{waitpid, WaitPidFlag, WaitStatus};
+use nix::unistd::{dup2_stderr, dup2_stdin, dup2_stdout, fork, setsid, ForkResult, Pid};
 use std::collections::HashMap;
 use std::ffi::CString;
-use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
+use std::os::unix::io::{AsRawFd, RawFd};
 use std::sync::Arc;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::Mutex;
@@ -47,8 +47,7 @@ impl PtySession {
         env: Option<&HashMap<String, String>>,
     ) -> Result<Self> {
         // Open a new PTY pair
-        let OpenptyResult { master, slave } = openpty(None, None)
-            .context("Failed to open PTY")?;
+        let OpenptyResult { master, slave } = openpty(None, None).context("Failed to open PTY")?;
 
         // Set initial window size
         let winsize = libc::winsize {
@@ -69,7 +68,7 @@ impl PtySession {
                 // Child process: set up PTY and exec
 
                 // Close the master fd in child
-                let _ = close(master.as_raw_fd());
+                drop(master);
 
                 // Create a new session (become session leader)
                 setsid().ok();
@@ -82,13 +81,17 @@ impl PtySession {
 
                 // Redirect stdin/stdout/stderr to the slave PTY
                 let slave_fd = slave.as_raw_fd();
-                dup2(slave_fd, 0).expect("dup2 stdin failed");
-                dup2(slave_fd, 1).expect("dup2 stdout failed");
-                dup2(slave_fd, 2).expect("dup2 stderr failed");
+                dup2_stdin(&slave).expect("dup2 stdin failed");
+                dup2_stdout(&slave).expect("dup2 stdout failed");
+                dup2_stderr(&slave).expect("dup2 stderr failed");
 
                 // Close the original slave fd if it's not one of stdin/stdout/stderr
                 if slave_fd > 2 {
-                    let _ = close(slave_fd);
+                    drop(slave);
+                } else {
+                    // The descriptor is one of the standard streams and must
+                    // remain open across exec.
+                    std::mem::forget(slave);
                 }
 
                 // Prepare command and arguments
@@ -116,7 +119,7 @@ impl PtySession {
                     ("HOME", "/root"),
                     ("PATH", "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"),
                 ] {
-                    if env.map_or(true, |e| !e.contains_key(key)) {
+                    if env.is_none_or(|e| !e.contains_key(key)) {
                         let env_str = format!("{}={}", key, value);
                         if let Ok(c_env) = CString::new(env_str) {
                             unsafe {
@@ -127,18 +130,18 @@ impl PtySession {
                 }
 
                 // Exec the command
-                nix::unistd::execvp(&cmd, &c_args).expect("execvp failed");
-                unreachable!()
+                match nix::unistd::execvp(&cmd, &c_args) {
+                    Ok(infallible) => match infallible {},
+                    Err(error) => panic!("execvp failed: {error}"),
+                }
             }
             ForkResult::Parent { child } => {
                 // Parent process: close slave, return session
-                let _ = close(slave.as_raw_fd());
+                drop(slave);
 
                 // Create async file wrapper for the master fd
-                let master_fd = master.as_raw_fd();
-                let master_file = unsafe {
-                    std::fs::File::from_raw_fd(master_fd)
-                };
+                let master_file = std::fs::File::from(master);
+                let master_fd = master_file.as_raw_fd();
                 let master_file = tokio::fs::File::from_std(master_file);
 
                 Ok(Self {
@@ -159,11 +162,12 @@ impl PtySession {
             ws_xpixel: 0,
             ws_ypixel: 0,
         };
-        let result = unsafe {
-            libc::ioctl(self.master_fd, libc::TIOCSWINSZ, &winsize)
-        };
+        let result = unsafe { libc::ioctl(self.master_fd, libc::TIOCSWINSZ, &winsize) };
         if result < 0 {
-            bail!("Failed to resize terminal: {}", std::io::Error::last_os_error());
+            bail!(
+                "Failed to resize terminal: {}",
+                std::io::Error::last_os_error()
+            );
         }
         Ok(())
     }
@@ -171,7 +175,9 @@ impl PtySession {
     /// Write data to the PTY (input to the process)
     pub async fn write(&mut self, data: &[u8]) -> Result<()> {
         if let Some(ref mut file) = self.master_file {
-            file.write_all(data).await.context("Failed to write to PTY")?;
+            file.write_all(data)
+                .await
+                .context("Failed to write to PTY")?;
             file.flush().await.context("Failed to flush PTY")?;
         }
         Ok(())
@@ -355,10 +361,69 @@ impl Default for SessionManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
 
     #[test]
     fn test_session_manager_creation() {
         let manager = SessionManager::new();
         assert!(manager.sessions.try_lock().is_ok());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_pty_session_round_trip() {
+        let manager = SessionManager::new();
+        let args = vec![
+            "-c".to_string(),
+            "printf 'ready\\n'; IFS= read -r line; printf 'echo:%s\\n' \"$line\"".to_string(),
+        ];
+        let id = manager
+            .create_session("/bin/sh", &args, 24, 80, None)
+            .await
+            .expect("PTY session should start");
+
+        assert!(manager.has_session(&id).await);
+        assert!(manager.list_sessions().await.contains(&id));
+        manager
+            .resize_session(&id, 40, 120)
+            .await
+            .expect("PTY resize should succeed");
+        manager
+            .write_to_session(&id, b"hello\n")
+            .await
+            .expect("PTY input should succeed");
+
+        let mut output = Vec::new();
+        let read_output = async {
+            let mut buffer = [0_u8; 256];
+            loop {
+                let count = manager
+                    .read_from_session(&id, &mut buffer)
+                    .await
+                    .expect("PTY output should be readable");
+                output.extend_from_slice(&buffer[..count]);
+                if count == 0
+                    || output
+                        .windows(b"echo:hello".len())
+                        .any(|w| w == b"echo:hello")
+                {
+                    break;
+                }
+            }
+        };
+        tokio::time::timeout(Duration::from_secs(5), read_output)
+            .await
+            .expect("PTY round trip timed out");
+
+        let output = String::from_utf8_lossy(&output);
+        assert!(output.contains("ready"), "missing ready marker: {output:?}");
+        assert!(
+            output.contains("echo:hello"),
+            "missing echoed input: {output:?}"
+        );
+        manager
+            .close_session(&id)
+            .await
+            .expect("PTY session should close");
+        assert!(!manager.has_session(&id).await);
     }
 }

--- a/src/embedded/guest_agent_cargo.toml
+++ b/src/embedded/guest_agent_cargo.toml
@@ -2,6 +2,7 @@
 name = "agentkernel-guest"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.89"
 description = "Guest agent for agentkernel microVMs"
 authors = ["Paul Thrasher <thrashr888@gmail.com>"]
 license = "MIT"
@@ -12,13 +13,13 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0"
-base64 = "0.22"
+base64 = "0.23"
 libc = "0.2"
-nix = { version = "0.29", features = ["fs", "process", "signal", "term"] }
+nix = { version = "0.31", features = ["fs", "process", "signal", "term"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.0", features = ["rt", "io-util", "sync", "process", "time", "macros", "fs", "signal"] }
-tokio-vsock = "0.6"
+tokio-vsock = "0.7"
 uuid = { version = "1.0", features = ["v4"] }
 
 [profile.release]

--- a/src/embedded/guest_agent_main.rs
+++ b/src/embedded/guest_agent_main.rs
@@ -292,7 +292,9 @@ async fn handle_request(
                     eprintln!("Shell session started: {}", session_id);
                     AgentResponse::shell_started(&request.id, session_id)
                 }
-                Err(e) => AgentResponse::error(&request.id, &format!("Failed to start shell: {}", e)),
+                Err(e) => {
+                    AgentResponse::error(&request.id, &format!("Failed to start shell: {}", e))
+                }
             }
         }
 
@@ -314,7 +316,9 @@ async fn handle_request(
 
             match session_manager.write_to_session(&session_id, &input).await {
                 Ok(()) => AgentResponse::success(&request.id),
-                Err(e) => AgentResponse::error(&request.id, &format!("Failed to write to session: {}", e)),
+                Err(e) => {
+                    AgentResponse::error(&request.id, &format!("Failed to write to session: {}", e))
+                }
             }
         }
 
@@ -326,9 +330,14 @@ async fn handle_request(
             let rows = request.rows.unwrap_or(24);
             let cols = request.cols.unwrap_or(80);
 
-            match session_manager.resize_session(&session_id, rows, cols).await {
+            match session_manager
+                .resize_session(&session_id, rows, cols)
+                .await
+            {
                 Ok(()) => AgentResponse::success(&request.id),
-                Err(e) => AgentResponse::error(&request.id, &format!("Failed to resize session: {}", e)),
+                Err(e) => {
+                    AgentResponse::error(&request.id, &format!("Failed to resize session: {}", e))
+                }
             }
         }
 
@@ -340,10 +349,15 @@ async fn handle_request(
 
             match session_manager.close_session(&session_id).await {
                 Ok(exit_code) => {
-                    eprintln!("Shell session closed: {} (exit: {:?})", session_id, exit_code);
+                    eprintln!(
+                        "Shell session closed: {} (exit: {:?})",
+                        session_id, exit_code
+                    );
                     AgentResponse::shell_exited(&request.id, &session_id, exit_code.unwrap_or(-1))
                 }
-                Err(e) => AgentResponse::error(&request.id, &format!("Failed to close session: {}", e)),
+                Err(e) => {
+                    AgentResponse::error(&request.id, &format!("Failed to close session: {}", e))
+                }
             }
         }
 
@@ -551,7 +565,7 @@ async fn main() -> Result<()> {
     let session_manager = Arc::new(SessionManager::new());
 
     let addr = VsockAddr::new(VMADDR_CID_ANY, AGENT_PORT);
-    let mut listener = VsockListener::bind(addr).context("Failed to bind vsock listener")?;
+    let listener = VsockListener::bind(addr).context("Failed to bind vsock listener")?;
 
     eprintln!("Agent ready (with PTY support)");
 
@@ -570,5 +584,39 @@ async fn main() -> Result<()> {
                 eprintln!("Accept error: {}", e);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod protocol_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn shell_messages_keep_the_existing_wire_shape() {
+        let request: AgentRequest = serde_json::from_value(json!({
+            "id": "request-1",
+            "type": "shell_resize",
+            "session_id": "session-1",
+            "rows": 40,
+            "cols": 120
+        }))
+        .expect("shell resize request should deserialize");
+        assert!(matches!(request.request_type, RequestType::ShellResize));
+        assert_eq!(request.session_id.as_deref(), Some("session-1"));
+        assert_eq!(request.rows, Some(40));
+        assert_eq!(request.cols, Some(120));
+
+        let response =
+            AgentResponse::shell_output("request-1", "session-1", "aGVsbG8=".to_string());
+        assert_eq!(
+            serde_json::to_value(response).expect("shell output should serialize"),
+            json!({
+                "id": "request-1",
+                "session_id": "session-1",
+                "output_base64": "aGVsbG8=",
+                "shell_event": "output"
+            })
+        );
     }
 }

--- a/src/embedded/guest_agent_pty.rs
+++ b/src/embedded/guest_agent_pty.rs
@@ -4,14 +4,14 @@
 //! inside the guest VM. Uses `openpty()` for PTY creation and `fork()`/`exec()`
 //! for process spawning.
 
-use anyhow::{Context, Result, bail};
+use anyhow::{bail, Context, Result};
 use nix::pty::{openpty, OpenptyResult};
-use nix::sys::signal::{Signal, kill};
-use nix::sys::wait::{WaitStatus, waitpid, WaitPidFlag};
-use nix::unistd::{ForkResult, Pid, close, dup2, fork, setsid};
+use nix::sys::signal::{kill, Signal};
+use nix::sys::wait::{waitpid, WaitPidFlag, WaitStatus};
+use nix::unistd::{dup2_stderr, dup2_stdin, dup2_stdout, fork, setsid, ForkResult, Pid};
 use std::collections::HashMap;
 use std::ffi::CString;
-use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
+use std::os::unix::io::{AsRawFd, RawFd};
 use std::sync::Arc;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::Mutex;
@@ -47,8 +47,7 @@ impl PtySession {
         env: Option<&HashMap<String, String>>,
     ) -> Result<Self> {
         // Open a new PTY pair
-        let OpenptyResult { master, slave } = openpty(None, None)
-            .context("Failed to open PTY")?;
+        let OpenptyResult { master, slave } = openpty(None, None).context("Failed to open PTY")?;
 
         // Set initial window size
         let winsize = libc::winsize {
@@ -69,7 +68,7 @@ impl PtySession {
                 // Child process: set up PTY and exec
 
                 // Close the master fd in child
-                let _ = close(master.as_raw_fd());
+                drop(master);
 
                 // Create a new session (become session leader)
                 setsid().ok();
@@ -82,13 +81,17 @@ impl PtySession {
 
                 // Redirect stdin/stdout/stderr to the slave PTY
                 let slave_fd = slave.as_raw_fd();
-                dup2(slave_fd, 0).expect("dup2 stdin failed");
-                dup2(slave_fd, 1).expect("dup2 stdout failed");
-                dup2(slave_fd, 2).expect("dup2 stderr failed");
+                dup2_stdin(&slave).expect("dup2 stdin failed");
+                dup2_stdout(&slave).expect("dup2 stdout failed");
+                dup2_stderr(&slave).expect("dup2 stderr failed");
 
                 // Close the original slave fd if it's not one of stdin/stdout/stderr
                 if slave_fd > 2 {
-                    let _ = close(slave_fd);
+                    drop(slave);
+                } else {
+                    // The descriptor is one of the standard streams and must
+                    // remain open across exec.
+                    std::mem::forget(slave);
                 }
 
                 // Prepare command and arguments
@@ -116,7 +119,7 @@ impl PtySession {
                     ("HOME", "/root"),
                     ("PATH", "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"),
                 ] {
-                    if env.map_or(true, |e| !e.contains_key(key)) {
+                    if env.is_none_or(|e| !e.contains_key(key)) {
                         let env_str = format!("{}={}", key, value);
                         if let Ok(c_env) = CString::new(env_str) {
                             unsafe {
@@ -127,18 +130,18 @@ impl PtySession {
                 }
 
                 // Exec the command
-                nix::unistd::execvp(&cmd, &c_args).expect("execvp failed");
-                unreachable!()
+                match nix::unistd::execvp(&cmd, &c_args) {
+                    Ok(infallible) => match infallible {},
+                    Err(error) => panic!("execvp failed: {error}"),
+                }
             }
             ForkResult::Parent { child } => {
                 // Parent process: close slave, return session
-                let _ = close(slave.as_raw_fd());
+                drop(slave);
 
                 // Create async file wrapper for the master fd
-                let master_fd = master.as_raw_fd();
-                let master_file = unsafe {
-                    std::fs::File::from_raw_fd(master_fd)
-                };
+                let master_file = std::fs::File::from(master);
+                let master_fd = master_file.as_raw_fd();
                 let master_file = tokio::fs::File::from_std(master_file);
 
                 Ok(Self {
@@ -159,11 +162,12 @@ impl PtySession {
             ws_xpixel: 0,
             ws_ypixel: 0,
         };
-        let result = unsafe {
-            libc::ioctl(self.master_fd, libc::TIOCSWINSZ, &winsize)
-        };
+        let result = unsafe { libc::ioctl(self.master_fd, libc::TIOCSWINSZ, &winsize) };
         if result < 0 {
-            bail!("Failed to resize terminal: {}", std::io::Error::last_os_error());
+            bail!(
+                "Failed to resize terminal: {}",
+                std::io::Error::last_os_error()
+            );
         }
         Ok(())
     }
@@ -171,7 +175,9 @@ impl PtySession {
     /// Write data to the PTY (input to the process)
     pub async fn write(&mut self, data: &[u8]) -> Result<()> {
         if let Some(ref mut file) = self.master_file {
-            file.write_all(data).await.context("Failed to write to PTY")?;
+            file.write_all(data)
+                .await
+                .context("Failed to write to PTY")?;
             file.flush().await.context("Failed to flush PTY")?;
         }
         Ok(())
@@ -355,10 +361,69 @@ impl Default for SessionManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Duration;
 
     #[test]
     fn test_session_manager_creation() {
         let manager = SessionManager::new();
         assert!(manager.sessions.try_lock().is_ok());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn test_pty_session_round_trip() {
+        let manager = SessionManager::new();
+        let args = vec![
+            "-c".to_string(),
+            "printf 'ready\\n'; IFS= read -r line; printf 'echo:%s\\n' \"$line\"".to_string(),
+        ];
+        let id = manager
+            .create_session("/bin/sh", &args, 24, 80, None)
+            .await
+            .expect("PTY session should start");
+
+        assert!(manager.has_session(&id).await);
+        assert!(manager.list_sessions().await.contains(&id));
+        manager
+            .resize_session(&id, 40, 120)
+            .await
+            .expect("PTY resize should succeed");
+        manager
+            .write_to_session(&id, b"hello\n")
+            .await
+            .expect("PTY input should succeed");
+
+        let mut output = Vec::new();
+        let read_output = async {
+            let mut buffer = [0_u8; 256];
+            loop {
+                let count = manager
+                    .read_from_session(&id, &mut buffer)
+                    .await
+                    .expect("PTY output should be readable");
+                output.extend_from_slice(&buffer[..count]);
+                if count == 0
+                    || output
+                        .windows(b"echo:hello".len())
+                        .any(|w| w == b"echo:hello")
+                {
+                    break;
+                }
+            }
+        };
+        tokio::time::timeout(Duration::from_secs(5), read_output)
+            .await
+            .expect("PTY round trip timed out");
+
+        let output = String::from_utf8_lossy(&output);
+        assert!(output.contains("ready"), "missing ready marker: {output:?}");
+        assert!(
+            output.contains("echo:hello"),
+            "missing echoed input: {output:?}"
+        );
+        manager
+            .close_session(&id)
+            .await
+            .expect("PTY session should close");
+        assert!(!manager.has_session(&id).await);
     }
 }


### PR DESCRIPTION
## Summary
- declare Rust 1.89 as the guest-agent MSRV, matching the platform modernization policy
- refresh every compatible guest dependency and migrate base64 0.22 → 0.23, nix 0.29 → 0.31, and tokio-vsock 0.6 → 0.7
- adapt PTY descriptor duplication to nix 0.31's owned-FD APIs and transfer the PTY master into `File` without duplicate ownership
- preserve the JSON/vsock wire contract and terminal behavior with protocol-shape and real PTY spawn/input/resize/output regression tests
- document the exact Rust 1.89 musl container builds, including the required Alpine `musl-dev` package

## Resolved direct versions
- anyhow 1.0.104
- base64 0.23.1
- libc 0.2.189
- nix 0.31.3
- serde 1.0.229
- serde_json 1.0.151
- tokio 1.53.1
- tokio-vsock 0.7.2
- uuid 1.24.1

The refreshed graph drops from 69 to 56 packages and removes duplicate nix 0.29/0.30 copies.

## Validation
- Rust 1.89: `cargo fmt --all -- --check`
- Rust 1.89: `cargo check --locked --all-targets`
- Rust 1.89: `cargo clippy --locked --all-targets` using the matching 1.89 rustc/clippy-driver
- Rust 1.89: `cargo test --locked` — 3 passed
- stable Rust 1.93: all-target check, Clippy, and 3 tests passed
- `cargo outdated --root-deps-only --exit-code 1` — all current
- `cargo audit` — 0 vulnerabilities
- `cargo tree --locked -d` — no duplicate versions
- ARM64 musl release: official `rust:1.89-alpine3.22`, stripped statically linked ELF, 659,608 bytes
- x86_64 musl release: same toolchain under Docker emulation, stripped static PIE, 770,720 bytes
- `git diff --check`

## Constraints and scope
- The macOS host needs Docker multi-platform execution for Linux-musl release proof; x86_64 LTO/linking under emulation took 7m46s.
- Existing guest dead-code warnings remain; no broad cleanup or suppression was added.
- Root, Tauri, SDK, Firecracker, and generated build artifacts are unchanged.
- The commit is unsigned because the local 1Password signing integration is unavailable.

No dependency or target was deferred.