### PR TITLE
Modernize Firecracker and guest kernel defaults

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -19,3 +19,5 @@
 !images/build/**
 !images/kernel/
 !images/kernel/microvm.config
+!docker/
+!docker/entrypoint.sh

--- a/.github/workflows/firecracker-kvm-smoke.yml
+++ b/.github/workflows/firecracker-kvm-smoke.yml
@@ -1,0 +1,41 @@
+name: Firecracker KVM Smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm_safe_runner:
+        description: Run only on the dedicated AgentKernel KVM smoke runner
+        required: true
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  native-kvm-smoke:
+    if: ${{ inputs.confirm_safe_runner }}
+    runs-on: [self-hosted, Linux, X64, agentkernel-kvm-safe]
+    timeout-minutes: 30
+    env:
+      AGENTKERNEL_KVM_SMOKE: "1"
+      FIRECRACKER_BIN: /opt/agentkernel/bin/firecracker
+      AGENTKERNEL_KVM_KERNEL: /opt/agentkernel/images/kernel/vmlinux-6.18.45-agentkernel
+      AGENTKERNEL_KVM_ROOTFS: /opt/agentkernel/images/rootfs/base.ext4
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.89"
+      - name: Verify dedicated KVM runner assets
+        run: |
+          test "$(uname -s)" = Linux
+          test "$(uname -m)" = x86_64
+          test -r /dev/kvm
+          test -w /dev/kvm
+          test -x "$FIRECRACKER_BIN"
+          test -f "$AGENTKERNEL_KVM_KERNEL"
+          test -f "$AGENTKERNEL_KVM_ROOTFS"
+          "$FIRECRACKER_BIN" --version | grep -F 'v1.16.1'
+      - name: Lifecycle, exec, networking, vsock, snapshot, and recovery
+        run: cargo test --locked --test firecracker_kvm_smoke -- --ignored --nocapture

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,9 +36,9 @@ cargo run -- <command>
 # Build kernel (via Docker, works on macOS)
 cd images/build
 docker build -t agentkernel-kernel-builder -f Dockerfile.kernel-builder .
-docker run --rm -v "$(pwd)/../kernel:/kernel" agentkernel-kernel-builder 6.1.70
+docker run --rm -v "$(pwd)/../kernel:/kernel" agentkernel-kernel-builder 6.18.45
 
-# Output: images/kernel/vmlinux-6.1.70-agentkernel (~4MB)
+# Output: images/kernel/vmlinux-6.18.45-agentkernel (~4MB)
 ```
 
 ## Architecture

--- a/docker/Dockerfile.kvm-host
+++ b/docker/Dockerfile.kvm-host
@@ -27,15 +27,21 @@ RUN mkdir -p /opt/agentkernel/bin \
     /var/run/agentkernel
 
 # Download Firecracker
-ARG FIRECRACKER_VERSION=v1.7.0
+ARG FIRECRACKER_VERSION=v1.16.1
 ARG TARGETARCH
 
-RUN ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64" || echo "x86_64") && \
-    curl -fsSL "https://github.com/firecracker-microvm/firecracker/releases/download/${FIRECRACKER_VERSION}/firecracker-${FIRECRACKER_VERSION}-${ARCH}.tgz" \
-    | tar -xz -C /tmp && \
+RUN case "$TARGETARCH" in \
+      ""|amd64) ARCH=x86_64; FIRECRACKER_SHA256=382a02a869e4d6d5cb14c40577f9545e8458021ea8b0b2d3fc10ec14d9c242e6 ;; \
+      arm64) ARCH=aarch64; FIRECRACKER_SHA256=8d0e69f6d6f9a1724551f607f18504052c16c1828ee3d4d7b6e6c73380871e0e ;; \
+      *) echo "Unsupported TARGETARCH: $TARGETARCH" >&2; exit 1 ;; \
+    esac && \
+    ASSET="firecracker-${FIRECRACKER_VERSION}-${ARCH}.tgz" && \
+    curl -fsSL --output "/tmp/${ASSET}" "https://github.com/firecracker-microvm/firecracker/releases/download/${FIRECRACKER_VERSION}/${ASSET}" && \
+    echo "${FIRECRACKER_SHA256}  /tmp/${ASSET}" | sha256sum -c - && \
+    tar -xzf "/tmp/${ASSET}" -C /tmp && \
     mv /tmp/release-${FIRECRACKER_VERSION}-${ARCH}/firecracker-${FIRECRACKER_VERSION}-${ARCH} /opt/agentkernel/bin/firecracker && \
     chmod +x /opt/agentkernel/bin/firecracker && \
-    rm -rf /tmp/release-*
+    rm -rf /tmp/release-* "/tmp/${ASSET}"
 
 # Add firecracker to PATH
 ENV PATH="/opt/agentkernel/bin:${PATH}"

--- a/images/README.md
+++ b/images/README.md
@@ -2,6 +2,17 @@
 
 Pre-built kernel and rootfs images for Firecracker microVMs.
 
+Fresh setup defaults to Firecracker `v1.16.1` and Linux `6.18.45`. Firecracker
+1.16 is the first supported line for the 6.18 host kernel, and 1.16.1 is the
+minimum supported release for the 6.18 guest kernel. The setup command keeps an
+already-installed Firecracker binary and any existing `vmlinux-*` image; an
+explicit kernel version passed to `build-kernel.sh` also remains authoritative.
+
+Release metadata is sourced from the upstream [Firecracker release policy](https://github.com/firecracker-microvm/firecracker/blob/main/docs/RELEASE_POLICY.md),
+[Firecracker kernel policy](https://github.com/firecracker-microvm/firecracker/blob/main/docs/kernel-policy.md),
+and [kernel.org releases](https://www.kernel.org/releases.html). Downloads are
+verified against the upstream SHA-256 values before extraction.
+
 ## Directory Structure
 
 ```
@@ -25,7 +36,11 @@ Requirements:
 
 ```bash
 cd images/build
-./build-kernel.sh 6.1.70
+./build-kernel.sh 6.18.45
+
+# Existing explicit selections remain supported. The checksum is resolved from
+# kernel.org, or can be supplied as a second argument for a custom source.
+./build-kernel.sh 6.18.44
 ```
 
 ### Using Docker (Any Platform)
@@ -33,7 +48,7 @@ cd images/build
 ```bash
 cd images/build
 docker build -t agentkernel-kernel-builder -f Dockerfile.kernel-builder .
-docker run -v $(pwd)/../kernel:/output agentkernel-kernel-builder 6.1.70
+docker run -v $(pwd)/../kernel:/output agentkernel-kernel-builder 6.18.45
 ```
 
 ### Output

--- a/images/build/Dockerfile.kernel-builder
+++ b/images/build/Dockerfile.kernel-builder
@@ -4,7 +4,7 @@
 #   docker build -t agentkernel-kernel-builder -f Dockerfile.kernel-builder .
 #
 # Run:
-#   docker run --rm -v "$(pwd)/../kernel:/kernel" agentkernel-kernel-builder 6.1.70
+#   docker run --rm -v "$(pwd)/../kernel:/kernel" agentkernel-kernel-builder 6.18.45
 
 FROM ubuntu:24.04
 
@@ -32,4 +32,4 @@ RUN mkdir -p /kernel
 ENV BUILD_DIR=/tmp/kernel-build
 
 ENTRYPOINT ["/build/build-kernel.sh"]
-CMD ["6.1.70"]
+CMD ["6.18.45"]

--- a/images/build/build-kernel.sh
+++ b/images/build/build-kernel.sh
@@ -2,11 +2,11 @@
 # Build minimal Linux kernel for Firecracker microVMs
 #
 # Usage: ./build-kernel.sh [version]
-# Example: ./build-kernel.sh 6.1.70
+# Example: ./build-kernel.sh 6.18.45
 #
 # For macOS, use Docker:
 #   docker build -t agentkernel-kernel-builder -f Dockerfile.kernel-builder .
-#   docker run --rm -v "$(pwd)/../kernel:/kernel" agentkernel-kernel-builder 6.1.70
+#   docker run --rm -v "$(pwd)/../kernel:/kernel" agentkernel-kernel-builder 6.18.45
 #
 # Requirements (Linux native):
 #   - gcc, make, flex, bison, libelf-dev, libssl-dev, bc
@@ -16,8 +16,11 @@
 
 set -euo pipefail
 
-# Default kernel version (6.1 LTS)
-KERNEL_VERSION="${1:-6.1.70}"
+# Default kernel version (6.18 LTS, supported by Firecracker 1.16)
+# An explicit first argument remains authoritative for existing build workflows.
+KERNEL_VERSION="${1:-6.18.45}"
+DEFAULT_KERNEL_SHA256="30fa4a56579ca614ac125a12614f7f6466f87ab1278aef7b951dd74156deab33"
+KERNEL_SHA256="${2:-}"
 KERNEL_MAJOR="${KERNEL_VERSION%%.*}"
 
 echo "==> Building kernel $KERNEL_VERSION for Firecracker"
@@ -46,7 +49,34 @@ KERNEL_URL="https://cdn.kernel.org/pub/linux/kernel/v${KERNEL_MAJOR}.x/${KERNEL_
 
 if [[ ! -f "$KERNEL_TARBALL" ]]; then
     echo "==> Downloading kernel source..."
-    curl -LO "$KERNEL_URL"
+    curl -fL --output "$KERNEL_TARBALL" "$KERNEL_URL"
+fi
+
+# Verify the pinned default against kernel.org's signed checksum manifest. For an
+# explicit version, accept an explicit checksum or resolve it from that manifest.
+if [[ -z "$KERNEL_SHA256" ]]; then
+    if [[ "$KERNEL_VERSION" == "6.18.45" ]]; then
+        KERNEL_SHA256="$DEFAULT_KERNEL_SHA256"
+    else
+        KERNEL_SHA256="$(curl -fsSL "https://cdn.kernel.org/pub/linux/kernel/v${KERNEL_MAJOR}.x/sha256sums.asc" \
+            | awk -v file="$KERNEL_TARBALL" '$2 == file { print $1; exit }')"
+    fi
+fi
+
+if [[ -z "$KERNEL_SHA256" ]]; then
+    echo "ERROR: No official checksum found for $KERNEL_TARBALL"
+    echo "Pass the expected SHA-256 as the second argument for a custom source."
+    exit 1
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+    echo "$KERNEL_SHA256  $KERNEL_TARBALL" | sha256sum -c -
+else
+    ACTUAL_SHA256="$(shasum -a 256 "$KERNEL_TARBALL" | awk '{print $1}')"
+    [[ "$ACTUAL_SHA256" == "$KERNEL_SHA256" ]] || {
+        echo "ERROR: SHA-256 mismatch for $KERNEL_TARBALL"
+        exit 1
+    }
 fi
 
 # Extract if not already extracted

--- a/images/kernel/microvm.config
+++ b/images/kernel/microvm.config
@@ -1,6 +1,6 @@
 # Agentkernel Minimal Kernel Config for Firecracker
 # Based on Firecracker's recommended configuration
-# Target: Linux 6.1 LTS or 5.10 LTS
+# Target: Linux 6.18 LTS
 #
 # This config produces a ~4MB vmlinux suitable for microVM boot
 

--- a/src/firecracker_client.rs
+++ b/src/firecracker_client.rs
@@ -66,6 +66,32 @@ pub struct NetworkInterface {
     pub host_dev_name: String,
 }
 
+/// Full snapshot creation parameters.
+#[derive(Debug, Serialize)]
+#[allow(dead_code)]
+pub struct SnapshotCreateParams {
+    pub mem_file_path: String,
+    pub snapshot_path: String,
+    pub snapshot_type: String,
+}
+
+/// Override the host-side UDS when restoring a VM snapshot.
+#[derive(Debug, Serialize)]
+#[allow(dead_code)]
+pub struct VsockOverride {
+    pub uds_path: String,
+}
+
+/// Snapshot restoration parameters supported by Firecracker 1.16.
+#[derive(Debug, Serialize)]
+#[allow(dead_code)]
+pub struct SnapshotLoadParams {
+    pub mem_file_path: String,
+    pub snapshot_path: String,
+    pub resume_vm: bool,
+    pub vsock_override: VsockOverride,
+}
+
 /// Instance info response
 #[derive(Debug, Deserialize)]
 #[allow(dead_code)]
@@ -159,6 +185,18 @@ impl FirecrackerClient {
             action_type: "Resume".to_string(),
         };
         self.put("/actions", &action).await
+    }
+
+    /// Create a full VM snapshot. The VM must be paused first.
+    #[allow(dead_code)]
+    pub async fn create_snapshot(&self, snapshot: &SnapshotCreateParams) -> Result<()> {
+        self.put("/snapshot/create", snapshot).await
+    }
+
+    /// Load and optionally resume a VM from a snapshot.
+    #[allow(dead_code)]
+    pub async fn load_snapshot(&self, snapshot: &SnapshotLoadParams) -> Result<()> {
+        self.put("/snapshot/load", snapshot).await
     }
 
     /// Make a PUT request
@@ -263,6 +301,25 @@ mod tests {
         let json = serde_json::to_string(&boot).unwrap();
         assert!(json.contains("kernel_image_path"));
         assert!(json.contains("boot_args"));
+    }
+
+    #[test]
+    fn test_snapshot_load_serializes_vsock_override() {
+        let snapshot = SnapshotLoadParams {
+            mem_file_path: "/tmp/vm.mem".to_string(),
+            snapshot_path: "/tmp/vm.state".to_string(),
+            resume_vm: true,
+            vsock_override: VsockOverride {
+                uds_path: "/tmp/restored-vsock.sock".to_string(),
+            },
+        };
+
+        let value = serde_json::to_value(snapshot).unwrap();
+        assert_eq!(value["resume_vm"], true);
+        assert_eq!(
+            value["vsock_override"]["uds_path"],
+            "/tmp/restored-vsock.sock"
+        );
     }
 
     #[test]

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -3,11 +3,53 @@
 //! Handles downloading/building kernel, rootfs, and Firecracker.
 
 use anyhow::{Context, Result, bail};
+use sha2::{Digest, Sha256};
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use crate::plugin_installer;
+
+/// Supported runtime versions used for fresh AgentKernel installations.
+/// Existing user-provided binaries and kernel images are detected before these
+/// defaults are used, so upgrading AgentKernel does not replace explicit picks.
+pub const DEFAULT_FIRECRACKER_VERSION: &str = "v1.16.1";
+pub const DEFAULT_KERNEL_VERSION: &str = "6.18.45";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct FirecrackerRelease {
+    arch: &'static str,
+    sha256: &'static str,
+}
+
+fn firecracker_release(arch: &str) -> Result<FirecrackerRelease> {
+    match arch {
+        "x86_64" => Ok(FirecrackerRelease {
+            arch: "x86_64",
+            sha256: "382a02a869e4d6d5cb14c40577f9545e8458021ea8b0b2d3fc10ec14d9c242e6",
+        }),
+        "aarch64" => Ok(FirecrackerRelease {
+            arch: "aarch64",
+            sha256: "8d0e69f6d6f9a1724551f607f18504052c16c1828ee3d4d7b6e6c73380871e0e",
+        }),
+        other => bail!("Unsupported Firecracker architecture: {other}"),
+    }
+}
+
+fn firecracker_asset_name(release: FirecrackerRelease) -> String {
+    format!(
+        "firecracker-{}-{}.tgz",
+        DEFAULT_FIRECRACKER_VERSION, release.arch
+    )
+}
+
+fn firecracker_download_url(release: FirecrackerRelease) -> String {
+    format!(
+        "https://github.com/firecracker-microvm/firecracker/releases/download/{}/{}",
+        DEFAULT_FIRECRACKER_VERSION,
+        firecracker_asset_name(release)
+    )
+}
 
 /// Runtime options for rootfs
 pub const RUNTIMES: &[(&str, &str)] = &[
@@ -31,7 +73,7 @@ impl Default for SetupConfig {
     fn default() -> Self {
         Self {
             data_dir: default_data_dir(),
-            kernel_version: "6.1.70".to_string(),
+            kernel_version: DEFAULT_KERNEL_VERSION.to_string(),
             runtimes: vec!["base".to_string()],
             install_firecracker: true,
         }
@@ -597,11 +639,14 @@ RUN chmod +x /build/build-kernel.sh
 RUN mkdir -p /kernel
 ENV BUILD_DIR=/tmp/kernel-build
 ENTRYPOINT ["/build/build-kernel.sh"]
-CMD ["6.1.70"]
+CMD ["__AGENTKERNEL_DEFAULT_KERNEL__"]
 "#;
 
     let dockerfile_path = temp_dir.join("Dockerfile");
-    std::fs::write(&dockerfile_path, dockerfile)?;
+    std::fs::write(
+        &dockerfile_path,
+        dockerfile.replace("__AGENTKERNEL_DEFAULT_KERNEL__", DEFAULT_KERNEL_VERSION),
+    )?;
 
     // Build the Docker image
     let status = Command::new("docker")
@@ -628,7 +673,7 @@ CMD ["6.1.70"]
             "-v",
             &format!("{}:/kernel", kernel_dir.display()),
             "agentkernel-kernel-builder",
-            "6.1.70",
+            DEFAULT_KERNEL_VERSION,
         ])
         .status()
         .context("Failed to run kernel build")?;
@@ -1146,37 +1191,22 @@ async fn install_firecracker_binary(data_dir: &Path) -> Result<()> {
         bail!("Unsupported architecture");
     };
 
-    let version = "v1.7.0";
-    let url = format!(
-        "https://github.com/firecracker-microvm/firecracker/releases/download/{}/firecracker-{}-{}.tgz",
-        version, version, arch
+    let release = firecracker_release(arch)?;
+    let asset_name = firecracker_asset_name(release);
+    let url = firecracker_download_url(release);
+
+    println!(
+        "Downloading Firecracker {} for {}...",
+        DEFAULT_FIRECRACKER_VERSION, arch
     );
 
-    println!("Downloading Firecracker {} for {}...", version, arch);
-
-    // Download and extract
-    let status = Command::new("sh")
-        .args([
-            "-c",
-            &format!(
-                r#"curl -fsSL "{}" | tar -xz -C "{}" && \
-                   mv "{}/release-{}-{}/firecracker-{}-{}" "{}/firecracker" && \
-                   chmod +x "{}/firecracker" && \
-                   rm -rf "{}/release-{}-{}""#,
-                url,
-                bin_dir.display(),
-                bin_dir.display(),
-                version,
-                arch,
-                version,
-                arch,
-                bin_dir.display(),
-                bin_dir.display(),
-                bin_dir.display(),
-                version,
-                arch
-            ),
-        ])
+    let temp_dir =
+        tempfile::tempdir().context("Failed to create Firecracker download directory")?;
+    let archive_path = temp_dir.path().join(&asset_name);
+    let status = Command::new("curl")
+        .args(["-fsSL", "--output"])
+        .arg(&archive_path)
+        .arg(&url)
         .status()
         .context("Failed to download Firecracker")?;
 
@@ -1184,7 +1214,45 @@ async fn install_firecracker_binary(data_dir: &Path) -> Result<()> {
         bail!("Failed to download Firecracker");
     }
 
+    let archive = std::fs::read(&archive_path).context("Failed to read Firecracker archive")?;
+    let actual_sha256 = hex::encode(Sha256::digest(&archive));
+    if actual_sha256 != release.sha256 {
+        bail!(
+            "Firecracker archive checksum mismatch: expected {}, got {}",
+            release.sha256,
+            actual_sha256
+        );
+    }
+
+    let status = Command::new("tar")
+        .args(["-xzf"])
+        .arg(&archive_path)
+        .arg("-C")
+        .arg(temp_dir.path())
+        .status()
+        .context("Failed to extract Firecracker")?;
+    if !status.success() {
+        bail!("Failed to extract Firecracker");
+    }
+
+    let extracted = temp_dir.path().join(format!(
+        "release-{}-{}/firecracker-{}-{}",
+        DEFAULT_FIRECRACKER_VERSION, arch, DEFAULT_FIRECRACKER_VERSION, arch
+    ));
     let firecracker_path = bin_dir.join("firecracker");
+    std::fs::copy(&extracted, &firecracker_path).with_context(|| {
+        format!(
+            "Failed to install Firecracker binary from {}",
+            extracted.display()
+        )
+    })?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&firecracker_path, std::fs::Permissions::from_mode(0o755))?;
+    }
+
     println!("Firecracker installed to: {}", firecracker_path.display());
 
     // Add to PATH hint
@@ -1197,6 +1265,52 @@ async fn install_firecracker_binary(data_dir: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn supported_runtime_defaults_match_verified_release_metadata() {
+        assert_eq!(
+            SetupConfig::default().kernel_version,
+            DEFAULT_KERNEL_VERSION
+        );
+        assert_eq!(DEFAULT_FIRECRACKER_VERSION, "v1.16.1");
+
+        let x86 = firecracker_release("x86_64").unwrap();
+        assert_eq!(
+            firecracker_asset_name(x86),
+            "firecracker-v1.16.1-x86_64.tgz"
+        );
+        assert_eq!(x86.sha256.len(), 64);
+
+        let arm = firecracker_release("aarch64").unwrap();
+        assert_eq!(
+            firecracker_asset_name(arm),
+            "firecracker-v1.16.1-aarch64.tgz"
+        );
+        assert_eq!(arm.sha256.len(), 64);
+        assert!(firecracker_release("riscv64").is_err());
+    }
+
+    #[test]
+    fn packaging_defaults_do_not_drift_from_setup() {
+        let kernel_script = include_str!("../images/build/build-kernel.sh");
+        let kernel_dockerfile = include_str!("../images/build/Dockerfile.kernel-builder");
+        let kvm_dockerfile = include_str!("../docker/Dockerfile.kvm-host");
+
+        assert!(kernel_script.contains(&format!(
+            "KERNEL_VERSION=\"${{1:-{DEFAULT_KERNEL_VERSION}}}\""
+        )));
+        assert!(
+            kernel_script
+                .contains("30fa4a56579ca614ac125a12614f7f6466f87ab1278aef7b951dd74156deab33")
+        );
+        assert!(kernel_dockerfile.contains(&format!("CMD [\"{DEFAULT_KERNEL_VERSION}\"]")));
+        assert!(kvm_dockerfile.contains(&format!(
+            "ARG FIRECRACKER_VERSION={DEFAULT_FIRECRACKER_VERSION}"
+        )));
+        for arch in ["x86_64", "aarch64"] {
+            assert!(kvm_dockerfile.contains(firecracker_release(arch).unwrap().sha256));
+        }
+    }
 
     #[test]
     fn guest_agent_build_context_materializes_declared_modules() {

--- a/tests/firecracker_kvm_smoke.rs
+++ b/tests/firecracker_kvm_smoke.rs
@@ -1,0 +1,150 @@
+//! Native x86_64 Firecracker smoke coverage.
+//!
+//! This is deliberately ignored and additionally requires an opt-in environment
+//! variable because it starts a real microVM through `/dev/kvm`.
+
+use agentkernel::backend::firecracker::FirecrackerSandbox;
+use agentkernel::backend::{Sandbox, SandboxConfig};
+use agentkernel::firecracker_client::{
+    FirecrackerClient, SnapshotCreateParams, SnapshotLoadParams, VsockOverride,
+};
+use agentkernel::vsock::VsockClient;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+fn required_path(name: &str) -> PathBuf {
+    let path = std::env::var_os(name)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| panic!("{name} must point to a prepared smoke-test asset"));
+    assert!(path.is_file(), "{name} does not exist: {}", path.display());
+    path
+}
+
+async fn wait_for_path(path: &Path) {
+    for _ in 0..100 {
+        if path.exists() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    panic!("timed out waiting for {}", path.display());
+}
+
+async fn wait_for_vsock(path: &Path) -> VsockClient {
+    let client = VsockClient::for_firecracker(path.to_path_buf());
+    for _ in 0..100 {
+        if client.ping().await.unwrap_or(false) {
+            return client;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    panic!("timed out waiting for restored vsock {}", path.display());
+}
+
+#[tokio::test]
+#[ignore = "requires an explicitly approved native x86_64 KVM runner"]
+async fn firecracker_lifecycle_exec_network_vsock_snapshot_recovery() {
+    assert_eq!(std::env::consts::OS, "linux");
+    assert_eq!(std::env::consts::ARCH, "x86_64");
+    assert_eq!(std::env::var("AGENTKERNEL_KVM_SMOKE").as_deref(), Ok("1"));
+
+    let firecracker = required_path("FIRECRACKER_BIN");
+    let kernel = required_path("AGENTKERNEL_KVM_KERNEL");
+    let rootfs = required_path("AGENTKERNEL_KVM_ROOTFS");
+    let version = Command::new(&firecracker)
+        .arg("--version")
+        .output()
+        .expect("run firecracker --version");
+    assert!(version.status.success());
+    assert!(String::from_utf8_lossy(&version.stdout).contains("v1.16.1"));
+
+    let name = format!("kvm-smoke-{}", std::process::id());
+    let mut sandbox = FirecrackerSandbox::new(&name)
+        .expect("create Firecracker sandbox")
+        .with_kernel(kernel)
+        .with_rootfs(rootfs);
+    sandbox
+        .start(&SandboxConfig::default())
+        .await
+        .expect("start Firecracker microVM");
+    assert!(sandbox.is_running());
+
+    let exec = sandbox
+        .exec(&["sh", "-c", "printf agentkernel-vsock"])
+        .await
+        .expect("execute over vsock");
+    assert_eq!(exec.exit_code, 0, "{}", exec.stderr);
+    assert_eq!(exec.stdout, "agentkernel-vsock");
+
+    let network = sandbox
+        .exec(&["sh", "-c", "ip -o link show lo && ping -c 1 -W 1 127.0.0.1"])
+        .await
+        .expect("inspect guest network stack over vsock");
+    assert_eq!(network.exit_code, 0, "{}", network.stderr);
+    assert!(network.stdout.contains("LOOPBACK"));
+
+    sandbox
+        .write_file("/tmp/snapshot-marker", b"survived-restore")
+        .await
+        .expect("write snapshot marker over vsock");
+
+    let snapshot_dir = tempfile::tempdir().expect("create snapshot directory");
+    let mem_path = snapshot_dir.path().join("microvm.mem");
+    let state_path = snapshot_dir.path().join("microvm.state");
+    let original_socket = PathBuf::from(format!("/tmp/agentkernel-{name}.sock"));
+    let original_rootfs = PathBuf::from(format!("/tmp/agentkernel-{name}-rootfs.ext4"));
+    let rootfs_backup = snapshot_dir.path().join("rootfs.ext4");
+    let client = FirecrackerClient::new(&original_socket);
+    client.pause().await.expect("pause microVM for snapshot");
+    client
+        .create_snapshot(&SnapshotCreateParams {
+            mem_file_path: mem_path.to_string_lossy().into_owned(),
+            snapshot_path: state_path.to_string_lossy().into_owned(),
+            snapshot_type: "Full".to_string(),
+        })
+        .await
+        .expect("create full Firecracker snapshot");
+    std::fs::copy(&original_rootfs, &rootfs_backup).expect("preserve snapshot rootfs");
+    sandbox.stop().await.expect("stop original microVM");
+    std::fs::copy(&rootfs_backup, &original_rootfs).expect("restore snapshot rootfs path");
+
+    let restored_socket = snapshot_dir.path().join("restored-api.sock");
+    let restored_vsock = snapshot_dir.path().join("restored-vsock.sock");
+    let mut restored = Command::new(&firecracker)
+        .arg("--api-sock")
+        .arg(&restored_socket)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("start Firecracker for snapshot recovery");
+    wait_for_path(&restored_socket).await;
+
+    let restored_client = FirecrackerClient::new(&restored_socket);
+    restored_client
+        .load_snapshot(&SnapshotLoadParams {
+            mem_file_path: mem_path.to_string_lossy().into_owned(),
+            snapshot_path: state_path.to_string_lossy().into_owned(),
+            resume_vm: true,
+            vsock_override: VsockOverride {
+                uds_path: restored_vsock.to_string_lossy().into_owned(),
+            },
+        })
+        .await
+        .expect("load and resume Firecracker snapshot");
+
+    let restored_vsock_client = wait_for_vsock(&restored_vsock).await;
+    let marker = restored_vsock_client
+        .run_command(&["cat".to_string(), "/tmp/snapshot-marker".to_string()])
+        .await
+        .expect("execute after snapshot recovery");
+    assert_eq!(marker.exit_code, 0, "{}", marker.stderr);
+    assert_eq!(marker.stdout, "survived-restore");
+
+    let _ = restored_client.send_ctrl_alt_del().await;
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    let _ = restored.kill();
+    let _ = restored.wait();
+    let _ = std::fs::remove_file(original_rootfs);
+}


### PR DESCRIPTION
## Summary
- move fresh setup and KVM host packaging from Firecracker v1.7.0 to supported v1.16.1, with verified x86_64/aarch64 SHA-256 checks before extraction
- move the default guest kernel from Linux 6.1.70 to current 6.18 LTS patch 6.18.45, verify the kernel.org checksum, and retain explicit custom kernel selections and existing installed assets
- add version/checksum drift tests plus Firecracker 1.16 snapshot/vsock-restore API coverage
- add an opt-in native x86_64 KVM workflow covering lifecycle, exec, loopback networking, vsock, full snapshot, restore, and post-restore exec
- include the KVM host entrypoint in the Docker build context so the packaging image is buildable

## Validation
- exact Rust 1.89 cargo check --locked --all-targets
- exact Rust 1.89 cargo clippy --locked -- -D warnings
- exact Rust 1.89 cargo test --locked: 328 library tests and 608 binary tests passed; CLI 25/25 passed; expected live integrations ignored
- cargo fmt --all -- --check; git diff --check; bash syntax check
- cargo audit --ignore RUSTSEC-2023-0071: zero vulnerabilities; 10 existing allowed warnings in the unmodernized base dependency graph
- freshly downloaded and verified both official Firecracker release archives and their internal binary paths
- KVM host Docker image built successfully for linux/amd64 and linux/arm64, with both pinned checksums reported OK

## Live KVM status
The repository currently has zero configured self-hosted runners, so the native KVM workflow cannot be dispatched safely. It is gated on the dedicated labels self-hosted, Linux, X64, agentkernel-kvm-safe and requires explicit workflow confirmation. No unrelated host or credentials were changed.