### PR TITLE
chore: default to Alpine 3.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Command-driven runs do not implicitly build a Dockerfile found in the working di
 | Elixir | `mix.exs` | `elixir`, `mix` | `elixir:1.16-alpine` |
 | Lua | `*.lua` | `lua`, `luajit` | `nickblah/lua:5.4-alpine` |
 | HCL/Terraform | `*.tf`, `*.tfvars` | `terraform` | `hashicorp/terraform:1.10` |
-| Shell | `*.sh` | `bash`, `sh`, `zsh` | `alpine:3.20` |
+| Shell | `*.sh` | `bash`, `sh`, `zsh` | `alpine:3.24` |
 
 ### Procfile Support
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -186,7 +186,7 @@ paths:
                 created:
                   value: |
                     event: sandbox.created
-                    data: {"event":"sandbox.created","timestamp":"2026-02-23T12:00:00Z","sandbox":"my-sandbox","labels":{},"metadata":{"image":"alpine:3.20","backend":"docker","vcpus":1,"memory_mb":512,"duration_ms":150}}
+                    data: {"event":"sandbox.created","timestamp":"2026-02-23T12:00:00Z","sandbox":"my-sandbox","labels":{},"metadata":{"image":"alpine:3.24","backend":"docker","vcpus":1,"memory_mb":512,"duration_ms":150}}
         '503':
           description: Event bus not enabled
 
@@ -1187,7 +1187,7 @@ components:
           example: "my-sandbox"
         image:
           type: string
-          default: "alpine:3.20"
+          default: "alpine:3.24"
           description: Docker image to use
           example: "python:3.12-alpine"
         vcpus:

--- a/app/src/components/SetupWizard.tsx
+++ b/app/src/components/SetupWizard.tsx
@@ -135,7 +135,7 @@ export function SetupWizard({ open, onComplete }: SetupWizardProps) {
     mutationFn: () =>
       api.createSandbox({
         name: sandboxName,
-        image: "alpine:3.20",
+        image: "alpine:3.24",
         vcpus: 2,
         memory_mb: 512,
       }),

--- a/app/src/components/dashboard/quick-actions.tsx
+++ b/app/src/components/dashboard/quick-actions.tsx
@@ -20,7 +20,7 @@ import type { RunOutput } from "@/lib/types";
 export function QuickActions() {
   const [open, setOpen] = useState(false);
   const [command, setCommand] = useState("");
-  const [image, setImage] = useState("alpine:3.20");
+  const [image, setImage] = useState("alpine:3.24");
   const [output, setOutput] = useState<string | null>(null);
 
   const quickRunMutation = useMutation({
@@ -62,7 +62,7 @@ export function QuickActions() {
     if (!next) {
       // Reset state when closing
       setCommand("");
-      setImage("alpine:3.20");
+      setImage("alpine:3.24");
       setOutput(null);
       quickRunMutation.reset();
     }
@@ -98,7 +98,7 @@ export function QuickActions() {
               <Label htmlFor="qr-image">Image</Label>
               <Input
                 id="qr-image"
-                placeholder="alpine:3.20"
+                placeholder="alpine:3.24"
                 value={image}
                 onChange={(e) => setImage(e.target.value)}
                 disabled={quickRunMutation.isPending}

--- a/app/src/components/sandbox-picker.tsx
+++ b/app/src/components/sandbox-picker.tsx
@@ -24,7 +24,7 @@ export function SandboxPicker({
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
   const [creatingName, setCreatingName] = useState<string | null>(null);
-  const [newImage, setNewImage] = useState("alpine:3.20");
+  const [newImage, setNewImage] = useState("alpine:3.24");
   const containerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -59,14 +59,14 @@ export function SandboxPicker({
 
   const createMutation = useMutation({
     mutationFn: (name: string) =>
-      api.createSandbox({ name, image: newImage.trim() || "alpine:3.20" }),
+      api.createSandbox({ name, image: newImage.trim() || "alpine:3.24" }),
     onSuccess: (_data, name) => {
       queryClient.invalidateQueries({ queryKey: ["sandboxes"] });
       onChange(name);
       setOpen(false);
       setSearch("");
       setCreatingName(null);
-      setNewImage("alpine:3.20");
+      setNewImage("alpine:3.24");
       toast.success(`Sandbox "${name}" created`);
     },
     onError: (err) => {
@@ -147,7 +147,7 @@ export function SandboxPicker({
                   type="text"
                   value={newImage}
                   onChange={(e) => setNewImage(e.target.value)}
-                  placeholder="Image (e.g. alpine:3.20)"
+                  placeholder="Image (e.g. alpine:3.24)"
                   className="flex-1 rounded border bg-background px-2 py-1 text-xs font-mono focus:outline-none focus:ring-1 focus:ring-ring"
                   onKeyDown={(e) => {
                     if (e.key === "Enter") {

--- a/app/src/pages/Sandboxes.tsx
+++ b/app/src/pages/Sandboxes.tsx
@@ -62,7 +62,7 @@ export function Sandboxes() {
   }, [searchParams, setSearchParams]);
 
   const [formName, setFormName] = useState("");
-  const [formImage, setFormImage] = useState("alpine:3.20");
+  const [formImage, setFormImage] = useState("alpine:3.24");
   const [formVcpus, setFormVcpus] = useState(1);
   const [formMemory, setFormMemory] = useState(512);
   const [formProfile, setFormProfile] = useState("restrictive");
@@ -167,7 +167,7 @@ export function Sandboxes() {
 
   function resetForm() {
     setFormName("");
-    setFormImage("alpine:3.20");
+    setFormImage("alpine:3.24");
     setFormVcpus(1);
     setFormMemory(512);
     setFormProfile("restrictive");

--- a/autoresearch/README.md
+++ b/autoresearch/README.md
@@ -34,7 +34,7 @@ Environment overrides:
 AK_BENCH_BACKENDS=docker
 AK_BENCH_ITERATIONS=5
 AK_BENCH_WARMUP=1
-AK_BENCH_IMAGE=alpine:3.20
+AK_BENCH_IMAGE=alpine:3.24
 ./autoresearch/run_eval.sh
 ```
 

--- a/autoresearch/program.md
+++ b/autoresearch/program.md
@@ -14,7 +14,7 @@ Default eval command
 
 Default target on this machine
 - backend: docker
-- image: alpine:3.20
+- image: alpine:3.24
 - measured iterations: 5
 - warmup iterations: 1
 

--- a/autoresearch/run_eval.sh
+++ b/autoresearch/run_eval.sh
@@ -7,7 +7,7 @@ cd "$ROOT"
 BACKENDS="${AK_BENCH_BACKENDS:-docker}"
 ITERATIONS="${AK_BENCH_ITERATIONS:-5}"
 WARMUP="${AK_BENCH_WARMUP:-1}"
-IMAGE="${AK_BENCH_IMAGE:-alpine:3.20}"
+IMAGE="${AK_BENCH_IMAGE:-alpine:3.24}"
 REPORT="${AK_BENCH_REPORT:-autoresearch/latest-report.json}"
 
 mkdir -p "$(dirname "$REPORT")"

--- a/claude-plugin/.claude/skills/agentkernel/SKILL.md
+++ b/claude-plugin/.claude/skills/agentkernel/SKILL.md
@@ -143,7 +143,7 @@ agentkernel sandbox remove my-sandbox
 | .NET | `dotnet` | `mcr.microsoft.com/dotnet/sdk:8.0` |
 | Terraform | `terraform` | `hashicorp/terraform:1.10` |
 | Lua | `lua`, `luajit` | `nickblah/lua:5.4-alpine` |
-| Shell | `bash`, `sh`, `zsh` | `alpine:3.20` |
+| Shell | `bash`, `sh`, `zsh` | `alpine:3.24` |
 
 ## Security Notes
 

--- a/deploy/helm/agentkernel/values.yaml
+++ b/deploy/helm/agentkernel/values.yaml
@@ -19,7 +19,7 @@ orchestrator:
 # Default sandbox resource limits
 sandbox:
   defaults:
-    image: alpine:3.20
+    image: alpine:3.24
     memory: 512Mi
     cpu: "1"
     securityProfile: restrictive

--- a/docs/commands/images.md
+++ b/docs/commands/images.md
@@ -78,7 +78,7 @@ No agentkernel images found. Use --all to show all images.
 $ agentkernel images list --all
 REPOSITORY:TAG                           IMAGE ID        USED BY            SIZE
 python:3.12-alpine                       82585c9f05cf    1 sandbox        79.7MB
-alpine:3.20                              a4f4213abb84    2 sandboxes      13.7MB
+alpine:3.24                              a4f4213abb84    2 sandboxes      13.7MB
 node:22-alpine                           d7119ab9e005    unused            307MB
 
 3 images, 3 sandbox references

--- a/docs/commands/parallel.md
+++ b/docs/commands/parallel.md
@@ -61,8 +61,8 @@ agentkernel parallel \
 
 ```bash
 $ agentkernel parallel \
-    --job "pass:alpine:3.20:echo ok" \
-    --job "fail:alpine:3.20:false" \
+    --job "pass:alpine:3.24:echo ok" \
+    --job "fail:alpine:3.24:false" \
     -B docker
 Running 2 jobs in parallel...
 

--- a/docs/commands/run.md
+++ b/docs/commands/run.md
@@ -141,7 +141,7 @@ The `run` command automatically selects an appropriate Docker image based on you
 | `cargo`, `rustc` | `rust:1.85-alpine` |
 | `go` | `golang:1.23-alpine` |
 | `ruby`, `gem`, `bundle` | `ruby:3.3-alpine` |
-| Others | `alpine:3.20` |
+| Others | `alpine:3.24` |
 
 Override with `--image` when needed, or pass `--build` to build the current project's Dockerfile first.
 

--- a/docs/commands/templates.md
+++ b/docs/commands/templates.md
@@ -31,9 +31,9 @@ agentkernel ships with 26 built-in templates:
 | `ruby` | `ruby:3.3-alpine` | Ruby development |
 | `java` | `eclipse-temurin:21-alpine` | Java development |
 | `dotnet` | `mcr.microsoft.com/dotnet/sdk:8.0` | .NET development |
-| `bash` | `alpine:3.20` | Shell scripting |
+| `bash` | `alpine:3.24` | Shell scripting |
 | `c` | `gcc:14-bookworm` | C/C++ development |
-| `secure` | `alpine:3.20` | Restrictive (no network) |
+| `secure` | `alpine:3.24` | Restrictive (no network) |
 
 ### AI Agent Sandboxes
 
@@ -70,7 +70,7 @@ agentkernel ships with 26 built-in templates:
 ```bash
 $ agentkernel template list
 NAME                 SOURCE     IMAGE
-bash                 built-in   alpine:3.20
+bash                 built-in   alpine:3.24
 c                    built-in   gcc:14-bookworm
 claude-sandbox       built-in   python:3.12-alpine
 python               built-in   python:3.12-alpine

--- a/docs/config/backends.md
+++ b/docs/config/backends.md
@@ -127,7 +127,7 @@ Run sandboxes as Kubernetes Pods on any cluster. Requires building with `--featu
 ```bash
 cargo build --features kubernetes
 
-agentkernel sandbox create my-sandbox --backend kubernetes --image alpine:3.20
+agentkernel sandbox create my-sandbox --backend kubernetes --image alpine:3.24
 ```
 
 **Requirements:**
@@ -155,7 +155,7 @@ Run sandboxes as HashiCorp Nomad job allocations. Requires building with `--feat
 ```bash
 cargo build --features nomad
 
-agentkernel sandbox create my-sandbox --backend nomad --image alpine:3.20
+agentkernel sandbox create my-sandbox --backend nomad --image alpine:3.24
 ```
 
 **Requirements:**

--- a/docs/features/durable-functions.md
+++ b/docs/features/durable-functions.md
@@ -215,7 +215,7 @@ name = "deploy-pipeline"
 activities = [
     { name = "clone-repo", image = "alpine/git", command = ["git", "clone", "$input.repo"] },
     { name = "run-tests", image = "rust:1.82-alpine", command = ["cargo", "test"] },
-    { name = "deploy",    image = "alpine:3.20",      command = ["sh", "deploy.sh"] },
+    { name = "deploy",    image = "alpine:3.24",      command = ["sh", "deploy.sh"] },
 ]
 ```
 
@@ -330,7 +330,7 @@ retry_policy = { max_attempts = 2 }
 
 [[orchestrations.activities]]
 name = "deploy"
-image = "alpine:3.20"
+image = "alpine:3.24"
 command = ["sh", "/workspace/deploy.sh"]
 timeout_ms = 120000
 ```

--- a/docs/operations/kubernetes.md
+++ b/docs/operations/kubernetes.md
@@ -7,7 +7,7 @@ Run sandboxes as Kubernetes Pods on any cluster. Each sandbox is a Pod running `
 
 ```bash
 # Create and run a sandbox on Kubernetes
-agentkernel sandbox create my-sandbox --backend kubernetes --image alpine:3.20
+agentkernel sandbox create my-sandbox --backend kubernetes --image alpine:3.24
 agentkernel sandbox start my-sandbox
 agentkernel exec my-sandbox -- echo "hello from k8s"
 agentkernel sandbox stop my-sandbox
@@ -127,7 +127,7 @@ metadata:
 spec:
   warm_pool_size: 20
   max_pool_size: 100
-  image: alpine:3.20
+  image: alpine:3.24
   vcpus: 1
   memory_mb: 512
 ```
@@ -277,7 +277,7 @@ orchestrator:
 
 sandbox:
   defaults:
-    image: alpine:3.20
+    image: alpine:3.24
     memory: 512Mi
     cpu: "1"
     securityProfile: restrictive

--- a/docs/operations/nomad.md
+++ b/docs/operations/nomad.md
@@ -7,7 +7,7 @@ Run sandboxes as HashiCorp Nomad job allocations. Each sandbox is a batch job ru
 
 ```bash
 # Create and run a sandbox on Nomad
-agentkernel sandbox create my-sandbox --backend nomad --image alpine:3.20
+agentkernel sandbox create my-sandbox --backend nomad --image alpine:3.24
 agentkernel sandbox start my-sandbox
 agentkernel exec my-sandbox -- echo "hello from nomad"
 agentkernel sandbox stop my-sandbox

--- a/examples/README.md
+++ b/examples/README.md
@@ -129,7 +129,7 @@ agentkernel start bash-app
 agentkernel exec bash-app echo "Hello!"
 ```
 
-**Features**: Alpine 3.20, busybox, shell scripting
+**Features**: Alpine 3.24, busybox, shell scripting
 
 ### Kubernetes
 Run sandboxes as Kubernetes Pods on any cluster. Requires `--features kubernetes`.

--- a/examples/bash-app/agentkernel.toml
+++ b/examples/bash-app/agentkernel.toml
@@ -3,7 +3,7 @@
 
 [sandbox]
 name = "bash-app"
-base_image = "alpine:3.20"
+base_image = "alpine:3.24"
 
 [agent]
 preferred = "claude"

--- a/examples/enterprise/agentkernel.toml
+++ b/examples/enterprise/agentkernel.toml
@@ -3,7 +3,7 @@
 
 [sandbox]
 name = "enterprise-sandbox"
-base_image = "alpine:3.20"
+base_image = "alpine:3.24"
 
 [agent]
 preferred = "claude"

--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -18,7 +18,7 @@ k3d cluster create agentkernel
 cargo build --features kubernetes
 
 # Create and run a sandbox
-agentkernel create k8s-sandbox --backend kubernetes --image alpine:3.20
+agentkernel create k8s-sandbox --backend kubernetes --image alpine:3.24
 agentkernel start k8s-sandbox
 agentkernel exec k8s-sandbox -- echo "hello from kubernetes"
 

--- a/examples/kubernetes/agentkernel.toml
+++ b/examples/kubernetes/agentkernel.toml
@@ -3,7 +3,7 @@
 
 [sandbox]
 name = "k8s-sandbox"
-base_image = "alpine:3.20"
+base_image = "alpine:3.24"
 
 [agent]
 preferred = "claude"

--- a/examples/nomad/README.md
+++ b/examples/nomad/README.md
@@ -19,7 +19,7 @@ nomad agent -dev &
 cargo build --features nomad
 
 # Create and run a sandbox
-agentkernel create nomad-sandbox --backend nomad --image alpine:3.20
+agentkernel create nomad-sandbox --backend nomad --image alpine:3.24
 agentkernel start nomad-sandbox
 agentkernel exec nomad-sandbox -- echo "hello from nomad"
 

--- a/examples/nomad/agentkernel.toml
+++ b/examples/nomad/agentkernel.toml
@@ -3,7 +3,7 @@
 
 [sandbox]
 name = "nomad-sandbox"
-base_image = "alpine:3.20"
+base_image = "alpine:3.24"
 
 [agent]
 preferred = "claude"

--- a/images/build/build-rootfs.sh
+++ b/images/build/build-rootfs.sh
@@ -55,7 +55,7 @@ mkdir -p "$ROOTFS_DIR"
 
 # Build in Docker for consistency
 docker build -t agentkernel-rootfs-builder -f - "$SCRIPT_DIR" << 'DOCKERFILE'
-FROM alpine:3.20
+FROM alpine:3.24
 
 RUN apk add --no-cache \
     e2fsprogs \
@@ -122,8 +122,8 @@ mount -o loop "$ROOTFS_IMG" "$MOUNT_DIR"
 
 # Create Alpine rootfs using static busybox approach
 echo "==> Installing Alpine base system..."
-apk -X https://dl-cdn.alpinelinux.org/alpine/v3.20/main \
-    -X https://dl-cdn.alpinelinux.org/alpine/v3.20/community \
+apk -X https://dl-cdn.alpinelinux.org/alpine/v3.24/main \
+    -X https://dl-cdn.alpinelinux.org/alpine/v3.24/community \
     -U --allow-untrusted --root "$MOUNT_DIR" --initdb \
     add alpine-base busybox-static $PACKAGES
 

--- a/packages/pi-agentkernel/index.ts
+++ b/packages/pi-agentkernel/index.ts
@@ -196,7 +196,7 @@ export default function (pi: ExtensionAPI) {
       image: Type.Optional(
         Type.String({
           description:
-            "Container image (default: alpine:3.20). Examples: python:3.12-alpine, node:22-alpine",
+            "Container image (default: alpine:3.24). Examples: python:3.12-alpine, node:22-alpine",
         }),
       ),
     }),
@@ -214,7 +214,7 @@ export default function (pi: ExtensionAPI) {
         });
         return {
           content: [{ type: "text", text: result.output }],
-          details: { sandbox: "one-shot", image: image ?? "alpine:3.20" },
+          details: { sandbox: "one-shot", image: image ?? "alpine:3.24" },
         };
       } catch (err: unknown) {
         const message =

--- a/plan/orchestration.md
+++ b/plan/orchestration.md
@@ -213,7 +213,7 @@ resources:
 
 sandbox:
   defaults:
-    image: alpine:3.20
+    image: alpine:3.24
     memory: 512Mi
     cpu: "1"
     securityProfile: restrictive
@@ -384,7 +384,7 @@ Use Nomad parameterized batch jobs:
 warm_pool_size = 20       # pre-warmed sandboxes
 max_sandboxes = 500       # hard cap on total concurrent sandboxes
 warm_pool_images = [      # which images to pre-warm
-  "alpine:3.20",
+  "alpine:3.24",
   "python:3.12-alpine",
   "node:22-alpine",
 ]
@@ -427,7 +427,7 @@ metadata:
   name: default-pool
 spec:
   size: 20
-  image: alpine:3.20
+  image: alpine:3.24
   resources:
     memory: 256Mi
 ```
@@ -481,7 +481,7 @@ kubectl port-forward svc/agentkernel 18888:18888
 for i in $(seq 1 100); do
   curl -s -X POST http://localhost:18888/sandboxes \
     -H 'Content-Type: application/json' \
-    -d "{\"name\": \"test-$i\", \"image\": \"alpine:3.20\"}" &
+    -d "{\"name\": \"test-$i\", \"image\": \"alpine:3.24\"}" &
 done; wait
 
 kubectl -n agentkernel-sandboxes get pods | wc -l

--- a/plugins/pi/.pi/extensions/agentkernel/index.ts
+++ b/plugins/pi/.pi/extensions/agentkernel/index.ts
@@ -196,7 +196,7 @@ export default function (pi: ExtensionAPI) {
       image: Type.Optional(
         Type.String({
           description:
-            "Container image (default: alpine:3.20). Examples: python:3.12-alpine, node:22-alpine",
+            "Container image (default: alpine:3.24). Examples: python:3.12-alpine, node:22-alpine",
         }),
       ),
     }),
@@ -214,7 +214,7 @@ export default function (pi: ExtensionAPI) {
         });
         return {
           content: [{ type: "text", text: result.output }],
-          details: { sandbox: "one-shot", image: image ?? "alpine:3.20" },
+          details: { sandbox: "one-shot", image: image ?? "alpine:3.24" },
         };
       } catch (err: unknown) {
         const message =

--- a/scripts/remote-bridge.mjs
+++ b/scripts/remote-bridge.mjs
@@ -741,7 +741,7 @@ async function createDaytonaSandbox(providerRequest) {
   return withDaytonaClient(async (daytona) => {
     const sandbox = await daytona.create({
       name: providerRequest.sandbox_name,
-      image: providerRequest.image || "alpine:3.20",
+      image: providerRequest.image || "alpine:3.24",
       envVars: daytonaEnvMap(providerRequest.env),
       resources: {
         cpu: providerRequest.vcpus || 1,
@@ -1543,9 +1543,9 @@ function modalImageRef(providerRequest) {
     providerRequest.remote_metadata?.image_ref ||
     providerRequest.image ||
     providerRequest.profile ||
-    "alpine:3.20";
+    "alpine:3.24";
   if (!requested || requested === "base" || requested === "default") {
-    return "alpine:3.20";
+    return "alpine:3.24";
   }
   return requested;
 }

--- a/sdk/nodejs/src/types.ts
+++ b/sdk/nodejs/src/types.ts
@@ -29,7 +29,7 @@ export interface RunOptions {
 
 /** Options for creating a sandbox. */
 export interface CreateSandboxOptions {
-  /** Docker image to use. Default: alpine:3.20 */
+  /** Docker image to use. Default: alpine:3.24 */
   image?: string;
   vcpus?: number;
   memory_mb?: number;

--- a/src/audit.rs
+++ b/src/audit.rs
@@ -261,7 +261,7 @@ mod tests {
     fn test_audit_entry_serialization() {
         let entry = AuditEntry::new(AuditEvent::SandboxCreated {
             name: "test".to_string(),
-            image: "alpine:3.20".to_string(),
+            image: "alpine:3.24".to_string(),
             backend: "docker".to_string(),
             labels: Default::default(),
         });

--- a/src/backend/apple.rs
+++ b/src/backend/apple.rs
@@ -591,6 +591,7 @@ mod tests {
 
     #[test]
     fn test_is_local_image_rejects_registry_images() {
+        // Legacy compatibility: explicit old registry images remain valid remote images.
         assert!(!is_local_image("alpine:3.20"));
         assert!(!is_local_image("python:3.12-alpine"));
         assert!(!is_local_image("docker.io/library/alpine"));

--- a/src/backend/kubernetes_operator.rs
+++ b/src/backend/kubernetes_operator.rs
@@ -1040,7 +1040,7 @@ mod tests {
         let sandbox = AgentSandbox::new(
             "test-sandbox",
             AgentSandboxSpec {
-                image: "alpine:3.20".to_string(),
+                image: "alpine:3.24".to_string(),
                 vcpus: 1,
                 memory_mb: 512,
                 network: true,

--- a/src/backend/kubernetes_pool.rs
+++ b/src/backend/kubernetes_pool.rs
@@ -39,7 +39,7 @@ impl Default for KubernetesPoolConfig {
         Self {
             warm_pool_size: 10,
             max_pool_size: 50,
-            image: "alpine:3.20".to_string(),
+            image: "alpine:3.24".to_string(),
             namespace: "agentkernel".to_string(),
             runtime_class: None,
             memory_mb: 512,

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -335,7 +335,7 @@ pub struct SandboxConfig {
 impl Default for SandboxConfig {
     fn default() -> Self {
         Self {
-            image: "alpine:3.20".to_string(),
+            image: "alpine:3.24".to_string(),
             vcpus: 1,
             memory_mb: 512,
             mount_cwd: false,
@@ -941,7 +941,7 @@ mod tests {
     #[test]
     fn test_sandbox_config_default() {
         let config = SandboxConfig::default();
-        assert_eq!(config.image, "alpine:3.20");
+        assert_eq!(config.image, "alpine:3.24");
         assert_eq!(config.vcpus, 1);
         assert_eq!(config.memory_mb, 512);
         assert!(!config.mount_cwd);

--- a/src/backend/nomad_pool.rs
+++ b/src/backend/nomad_pool.rs
@@ -116,7 +116,7 @@ impl Default for NomadPoolConfig {
             nomad_token: std::env::var("NOMAD_TOKEN").ok(),
             warm_pool_size: 10,
             max_pool_size: 50,
-            image: "alpine:3.20".to_string(),
+            image: "alpine:3.24".to_string(),
             driver: "docker".to_string(),
             datacenter: "dc1".to_string(),
             memory_mb: 512,

--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -544,7 +544,7 @@ mod tests {
         let path = tmp.path().join("report.json");
         let report = BenchmarkReport {
             generated_at: "2026-03-23T00:00:00Z".to_string(),
-            image: "alpine:3.20".to_string(),
+            image: "alpine:3.24".to_string(),
             measured_iterations: 3,
             warmup_iterations: 1,
             primary_metric: "total_score".to_string(),

--- a/src/build.rs
+++ b/src/build.rs
@@ -153,7 +153,7 @@ mod tests {
         let dockerfile_path = dir.path().join("Dockerfile");
 
         let mut file = std::fs::File::create(&dockerfile_path).unwrap();
-        writeln!(file, "FROM alpine:3.20").unwrap();
+        writeln!(file, "FROM alpine:3.24").unwrap();
 
         let name = dockerfile_image_name("my-project", &dockerfile_path);
         assert!(name.starts_with("agentkernel-my-project:"));

--- a/src/config.rs
+++ b/src/config.rs
@@ -837,7 +837,7 @@ impl Config {
             "java" => "eclipse-temurin:21-alpine".to_string(),
             "c" => "gcc:14-bookworm".to_string(),
             "dotnet" => "mcr.microsoft.com/dotnet/sdk:8.0".to_string(),
-            _ => "alpine:3.20".to_string(),
+            _ => "alpine:3.24".to_string(),
         }
     }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -196,7 +196,7 @@ mod tests {
             timestamp: Utc::now(),
             sandbox: "test-sandbox".to_string(),
             labels: HashMap::new(),
-            metadata: serde_json::json!({"image": "alpine:3.20"}),
+            metadata: serde_json::json!({"image": "alpine:3.24"}),
         };
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains("sandbox.created"));

--- a/src/http_api.rs
+++ b/src/http_api.rs
@@ -1414,8 +1414,8 @@ async fn handle_run(req: Request<Incoming>, state: Arc<AppState>) -> Response<Bo
     // Fast path: use container pool (default for HTTP API)
     if body.fast {
         if body.image.is_some() {
-            // Pool uses alpine:3.20, warn if custom image requested
-            eprintln!("Warning: custom image ignored in fast mode (pool uses alpine:3.20)");
+            // Pool uses alpine:3.24, warn if custom image requested
+            eprintln!("Warning: custom image ignored in fast mode (pool uses alpine:3.24)");
         }
 
         match VmManager::run_pooled(&body.command).await {
@@ -2895,7 +2895,7 @@ async fn handle_create_sandbox(req: Request<Incoming>, state: Arc<AppState>) -> 
         );
     }
 
-    let image = body.image.as_deref().unwrap_or("alpine:3.20");
+    let image = body.image.as_deref().unwrap_or("alpine:3.24");
     let vcpus = body.vcpus.unwrap_or(1);
     let memory_mb = body.memory_mb.unwrap_or(512);
 
@@ -6996,7 +6996,7 @@ async fn handle_benchmark(state: Arc<AppState>) -> Response<BoxBody> {
             .next()
             .unwrap_or("0")
     );
-    let image = "alpine:3.20";
+    let image = "alpine:3.24";
 
     let started_at = chrono::Utc::now();
 
@@ -7442,10 +7442,11 @@ mod tests {
 
     #[test]
     fn test_run_request_deserialize() {
+        // Legacy compatibility: explicitly requested old tags deserialize unchanged.
         let json = r#"{"command": ["echo", "hello"], "image": "alpine:3.20"}"#;
         let req: RunRequest = serde_json::from_str(json).unwrap();
         assert_eq!(req.command, vec!["echo", "hello"]);
-        assert_eq!(req.image, Some("alpine:3.20".to_string()));
+        assert_eq!(req.image, Some("alpine:3.20".to_string())); // legacy compatibility
         assert!(req.fast); // default is true
     }
 

--- a/src/languages.rs
+++ b/src/languages.rs
@@ -115,7 +115,7 @@ const RUNTIMES: &[Runtime] = &[
     },
     // Shell scripts (uses lightweight alpine)
     Runtime {
-        image: "alpine:3.20",
+        image: "alpine:3.24",
         project_files: &["*.sh"],
         commands: &["sh", "bash", "zsh", "ash"],
     },
@@ -134,7 +134,7 @@ const RUNTIMES: &[Runtime] = &[
 ];
 
 /// Default image when nothing is detected
-const DEFAULT_IMAGE: &str = "alpine:3.20";
+const DEFAULT_IMAGE: &str = "alpine:3.24";
 
 /// Common Dockerfile names to detect
 const DOCKERFILE_NAMES: &[&str] = &[
@@ -351,11 +351,11 @@ mod tests {
     fn test_detect_shell_commands() {
         assert_eq!(
             detect_from_command(&["bash".to_string(), "-c".to_string(), "echo hi".to_string()]),
-            Some("alpine:3.20".to_string())
+            Some("alpine:3.24".to_string())
         );
         assert_eq!(
             detect_from_command(&["sh".to_string(), "script.sh".to_string()]),
-            Some("alpine:3.20".to_string())
+            Some("alpine:3.24".to_string())
         );
     }
 
@@ -404,7 +404,7 @@ mod tests {
         // Create a Dockerfile
         let dockerfile_path = dir.path().join("Dockerfile");
         let mut file = std::fs::File::create(&dockerfile_path).unwrap();
-        writeln!(file, "FROM alpine:3.20").unwrap();
+        writeln!(file, "FROM alpine:3.24").unwrap();
         writeln!(file, "RUN apk add --no-cache python3").unwrap();
 
         let result = detect_dockerfile(dir.path());
@@ -422,7 +422,7 @@ mod tests {
 
         // Create a Dockerfile
         let mut file = std::fs::File::create(&dockerfile_path).unwrap();
-        writeln!(file, "FROM alpine:3.20").unwrap();
+        writeln!(file, "FROM alpine:3.24").unwrap();
 
         let hash = dockerfile_content_hash(&dockerfile_path);
         assert!(hash.is_some());
@@ -442,7 +442,7 @@ mod tests {
         let dockerfile_path = dir.path().join("Dockerfile");
 
         let mut file = std::fs::File::create(&dockerfile_path).unwrap();
-        writeln!(file, "FROM alpine:3.20").unwrap();
+        writeln!(file, "FROM alpine:3.24").unwrap();
 
         let name = dockerfile_image_name("my-project", &dockerfile_path);
         assert!(name.starts_with("agentkernel-my-project:"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -328,7 +328,7 @@ enum Commands {
         #[arg(long, default_value = "1")]
         warmup: usize,
         /// Docker image to use for benchmark
-        #[arg(long, default_value = "alpine:3.20")]
+        #[arg(long, default_value = "alpine:3.24")]
         image: String,
         /// Output machine-readable JSON instead of the table view
         #[arg(long)]
@@ -2136,7 +2136,7 @@ memory_mb = 512
                 }
                 if image.is_some() || config.is_some() {
                     eprintln!(
-                        "Warning: --image and --config are ignored with --fast (pool uses alpine:3.20)"
+                        "Warning: --image and --config are ignored with --fast (pool uses alpine:3.24)"
                     );
                 }
 
@@ -2146,7 +2146,7 @@ memory_mb = 512
                         if let Some(path) = receipt_path.as_ref() {
                             write_run_receipt(
                                 path,
-                                Some("alpine:3.20".to_string()),
+                                Some("alpine:3.24".to_string()),
                                 None,
                                 0,
                                 &output,
@@ -2160,7 +2160,7 @@ memory_mb = 512
                             let (exit_code, combined_output, error_message) = error_details(&e);
                             write_run_receipt(
                                 path,
-                                Some("alpine:3.20".to_string()),
+                                Some("alpine:3.24".to_string()),
                                 None,
                                 exit_code,
                                 &combined_output,
@@ -3483,7 +3483,7 @@ memory_mb = 512
                         ));
                     }
                     4 => {
-                        // name:image:tag:command (image with tag like alpine:3.20)
+                        // name:image:tag:command (image with tag like alpine:3.24)
                         parsed_jobs.push((
                             parts[0].to_string(),
                             format!("{}:{}", parts[1], parts[2]),
@@ -3822,7 +3822,7 @@ memory_mb = 512
                 backend,
             } => {
                 let sess = session::create(&name, &agent)?;
-                let docker_image = image.unwrap_or_else(|| "alpine:3.20".to_string());
+                let docker_image = image.unwrap_or_else(|| "alpine:3.24".to_string());
 
                 let backend_type = if let Some(ref b) = backend {
                     Some(
@@ -5122,7 +5122,7 @@ mod tests {
 
     fn project_with_dockerfile() -> TempDir {
         let temp_dir = TempDir::new().unwrap();
-        std::fs::write(temp_dir.path().join("Dockerfile"), "FROM alpine:3.20\n").unwrap();
+        std::fs::write(temp_dir.path().join("Dockerfile"), "FROM alpine:3.24\n").unwrap();
         temp_dir
     }
 

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -266,7 +266,7 @@ impl McpServer {
                             },
                             "image": {
                                 "type": "string",
-                                "description": "Docker image to use (default: alpine:3.20)"
+                                "description": "Docker image to use (default: alpine:3.24)"
                             },
                             "ports": {
                                 "type": "array",
@@ -1049,7 +1049,7 @@ impl McpServer {
                 );
             }
             if args.get("image").is_some() {
-                eprintln!("Warning: custom image ignored in fast mode (pool uses alpine:3.20)");
+                eprintln!("Warning: custom image ignored in fast mode (pool uses alpine:3.24)");
             }
 
             return tokio::task::block_in_place(|| {
@@ -1119,7 +1119,7 @@ impl McpServer {
         let image = args
             .get("image")
             .and_then(|v| v.as_str())
-            .unwrap_or("alpine:3.20");
+            .unwrap_or("alpine:3.24");
 
         let ports: Vec<crate::backend::PortMapping> = args
             .get("ports")

--- a/src/object_runtime.rs
+++ b/src/object_runtime.rs
@@ -100,7 +100,7 @@ async fn wake_object(
 
         // Create if it doesn't exist
         if !mgr.exists(&sandbox_name) {
-            mgr.create(&sandbox_name, "alpine:3.20", 1, 256).await?;
+            mgr.create(&sandbox_name, "alpine:3.24", 1, 256).await?;
         }
 
         // Start if not running

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -344,7 +344,7 @@ command = "echo bad"
     fn test_pipeline_step_serde() {
         let step = PipelineStep {
             name: "test".to_string(),
-            image: "alpine:3.20".to_string(),
+            image: "alpine:3.24".to_string(),
             command: "echo hello".to_string(),
             input: Some("/in".to_string()),
             output: Some("/out".to_string()),

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -116,7 +116,7 @@ impl Drop for PersistentShell {
 /// Default pool configuration
 const DEFAULT_POOL_SIZE: usize = 10;
 const DEFAULT_MAX_POOL_SIZE: usize = 50;
-const DEFAULT_IMAGE: &str = "alpine:3.20";
+const DEFAULT_IMAGE: &str = "alpine:3.24";
 const GC_INTERVAL_MS: u64 = 1000;
 const GC_BATCH_SIZE: usize = 10;
 
@@ -687,7 +687,7 @@ mod tests {
     fn test_default_constants() {
         assert_eq!(DEFAULT_POOL_SIZE, 10);
         assert_eq!(DEFAULT_MAX_POOL_SIZE, 50);
-        assert_eq!(DEFAULT_IMAGE, "alpine:3.20");
+        assert_eq!(DEFAULT_IMAGE, "alpine:3.24");
         assert_eq!(GC_INTERVAL_MS, 1000);
         assert_eq!(GC_BATCH_SIZE, 10);
     }
@@ -735,7 +735,7 @@ mod tests {
     #[tokio::test]
     #[ignore] // Requires Docker
     async fn test_pool_basic() {
-        let pool = ContainerPool::with_config(2, 5, "alpine:3.20").unwrap();
+        let pool = ContainerPool::with_config(2, 5, "alpine:3.24").unwrap();
         pool.start().await.unwrap();
 
         // Acquire a container
@@ -762,7 +762,7 @@ mod tests {
     #[tokio::test]
     #[ignore] // Requires Docker
     async fn test_pool_acquire_release_cycle() {
-        let pool = ContainerPool::with_config(2, 5, "alpine:3.20").unwrap();
+        let pool = ContainerPool::with_config(2, 5, "alpine:3.24").unwrap();
         pool.start().await.unwrap();
 
         // Acquire and release multiple times
@@ -782,7 +782,7 @@ mod tests {
     #[tokio::test]
     #[ignore] // Requires Docker
     async fn test_pool_stats_after_operations() {
-        let pool = ContainerPool::with_config(2, 5, "alpine:3.20").unwrap();
+        let pool = ContainerPool::with_config(2, 5, "alpine:3.24").unwrap();
         pool.start().await.unwrap();
 
         // Initial stats

--- a/src/rootfs.rs
+++ b/src/rootfs.rs
@@ -303,7 +303,7 @@ echo "Conversion complete"
             &format!("{}:/input/agent:ro", agent_abs.display()),
             "-v",
             &format!("{}:/output", output_dir_abs.display()),
-            "alpine:3.20",
+            "alpine:3.24",
             "sh",
             "-c",
             &script,
@@ -351,6 +351,7 @@ mod tests {
 
     #[test]
     fn test_image_to_rootfs_name() {
+        // Legacy compatibility: explicit old image references still map to stable cache names.
         assert_eq!(image_to_rootfs_name("alpine:3.20"), "alpine-3.20.ext4");
         assert_eq!(
             image_to_rootfs_name("my-app/image:latest"),

--- a/src/sandbox_pool.rs
+++ b/src/sandbox_pool.rs
@@ -522,7 +522,7 @@ mod tests {
         // Try to detect available backend
         let backend = crate::backend::detect_best_backend().expect("No backend available");
 
-        let config = SandboxConfig::with_image("alpine:3.20");
+        let config = SandboxConfig::with_image("alpine:3.24");
         let pool = SandboxPool::with_config(backend, config, 2, 5).unwrap();
         pool.start().await.unwrap();
 
@@ -549,7 +549,7 @@ mod tests {
     #[ignore] // Requires Docker or Apple containers
     async fn test_sandbox_pool_stats_lifecycle() {
         let backend = crate::backend::detect_best_backend().expect("No backend available");
-        let config = SandboxConfig::with_image("alpine:3.20");
+        let config = SandboxConfig::with_image("alpine:3.24");
         let pool = SandboxPool::with_config(backend, config, 2, 5).unwrap();
 
         // Before start

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -310,9 +310,9 @@ fn initialize_apple_containers() -> Result<()> {
         println!("  Apple container system started");
 
         // Pre-pull alpine image for faster first run
-        println!("  Pre-pulling alpine:3.20 image...");
+        println!("  Pre-pulling alpine:3.24 image...");
         let _ = Command::new("container")
-            .args(["image", "pull", "alpine:3.20"])
+            .args(["image", "pull", "alpine:3.24"])
             .output();
 
         Ok(())
@@ -829,8 +829,8 @@ mkdir -p "$MOUNT_DIR"
 mount -o loop "$ROOTFS_IMG" "$MOUNT_DIR"
 
 echo "Installing Alpine base system..."
-apk -X https://dl-cdn.alpinelinux.org/alpine/v3.20/main \
-    -X https://dl-cdn.alpinelinux.org/alpine/v3.20/community \
+apk -X https://dl-cdn.alpinelinux.org/alpine/v3.24/main \
+    -X https://dl-cdn.alpinelinux.org/alpine/v3.24/community \
     -U --allow-untrusted --root "$MOUNT_DIR" --initdb \
     add alpine-base busybox-static $PACKAGES || true
 
@@ -941,7 +941,7 @@ ls -lh "$ROOTFS_IMG"
             &format!("{}:/build.sh:ro", script_path.display()),
             "-v",
             &format!("{}:/agent-bin:ro", data_dir.join("bin").display()),
-            "alpine:3.20",
+            "alpine:3.24",
             "/bin/sh",
             "/build.sh",
         ])
@@ -1089,7 +1089,7 @@ fn offer_plugin_install(non_interactive: bool) -> Result<()> {
 
 /// Common Docker images to pre-pull for faster container startup
 const DOCKER_IMAGES: &[&str] = &[
-    "alpine:3.20",        // Default pool image
+    "alpine:3.24",        // Default pool image
     "python:3.12-alpine", // Python runtime
     "node:20-alpine",     // Node.js runtime
     "golang:1.22-alpine", // Go runtime

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -454,7 +454,7 @@ mod tests {
             sandbox: "my-sandbox".to_string(),
             image_tag: "agentkernel-snap:test-snap".to_string(),
             backend: "docker".to_string(),
-            base_image: "alpine:3.20".to_string(),
+            base_image: "alpine:3.24".to_string(),
             vcpus: 2,
             memory_mb: 512,
             created_at: "2026-02-01T00:00:00Z".to_string(),

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -163,7 +163,7 @@ mod tests {
         let entries = vec![
             make_entry(AuditEvent::SandboxCreated {
                 name: "test1".to_string(),
-                image: "alpine:3.20".to_string(),
+                image: "alpine:3.24".to_string(),
                 backend: "docker".to_string(),
                 labels: Default::default(),
             }),
@@ -188,7 +188,7 @@ mod tests {
         assert_eq!(stats.sandboxes_created, 1);
         assert_eq!(stats.sandboxes_removed, 1);
         assert_eq!(stats.sandboxes_active, 0);
-        assert_eq!(stats.top_images, vec![("alpine:3.20".to_string(), 1)]);
+        assert_eq!(stats.top_images, vec![("alpine:3.24".to_string(), 1)]);
         assert_eq!(stats.top_backends, vec![("docker".to_string(), 1)]);
     }
 

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -502,6 +502,7 @@ mod tests {
 
     #[test]
     fn test_valid_docker_images() {
+        // Legacy compatibility: explicit old tags remain accepted.
         assert!(validate_docker_image("alpine:3.20").is_ok());
         assert!(validate_docker_image("python:3.12-alpine").is_ok());
         assert!(validate_docker_image("ghcr.io/user/image:latest").is_ok());

--- a/src/vmm.rs
+++ b/src/vmm.rs
@@ -78,7 +78,7 @@ static CONTAINER_POOL: OnceCell<Arc<ContainerPool>> = OnceCell::const_new();
 async fn get_pool() -> Result<Arc<ContainerPool>> {
     CONTAINER_POOL
         .get_or_try_init(|| async {
-            let pool = ContainerPool::with_config(5, 20, "alpine:3.20")?;
+            let pool = ContainerPool::with_config(5, 20, "alpine:3.24")?;
             pool.start().await?;
             Ok(Arc::new(pool))
         })
@@ -3127,7 +3127,7 @@ mod tests {
         let state = SandboxState {
             name: "test-sandbox".to_string(),
             uuid: uuid::Uuid::now_v7().to_string(),
-            image: "alpine:3.20".to_string(),
+            image: "alpine:3.24".to_string(),
             vcpus: 2,
             memory_mb: 1024,
             vsock_cid: 5,
@@ -3165,7 +3165,7 @@ mod tests {
 
         let json = serde_json::to_string(&state).unwrap();
         assert!(json.contains("test-sandbox"));
-        assert!(json.contains("alpine:3.20"));
+        assert!(json.contains("alpine:3.24"));
         assert!(json.contains("1024"));
     }
 
@@ -3287,11 +3287,11 @@ mod tests {
     fn test_load_sandboxes_with_files() {
         let temp_dir = TempDir::new().unwrap();
 
-        // Create a valid sandbox JSON file
+        // Legacy compatibility: persisted old image selections are loaded unchanged.
         let state = SandboxState {
             name: "loaded-sandbox".to_string(),
             uuid: uuid::Uuid::now_v7().to_string(),
-            image: "alpine:3.20".to_string(),
+            image: "alpine:3.20".to_string(), // legacy compatibility
             vcpus: 1,
             memory_mb: 256,
             vsock_cid: 4,
@@ -3340,7 +3340,7 @@ mod tests {
         assert!(sandboxes.contains_key("loaded-sandbox"));
 
         let loaded = &sandboxes["loaded-sandbox"];
-        assert_eq!(loaded.image, "alpine:3.20");
+        assert_eq!(loaded.image, "alpine:3.20"); // legacy compatibility
         assert_eq!(loaded.memory_mb, 256);
     }
 
@@ -3357,7 +3357,7 @@ mod tests {
         // Legacy state without UUID should be backfilled on load.
         let legacy = r#"{
             "name": "legacy-box",
-            "image": "alpine:3.20",
+            "image": "alpine:3.24",
             "vcpus": 1,
             "memory_mb": 256,
             "vsock_cid": 4,
@@ -3456,7 +3456,7 @@ mod tests {
         let state = SandboxState {
             name: "label-test".to_string(),
             uuid: uuid::Uuid::now_v7().to_string(),
-            image: "alpine:3.20".to_string(),
+            image: "alpine:3.24".to_string(),
             vcpus: 1,
             memory_mb: 512,
             vsock_cid: 3,
@@ -3529,7 +3529,7 @@ mod tests {
             let state = SandboxState {
                 name: name.to_string(),
                 uuid: uuid::Uuid::now_v7().to_string(),
-                image: "alpine:3.20".to_string(),
+                image: "alpine:3.24".to_string(),
                 vcpus: 1,
                 memory_mb: 512,
                 vsock_cid: 3,
@@ -3603,7 +3603,7 @@ mod tests {
         let state = SandboxState {
             name: "desc-test".to_string(),
             uuid: uuid::Uuid::now_v7().to_string(),
-            image: "alpine:3.20".to_string(),
+            image: "alpine:3.24".to_string(),
             vcpus: 1,
             memory_mb: 512,
             vsock_cid: 3,
@@ -3673,7 +3673,7 @@ mod tests {
         let state = SandboxState {
             name: "persist-test".to_string(),
             uuid: uuid::Uuid::now_v7().to_string(),
-            image: "alpine:3.20".to_string(),
+            image: "alpine:3.24".to_string(),
             vcpus: 1,
             memory_mb: 512,
             vsock_cid: 3,
@@ -3739,7 +3739,7 @@ mod tests {
         SandboxState {
             name: name.to_string(),
             uuid: uuid::Uuid::now_v7().to_string(),
-            image: "alpine:3.20".to_string(),
+            image: "alpine:3.24".to_string(),
             vcpus: 1,
             memory_mb: 256,
             vsock_cid: 3,

--- a/templates/bash.toml
+++ b/templates/bash.toml
@@ -3,7 +3,7 @@
 
 [sandbox]
 name = "bash"
-base_image = "alpine:3.20"
+base_image = "alpine:3.24"
 
 [resources]
 vcpus = 1

--- a/templates/secure.toml
+++ b/templates/secure.toml
@@ -3,7 +3,7 @@
 
 [sandbox]
 name = "secure"
-base_image = "alpine:3.20"
+base_image = "alpine:3.24"
 
 [resources]
 vcpus = 1

--- a/templates/sqlite.toml
+++ b/templates/sqlite.toml
@@ -3,7 +3,7 @@
 
 [sandbox]
 name = "sqlite"
-base_image = "alpine:3.20"
+base_image = "alpine:3.24"
 init_script = """
 set -e
 apk add --no-cache sqlite

--- a/tests/alpine_default_drift_test.rs
+++ b/tests/alpine_default_drift_test.rs
@@ -1,0 +1,72 @@
+use std::fs;
+use std::path::Path;
+
+const LEGACY_IMAGE: &str = concat!("alpine:3", ".20");
+
+fn scan(path: &Path, failures: &mut Vec<String>) {
+    let Ok(entries) = fs::read_dir(path) else {
+        return;
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let relative = path
+            .strip_prefix(env!("CARGO_MANIFEST_DIR"))
+            .unwrap_or(&path);
+        let relative_text = relative.to_string_lossy();
+
+        if path.is_dir() {
+            if matches!(
+                relative_text.as_ref(),
+                ".git" | ".beads" | "target" | "node_modules" | "sdk/nodejs/dist"
+            ) {
+                continue;
+            }
+            scan(&path, failures);
+            continue;
+        }
+
+        if relative_text == "plan/0001-platform-modernization.md"
+            || (relative_text.starts_with("autoresearch/") && relative_text.ends_with(".json"))
+        {
+            continue;
+        }
+
+        let Ok(contents) = fs::read_to_string(&path) else {
+            continue;
+        };
+        let lines: Vec<_> = contents.lines().collect();
+        for (index, line) in lines.iter().enumerate() {
+            if !line.contains(LEGACY_IMAGE) {
+                continue;
+            }
+
+            let previous = index
+                .checked_sub(1)
+                .and_then(|i| lines.get(i))
+                .copied()
+                .unwrap_or("");
+            if line.to_ascii_lowercase().contains("legacy compatibility")
+                || previous
+                    .to_ascii_lowercase()
+                    .contains("legacy compatibility")
+            {
+                continue;
+            }
+
+            failures.push(format!("{}:{}: {}", relative_text, index + 1, line.trim()));
+        }
+    }
+}
+
+#[test]
+fn alpine_320_only_appears_in_documented_legacy_compatibility_cases() {
+    let mut failures = Vec::new();
+    scan(Path::new(env!("CARGO_MANIFEST_DIR")), &mut failures);
+
+    assert!(
+        failures.is_empty(),
+        "Alpine 3.20 must not be a product default; annotate intentional compatibility coverage:\n{}",
+        failures.join("\n")
+    );
+}

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -97,6 +97,7 @@ fn test_run_help() {
 #[test]
 fn test_run_build_conflicts_with_explicit_image() {
     let (exit_code, _stdout, stderr) =
+        // Legacy compatibility: an explicit old tag is still parsed as an image choice.
         run_cmd(&["run", "--build", "--image", "alpine:3.20", "echo", "hello"]);
     assert_ne!(exit_code, 0);
     assert!(

--- a/tests/kubernetes_integration_test.rs
+++ b/tests/kubernetes_integration_test.rs
@@ -17,7 +17,7 @@ fn test_orch_config() -> agentkernel::config::OrchestratorConfig {
 
 fn test_sandbox_config() -> agentkernel::backend::SandboxConfig {
     agentkernel::backend::SandboxConfig {
-        image: "alpine:3.20".to_string(),
+        image: "alpine:3.24".to_string(),
         vcpus: 1,
         memory_mb: 256,
         mount_cwd: false,

--- a/tests/nomad_integration_test.rs
+++ b/tests/nomad_integration_test.rs
@@ -20,7 +20,7 @@ fn test_orch_config() -> agentkernel::config::OrchestratorConfig {
 
 fn test_sandbox_config() -> agentkernel::backend::SandboxConfig {
     agentkernel::backend::SandboxConfig {
-        image: "alpine:3.20".to_string(),
+        image: "alpine:3.24".to_string(),
         vcpus: 1,
         memory_mb: 256,
         mount_cwd: false,

--- a/tests/pool_benchmark.rs
+++ b/tests/pool_benchmark.rs
@@ -10,7 +10,7 @@ use std::time::{Duration, Instant};
 
 const ITERATIONS: usize = 20;
 const POOL_SIZE: usize = 5;
-const IMAGE: &str = "alpine:3.20";
+const IMAGE: &str = "alpine:3.24";
 
 fn get_binary_path() -> String {
     std::env::current_dir()

--- a/tests/sandbox_lifecycle_test.rs
+++ b/tests/sandbox_lifecycle_test.rs
@@ -333,7 +333,7 @@ fn test_run_with_image() {
         "--backend",
         "docker",
         "--image",
-        "alpine:3.20",
+        "alpine:3.20", // legacy compatibility: explicit old images still run
         "--",
         "cat",
         "/etc/alpine-release",

--- a/tests/sandbox_pool_benchmark.rs
+++ b/tests/sandbox_pool_benchmark.rs
@@ -19,7 +19,7 @@ async fn benchmark_sandbox_pool() {
 
     // Measure pool startup time
     let start = Instant::now();
-    let config = SandboxConfig::with_image("alpine:3.20");
+    let config = SandboxConfig::with_image("alpine:3.24");
     let pool = SandboxPool::with_config(backend, config, 3, 10).unwrap();
     pool.start().await.unwrap();
     let startup_time = start.elapsed();


### PR DESCRIPTION
## Summary
- migrate new, default, and recommended Alpine selections from 3.20 to 3.24 across core, API, MCP, desktop, Helm, SDK-facing surfaces, templates, examples, scripts, and docs
- preserve explicit and persisted alpine:3.20 selections without rewriting them
- add a repository-wide drift test that rejects unannotated Alpine 3.20 product defaults

## Validation
- cargo fmt --all -- --check
- cargo test --test alpine_default_drift_test
- cargo test --lib: 325 passed, 2 ignored
- cargo test --bin agentkernel: 605 passed, 5 ignored
- cargo test --test cli_test: 25 passed
- npm run build in app
- JavaScript syntax checks for remote bridge and Pi extension entrypoints
- YAML parsing for OpenAPI and Helm values; shell syntax checks for changed scripts
- docker run --rm alpine:3.24 cat /etc/alpine-release returned 3.24.1

Helm CLI was not available locally, so chart rendering was not run. The values and OpenAPI documents parse successfully as YAML.