### PR TITLE
chore(app): upgrade Lucide icons

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -8,6 +8,7 @@
       "name": "agentkernel-desktop",
       "version": "0.19.0",
       "dependencies": {
+        "@primer/octicons-react": "^19.33.0",
         "@radix-ui/react-dialog": "^1.1.23",
         "@radix-ui/react-dropdown-menu": "^2.1.24",
         "@radix-ui/react-select": "^2.3.7",
@@ -21,7 +22,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.4.0",
-        "lucide-react": "^0.468.0",
+        "lucide-react": "^1.33.0",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
         "react-router-dom": "^7.18.2",
@@ -134,6 +135,18 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@primer/octicons-react": {
+      "version": "19.33.0",
+      "resolved": "https://registry.npmjs.org/@primer/octicons-react/-/octicons-react-19.33.0.tgz",
+      "integrity": "sha512-7VL8WuLXXZvUV/DP895ESFXPl/FJq816amCT3KZcmpQgxM1uv6lJGCcsEFpLX3K6SE+3qcmsftPpxn3ctr06+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "react": ">=16.3"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -2773,12 +2786,12 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.468.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.468.0.tgz",
-      "integrity": "sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.33.0.tgz",
+      "integrity": "sha512-MTRwMy0ZlL8Ur/vOAiJ9XGHE+kFPC7brq6MxAm0GiGXEBj0qy0jA/pG4N675oSzciO/UCdX8T+5yUQdmDeTLxg==",
       "license": "ISC",
       "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/app/package.json
+++ b/app/package.json
@@ -10,6 +10,7 @@
     "tauri": "tauri"
   },
   "dependencies": {
+    "@primer/octicons-react": "^19.33.0",
     "@radix-ui/react-dialog": "^1.1.23",
     "@radix-ui/react-dropdown-menu": "^2.1.24",
     "@radix-ui/react-select": "^2.3.7",
@@ -23,7 +24,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.4.0",
-    "lucide-react": "^0.468.0",
+    "lucide-react": "^1.33.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "react-router-dom": "^7.18.2",

--- a/app/src/components/layout/sidebar.tsx
+++ b/app/src/components/layout/sidebar.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { NavLink, Link } from "react-router-dom";
+import { MarkGithubIcon } from "@primer/octicons-react/MarkGithubIcon";
 import {
   LayoutDashboard,
   Box,
@@ -19,7 +20,6 @@ import {
   Timer,
   Database,
   BookOpen,
-  Github,
   ExternalLink,
   ShieldCheck,
   ShieldOff,
@@ -265,10 +265,12 @@ export function Sidebar() {
             <ExternalLink className="h-2.5 w-2.5" />
           </button>
           <button
+            type="button"
+            aria-label="Open AgentKernel on GitHub"
             onClick={() => open("https://github.com/thrashr888/agentkernel")}
             className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
           >
-            <Github className="h-3 w-3" />
+            <MarkGithubIcon className="h-3 w-3" size={12} />
             GitHub
             <ExternalLink className="h-2.5 w-2.5" />
           </button>


### PR DESCRIPTION
## Summary
- upgrade lucide-react from 0.468 to 1.33
- replace the removed GitHub glyph with GitHub Primer's official MarkGithubIcon
- preserve the existing 12px currentColor treatment and accessible button labeling

## Validation
- npm ci and production build
- native-loader build and npm audit (0 vulnerabilities)
- rendered-markup accessibility smoke
- Tauri Rust 1.89 fmt, check, strict Clippy, and tests

Tracks agentkernel-nl7s.1.