### PR TITLE
ci: enforce platform compatibility follow-ups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main, codex/apple-container-1-2-modernization]
+    branches: [main, codex/apple-container-1-2-modernization, codex/modernization-followups]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/hyperlight.yml
+++ b/.github/workflows/hyperlight.yml
@@ -31,6 +31,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: hyperlight
+          # hyperlight-wasm builds a nested guest runtime under target/. Restoring
+          # only part of that tree can leave an include_bytes! path dangling.
+          cache-targets: false
       - name: Check Hyperlight-only build
         run: cargo check --locked --lib --no-default-features --features hyperlight
       - name: Lint Hyperlight-only build
@@ -44,7 +47,6 @@ jobs:
     # hyperlight-wasm 0.14 pins the pre-arm64 hyperlight-host 0.14 line. Keep
     # probing the native target, but do not block releases until upstream ships
     # a Rust 1.89-compatible hyperlight-wasm that consumes hyperlight-host 0.16+.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@master
@@ -53,8 +55,26 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: hyperlight-arm64
+          cache-targets: false
       - name: Probe native arm64 Hyperlight-only build
-        run: cargo check --locked --lib --no-default-features --features hyperlight
+        run: |
+          set +e
+          cargo check --locked --lib --no-default-features --features hyperlight 2>&1 | tee hyperlight-arm64.log
+          status=${PIPESTATUS[0]}
+          set -e
+
+          if [[ "$status" -eq 0 ]]; then
+            exit 0
+          fi
+
+          if grep -q 'hyperlight-host-0.14.0/src/' hyperlight-arm64.log \
+            && grep -q 'error\[E0061\]' hyperlight-arm64.log; then
+            echo '::warning::Known upstream hyperlight-host 0.14 arm64 compiler failure; exception expires 2026-11-30.'
+            exit 0
+          fi
+
+          echo 'Hyperlight arm64 failed for a reason outside the bounded upstream exception.'
+          exit "$status"
 
   arm64-exception-expiry:
     name: Hyperlight arm64 exception expiry

--- a/.github/workflows/hyperlight.yml
+++ b/.github/workflows/hyperlight.yml
@@ -59,16 +59,32 @@ jobs:
       - name: Probe native arm64 Hyperlight-only build
         run: |
           set +e
-          cargo check --locked --lib --no-default-features --features hyperlight 2>&1 | tee hyperlight-arm64.log
-          status=${PIPESTATUS[0]}
+          cargo check --locked --lib --no-default-features --features hyperlight \
+            --message-format=json > hyperlight-arm64.json 2> hyperlight-arm64.stderr
+          status=$?
           set -e
 
           if [[ "$status" -eq 0 ]]; then
-            exit 0
+            echo 'Hyperlight arm64 now compiles; remove the exception and enable blocking arm64 lint/tests.'
+            exit 1
           fi
 
-          if grep -q 'hyperlight-host-0.14.0/src/' hyperlight-arm64.log \
-            && grep -q 'error\[E0061\]' hyperlight-arm64.log; then
+          cat hyperlight-arm64.stderr
+          jq -r 'select(.reason == "compiler-message" and .message.level == "error") | .message.rendered' \
+            hyperlight-arm64.json
+
+          error_count=$(jq -s '[.[] | select(.reason == "compiler-message" and .message.level == "error")] | length' hyperlight-arm64.json)
+          known_count=$(jq -s '[.[] | select(
+            .reason == "compiler-message"
+            and .message.level == "error"
+            and .message.code.code == "E0061"
+            and any(.message.spans[]?;
+              .is_primary
+              and (.file_name | endswith("/hyperlight-host-0.14.0/src/sandbox/uninitialized_evolve.rs"))
+            )
+          )] | length' hyperlight-arm64.json)
+
+          if [[ "$error_count" -eq 1 && "$known_count" -eq 1 ]]; then
             echo '::warning::Known upstream hyperlight-host 0.14 arm64 compiler failure; exception expires 2026-11-30.'
             exit 0
           fi

--- a/.github/workflows/hyperlight.yml
+++ b/.github/workflows/hyperlight.yml
@@ -2,7 +2,7 @@ name: Hyperlight
 
 on:
   pull_request:
-    branches: [main, codex/apple-container-1-2-modernization]
+    branches: [main, codex/apple-container-1-2-modernization, codex/modernization-followups]
     paths:
       - Cargo.toml
       - Cargo.lock
@@ -11,6 +11,8 @@ on:
       - tests/hyperlight_benchmark.rs
       - .github/workflows/hyperlight.yml
   workflow_dispatch:
+  schedule:
+    - cron: "31 9 * * 1"
 
 env:
   CARGO_TERM_COLOR: always
@@ -35,3 +37,32 @@ jobs:
         run: cargo clippy --locked --lib --no-default-features --features hyperlight -- -D warnings
       - name: Test Hyperlight-only library
         run: cargo test --locked --lib --no-default-features --features hyperlight
+
+  arm64-upstream-probe:
+    name: Hyperlight feature (Linux arm64 upstream probe)
+    runs-on: ubuntu-24.04-arm
+    # hyperlight-wasm 0.14 pins the pre-arm64 hyperlight-host 0.14 line. Keep
+    # probing the native target, but do not block releases until upstream ships
+    # a Rust 1.89-compatible hyperlight-wasm that consumes hyperlight-host 0.16+.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: hyperlight-arm64
+      - name: Probe native arm64 Hyperlight-only build
+        run: cargo check --locked --lib --no-default-features --features hyperlight
+
+  arm64-exception-expiry:
+    name: Hyperlight arm64 exception expiry
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce bounded upstream exception
+        run: |
+          if [[ "$(date -u +%Y-%m-%d)" > "2026-11-30" ]]; then
+            echo "Hyperlight arm64 exception expired; re-evaluate the published hyperlight-wasm line."
+            exit 1
+          fi

--- a/.github/workflows/nomad-compatibility.yml
+++ b/.github/workflows/nomad-compatibility.yml
@@ -1,0 +1,75 @@
+name: Nomad compatibility
+
+on:
+  pull_request:
+    branches: [main, codex/apple-container-1-2-modernization, codex/modernization-followups]
+    paths:
+      - Cargo.toml
+      - Cargo.lock
+      - src/backend/nomad.rs
+      - src/config.rs
+      - tests/nomad_integration_test.rs
+      - .github/workflows/nomad-compatibility.yml
+  schedule:
+    - cron: "17 10 * * 2"
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_VERSION: "1.89"
+  NOMAD_ADDR: http://127.0.0.1:4646
+  NOMAD_TEST_DRIVER: exec
+
+jobs:
+  compatibility:
+    name: Nomad ${{ matrix.nomad }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        nomad: ["1.10.5", "2.0.4"]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: nomad-${{ matrix.nomad }}
+      - name: Install verified Nomad release
+        env:
+          NOMAD_VERSION: ${{ matrix.nomad }}
+        run: |
+          curl --fail --silent --show-error --location \
+            --output nomad.zip \
+            "https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_linux_amd64.zip"
+          curl --fail --silent --show-error --location \
+            --output SHA256SUMS \
+            "https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_SHA256SUMS"
+          grep " nomad_${NOMAD_VERSION}_linux_amd64.zip$" SHA256SUMS > SHA256SUMS.linux
+          sha256sum --check SHA256SUMS.linux
+          unzip -q nomad.zip
+          sudo install nomad /usr/local/bin/nomad
+          nomad version
+      - name: Start Nomad development agent
+        run: |
+          nomad agent -dev -bind=127.0.0.1 > nomad.log 2>&1 &
+          for attempt in {1..30}; do
+            if curl --fail --silent "${NOMAD_ADDR}/v1/status/leader" > /dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          cat nomad.log
+          exit 1
+      - name: Run lifecycle compatibility smoke
+        run: >-
+          cargo test --locked --test nomad_integration_test --features nomad
+          test_nomad_lifecycle -- --ignored --nocapture --test-threads=1
+      - name: Run exec environment compatibility smoke
+        run: >-
+          cargo test --locked --test nomad_integration_test --features nomad
+          test_nomad_exec_with_env -- --ignored --nocapture --test-threads=1
+      - name: Show Nomad log on failure
+        if: failure()
+        run: cat nomad.log

--- a/.github/workflows/nomad-compatibility.yml
+++ b/.github/workflows/nomad-compatibility.yml
@@ -41,14 +41,14 @@ jobs:
           NOMAD_VERSION: ${{ matrix.nomad }}
         run: |
           curl --fail --silent --show-error --location \
-            --output nomad.zip \
+            --output "nomad_${NOMAD_VERSION}_linux_amd64.zip" \
             "https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_linux_amd64.zip"
           curl --fail --silent --show-error --location \
             --output SHA256SUMS \
             "https://releases.hashicorp.com/nomad/${NOMAD_VERSION}/nomad_${NOMAD_VERSION}_SHA256SUMS"
           grep " nomad_${NOMAD_VERSION}_linux_amd64.zip$" SHA256SUMS > SHA256SUMS.linux
           sha256sum --check SHA256SUMS.linux
-          unzip -q nomad.zip
+          unzip -q "nomad_${NOMAD_VERSION}_linux_amd64.zip"
           sudo install nomad /usr/local/bin/nomad
           nomad version
       - name: Start Nomad development agent
@@ -72,4 +72,4 @@ jobs:
           test_nomad_exec_with_env -- --ignored --nocapture --test-threads=1
       - name: Show Nomad log on failure
         if: failure()
-        run: cat nomad.log
+        run: test ! -f nomad.log || cat nomad.log

--- a/.github/workflows/nomad-compatibility.yml
+++ b/.github/workflows/nomad-compatibility.yml
@@ -18,7 +18,7 @@ env:
   CARGO_TERM_COLOR: always
   RUST_VERSION: "1.89"
   NOMAD_ADDR: http://127.0.0.1:4646
-  NOMAD_TEST_DRIVER: exec
+  NOMAD_TEST_DRIVER: docker
 
 jobs:
   compatibility:
@@ -53,10 +53,12 @@ jobs:
           nomad version
       - name: Start Nomad development agent
         run: |
-          # Nomad's Linux exec driver requires the client agent to run as root.
+          # Nomad's Linux client needs root for task-driver resource isolation.
           sudo nomad agent -dev -bind=127.0.0.1 > nomad.log 2>&1 &
           for attempt in {1..30}; do
-            if curl --fail --silent "${NOMAD_ADDR}/v1/status/leader" > /dev/null; then
+            if nomad node status -self -json 2>/dev/null \
+              | jq -e '.Status == "ready" and .Drivers.docker.Detected and .Drivers.docker.Healthy' \
+              > /dev/null; then
               exit 0
             fi
             sleep 1
@@ -73,4 +75,7 @@ jobs:
           test_nomad_exec_with_env -- --ignored --nocapture --test-threads=1
       - name: Show Nomad log on failure
         if: failure()
-        run: test ! -f nomad.log || cat nomad.log
+        run: |
+          nomad node status -self -verbose || true
+          nomad job status || true
+          test ! -f nomad.log || cat nomad.log

--- a/.github/workflows/nomad-compatibility.yml
+++ b/.github/workflows/nomad-compatibility.yml
@@ -53,7 +53,8 @@ jobs:
           nomad version
       - name: Start Nomad development agent
         run: |
-          nomad agent -dev -bind=127.0.0.1 > nomad.log 2>&1 &
+          # Nomad's Linux exec driver requires the client agent to run as root.
+          sudo nomad agent -dev -bind=127.0.0.1 > nomad.log 2>&1 &
           for attempt in {1..30}; do
             if curl --fail --silent "${NOMAD_ADDR}/v1/status/leader" > /dev/null; then
               exit 0

--- a/.github/workflows/rust-feature-matrix.yml
+++ b/.github/workflows/rust-feature-matrix.yml
@@ -1,0 +1,49 @@
+name: Rust feature matrix
+
+on:
+  pull_request:
+    branches: [main, codex/apple-container-1-2-modernization, codex/modernization-followups]
+    paths:
+      - Cargo.toml
+      - Cargo.lock
+      - src/**
+      - tests/**
+      - .github/workflows/rust-feature-matrix.yml
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_VERSION: "1.89"
+
+jobs:
+  check:
+    name: Rust 1.89 / ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: no default features
+            features: ""
+          - name: Kubernetes only
+            features: kubernetes
+          - name: Nomad only
+            features: nomad
+          - name: enterprise only
+            features: enterprise
+          - name: orchestrators combined
+            features: kubernetes,nomad,enterprise
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: feature-${{ matrix.name }}
+      - name: Check supported feature set
+        if: matrix.features != ''
+        run: cargo check --locked --no-default-features --features "${{ matrix.features }}"
+      - name: Check no-default baseline
+        if: matrix.features == ''
+        run: cargo check --locked --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,9 @@ include = [
 [features]
 default = ["kubernetes", "nomad", "enterprise"]
 hyperlight = ["dep:hyperlight-wasm"]
-kubernetes = ["dep:kube", "dep:k8s-openapi", "dep:schemars", "dep:serde_yaml", "dep:futures"]
-nomad = ["dep:reqwest"]
-enterprise = ["dep:cedar-policy", "dep:ed25519-dalek", "dep:jsonwebtoken", "dep:reqwest"]
+kubernetes = ["dep:kube", "dep:k8s-openapi", "dep:schemars", "dep:serde_yaml"]
+nomad = []
+enterprise = ["dep:cedar-policy", "dep:ed25519-dalek", "dep:jsonwebtoken"]
 
 [dependencies]
 anyhow = "1.0"
@@ -59,6 +59,7 @@ dirs = "6.0.0"
 sysinfo = "=0.38.4"
 urlencoding = "2"
 tokio-stream = "0.1"
+futures = "0.3"
 
 # SSH support (CA key generation and client key signing)
 ssh-key = { version = "0.6", features = ["ed25519", "getrandom"] }
@@ -82,15 +83,16 @@ kube = { version = "4.2", features = ["client", "runtime", "ws", "derive"], opti
 k8s-openapi = { version = "0.28", features = ["latest"], optional = true }
 schemars = { version = "1.2", optional = true }
 thiserror = "2"
-futures = { version = "0.3", optional = true }
 serde_yaml = { version = "0.9", optional = true }
+
+# Shared HTTP client used by core runtimes and the optional Nomad backend.
+reqwest = { version = "0.13", default-features = false, features = ["charset", "form", "http2", "json", "rustls", "stream", "system-proxy"] }
 
 # Nomad backend (optional, behind "nomad" feature flag)
 # Enterprise policy engine (optional, behind "enterprise" feature)
 cedar-policy = { version = "4", optional = true }
 ed25519-dalek = { version = "3", features = ["rand_core"], optional = true }
 jsonwebtoken = { version = "11", features = ["rust_crypto"], optional = true }
-reqwest = { version = "0.13", default-features = false, features = ["charset", "form", "http2", "json", "rustls", "stream", "system-proxy"], optional = true }
 webpki-roots = "1.0.6"
 
 # Unix socket support for Firecracker API

--- a/docs/operations/dependency-compatibility.md
+++ b/docs/operations/dependency-compatibility.md
@@ -3,8 +3,9 @@
 AgentKernel validates optional Rust feature sets at the package's Rust 1.89
 minimum supported version. The pull-request matrix covers no-default,
 Kubernetes-only, Nomad-only, enterprise-only, and the combined orchestrator
-features. The scheduled Nomad matrix runs lifecycle and exec smoke tests against
-Nomad 1.10.5 (the final 1.10 LTS community release) and Nomad 2.0.4.
+features. The scheduled Nomad matrix runs lifecycle and exec smoke tests with
+the default Docker task driver against Nomad 1.10.5 (the final 1.10 LTS
+community release) and Nomad 2.0.4.
 
 ## Hyperlight arm64 exception
 

--- a/docs/operations/dependency-compatibility.md
+++ b/docs/operations/dependency-compatibility.md
@@ -1,0 +1,33 @@
+# Dependency compatibility gates
+
+AgentKernel validates optional Rust feature sets at the package's Rust 1.89
+minimum supported version. The pull-request matrix covers no-default,
+Kubernetes-only, Nomad-only, enterprise-only, and the combined orchestrator
+features. The scheduled Nomad matrix runs lifecycle and exec smoke tests against
+Nomad 1.10.5 (the final 1.10 LTS community release) and Nomad 2.0.4.
+
+## Hyperlight arm64 exception
+
+Hyperlight remains fully required on Linux x86_64. Its check, strict Clippy, and
+library tests run on every relevant pull request.
+
+Native Linux arm64 is temporarily a visible, non-blocking probe through
+**2026-11-30**. The current published `hyperlight-wasm` release is 0.14.0 and
+requires `hyperlight-host ^0.14.0`. Initial KVM/aarch64 host support landed after
+that line and is available in `hyperlight-host` 0.16.0, but no corresponding
+`hyperlight-wasm` release has been published. Depending on an unpublished moving
+Git revision would weaken lockfile reproducibility and dependency auditing, so
+AgentKernel stays on the latest published Rust 1.89-compatible Wasm adapter.
+
+The exception must be removed or renewed before its expiry. Remove it as soon as
+upstream publishes a Rust 1.89-compatible `hyperlight-wasm` that consumes the
+arm64-capable host line, then make the native arm64 check blocking and add its
+Clippy and library-test gates.
+
+Primary upstream references:
+
+- [Published hyperlight-wasm releases](https://crates.io/crates/hyperlight-wasm/versions)
+- [Initial Hyperlight KVM/aarch64 support](https://github.com/hyperlight-dev/hyperlight/pull/1474)
+- [Open Hyperlight aarch64 support tracker](https://github.com/hyperlight-dev/hyperlight/issues/677)
+- [Nomad 1.10 release notes](https://developer.hashicorp.com/nomad/docs/release-notes/v1-10-x)
+- [Nomad 2.0 release notes](https://developer.hashicorp.com/nomad/docs/release-notes/v2-0-x)

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -24,3 +24,4 @@ Both backends are included in the default build. You must specify `--backend kub
 - [Nomad Backend](nomad.md) — Jobs, parameterized warm pools, task drivers, Nomad Pack deployment
 - [Remote Backends](remote.md) — Daytona, Runloop, and E2B setup, `/workspace` sync, snapshots, and examples
 - [Deployment Guide](deploy.md) — Docker image, building from source, HTTP API reference
+- [Dependency compatibility](dependency-compatibility.md) — Rust feature, Nomad version, and Hyperlight platform gates

--- a/src/vmm.rs
+++ b/src/vmm.rs
@@ -32,7 +32,9 @@ pub struct CommandFailed {
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, LazyLock};
+use std::sync::Arc;
+#[cfg(feature = "enterprise")]
+use std::sync::LazyLock;
 use tokio::sync::RwLock;
 
 /// Global proxy handle registry. Proxy handles must outlive individual VmManager

--- a/tests/nomad_integration_test.rs
+++ b/tests/nomad_integration_test.rs
@@ -12,7 +12,7 @@ fn test_orch_config() -> agentkernel::config::OrchestratorConfig {
     agentkernel::config::OrchestratorConfig {
         nomad_addr: std::env::var("NOMAD_ADDR").ok(),
         nomad_token: std::env::var("NOMAD_TOKEN").ok(),
-        nomad_driver: "docker".to_string(),
+        nomad_driver: std::env::var("NOMAD_TEST_DRIVER").unwrap_or_else(|_| "docker".to_string()),
         nomad_datacenter: Some("dc1".to_string()),
         ..Default::default()
     }


### PR DESCRIPTION
## Summary
- restore Rust 1.89 no-default feature compilation for Kubernetes, Nomad, enterprise, and combined builds
- add live Nomad 1.10 LTS and 2.0 compatibility lanes
- keep Hyperlight x86_64 blocking while adding a visible arm64 upstream probe
- enforce a 2026-11-30 expiry for the bounded arm64 exception and document the upstream release gap

## Validation
- exact Rust 1.89 no-default feature matrix: bare, Kubernetes, Nomad, enterprise, and combined
- default strict Clippy and tests
- workflow syntax and Nomad integration test coverage

Tracks agentkernel-zvvh.3.1 and agentkernel-zvvh.3.2.