### PR TITLE
perf: cache VM manager config and policy setup

### DIFF
--- a/src/benchmark.rs
+++ b/src/benchmark.rs
@@ -41,6 +41,7 @@ struct BenchmarkStats {
     remove: Vec<Duration>,
     startup: Vec<Duration>,
     lifecycle_total: Vec<Duration>,
+    /// End-to-end `agentkernel run` latency, including process/config startup.
     cli_total: Vec<Duration>,
 }
 
@@ -143,6 +144,7 @@ pub struct BackendBenchmarkReport {
     pub startup: MetricSummary,
     pub exec: MetricSummary,
     pub lifecycle_total: MetricSummary,
+    /// End-to-end `agentkernel run` latency, including process/config startup.
     pub total: MetricSummary,
     pub throughput_per_second: f64,
     pub scores: ScoreBreakdown,
@@ -521,6 +523,26 @@ mod tests {
         };
         assert_eq!(r.startup(), Duration::from_millis(30));
         assert_eq!(r.lifecycle_total(), Duration::from_millis(80));
+    }
+
+    #[test]
+    fn test_report_uses_end_to_end_cli_latency_for_total_score() {
+        let mut stats = BenchmarkStats::new(BackendType::Docker, 0);
+        stats.push(IterResult {
+            create: Duration::from_millis(10),
+            start: Duration::from_millis(20),
+            exec: Duration::from_millis(30),
+            stop: Duration::from_millis(15),
+            remove: Duration::from_millis(5),
+            // This includes process startup, config loading, and the actual
+            // `agentkernel run` invocation measured by the harness.
+            cli_total: Duration::from_millis(250),
+        });
+
+        let report = stats.to_report();
+        assert_eq!(report.lifecycle_total.avg_ms, 80.0);
+        assert_eq!(report.total.avg_ms, 250.0);
+        assert!(report.scores.latency_score < report.scores.startup_score);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,6 +9,7 @@ use std::time::SystemTime;
 
 use crate::backend::FileInjection;
 use crate::permissions::SecurityProfile;
+use sha2::{Digest, Sha256};
 
 /// LLM key configuration: maps API domain → vault key name.
 ///
@@ -21,18 +22,30 @@ use crate::permissions::SecurityProfile;
 pub type LlmKeysConfig = std::collections::BTreeMap<String, String>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct ConfigFingerprint {
+pub(crate) struct ConfigFingerprint {
     modified: Option<SystemTime>,
     len: u64,
+    content_hash: [u8; 32],
 }
 
 impl ConfigFingerprint {
+    #[allow(dead_code)]
     fn for_path(path: &Path) -> Option<Self> {
         let metadata = std::fs::metadata(path).ok()?;
+        let content = std::fs::read(path).ok()?;
         Some(Self {
             modified: metadata.modified().ok(),
             len: metadata.len(),
+            content_hash: Sha256::digest(content).into(),
         })
+    }
+
+    fn from_metadata_and_content(metadata: &std::fs::Metadata, content: &[u8]) -> Self {
+        Self {
+            modified: metadata.modified().ok(),
+            len: metadata.len(),
+            content_hash: Sha256::digest(content).into(),
+        }
     }
 }
 
@@ -996,50 +1009,56 @@ impl Config {
     /// Commands commonly load the same `agentkernel.toml` more than once while
     /// resolving an image, permissions, and file injections.  Keep those
     /// repeated reads cheap without making a long-lived server blind to edits:
-    /// the cache entry is refreshed whenever the file's size or modification
-    /// timestamp changes.  A cloned value is returned so callers retain the
-    /// ownership and mutation semantics of [`Self::from_file`].
+    /// the cache entry is refreshed whenever the file's metadata or content
+    /// changes.  A cloned value is returned so callers retain the ownership
+    /// and mutation semantics of [`Self::from_file`].
     pub fn from_file_cached(path: &Path) -> Result<Self> {
         let cache_path = if path.is_absolute() {
             path.to_path_buf()
         } else {
             std::env::current_dir()?.join(path)
         };
-        let fingerprint = ConfigFingerprint::for_path(&cache_path);
+        let metadata = std::fs::metadata(path)
+            .with_context(|| format!("Failed to read config file: {}", path.display()))?;
+        let content = std::fs::read(path)
+            .with_context(|| format!("Failed to read config file: {}", path.display()))?;
+        let fingerprint = ConfigFingerprint::from_metadata_and_content(&metadata, &content);
 
-        if let Some(fingerprint) = fingerprint.as_ref()
-            && let Some(entry) = CONFIG_CACHE
-                .lock()
-                .expect("config cache lock poisoned")
-                .get(&cache_path)
-            && entry.fingerprint == *fingerprint
+        if let Some(entry) = CONFIG_CACHE
+            .lock()
+            .expect("config cache lock poisoned")
+            .get(&cache_path)
+            && entry.fingerprint == fingerprint
         {
             return Ok((*entry.config).clone());
         }
 
-        let config = Arc::new(Self::from_file(path)?);
+        let content = String::from_utf8(content)
+            .with_context(|| format!("Failed to read config file: {}", path.display()))?;
+        let config = Arc::new(Self::from_str(&content)?);
 
-        // A file can disappear between metadata() and read_to_string().  In
-        // that case the load above returns an error and no stale entry is
-        // installed.  Successful loads always have a current fingerprint.
-        if let Some(fingerprint) = ConfigFingerprint::for_path(&cache_path) {
-            let mut cache = CONFIG_CACHE.lock().expect("config cache lock poisoned");
-            if cache.len() >= MAX_CACHED_CONFIGS
-                && !cache.contains_key(&cache_path)
-                && let Some(evicted) = cache.keys().next().cloned()
-            {
-                cache.remove(&evicted);
-            }
-            cache.insert(
-                cache_path,
-                CachedConfig {
-                    fingerprint,
-                    config: Arc::clone(&config),
-                },
-            );
+        let mut cache = CONFIG_CACHE.lock().expect("config cache lock poisoned");
+        if cache.len() >= MAX_CACHED_CONFIGS
+            && !cache.contains_key(&cache_path)
+            && let Some(evicted) = cache.keys().next().cloned()
+        {
+            cache.remove(&evicted);
         }
+        cache.insert(
+            cache_path,
+            CachedConfig {
+                fingerprint,
+                config: Arc::clone(&config),
+            },
+        );
 
         Ok((*config).clone())
+    }
+
+    /// Return a content-sensitive fingerprint for a config file.
+    #[allow(dead_code)]
+    pub(crate) fn file_fingerprint(path: &Path) -> Option<ConfigFingerprint> {
+        ConfigFingerprint::for_path(path)
     }
 
     /// Parse configuration from a TOML string.
@@ -1835,18 +1854,21 @@ mod tests {
     fn test_cached_config_reloads_when_file_changes() {
         let temp_dir = tempfile::tempdir().unwrap();
         let path = temp_dir.path().join("agentkernel.toml");
-        std::fs::write(&path, "[sandbox]\nname = \"first\"\n").unwrap();
+        let first_contents = "[sandbox]\nname = \"alpha\"\n";
+        let updated_contents = "[sandbox]\nname = \"omega\"\n";
+        assert_eq!(first_contents.len(), updated_contents.len());
+        std::fs::write(&path, first_contents).unwrap();
 
         let first = Config::from_file_cached(&path).unwrap();
         let cached = Config::from_file_cached(&path).unwrap();
-        assert_eq!(first.sandbox.name, "first");
-        assert_eq!(cached.sandbox.name, "first");
+        assert_eq!(first.sandbox.name, "alpha");
+        assert_eq!(cached.sandbox.name, "alpha");
 
-        // Change the file size as well as its contents so this remains
-        // deterministic on filesystems with coarse timestamp resolution.
-        std::fs::write(&path, "[sandbox]\nname = \"updated-config\"\n").unwrap();
+        // Same-length rewrites must invalidate the cache even on filesystems
+        // whose modification timestamps have coarse resolution.
+        std::fs::write(&path, updated_contents).unwrap();
         let updated = Config::from_file_cached(&path).unwrap();
-        assert_eq!(updated.sandbox.name, "updated-config");
+        assert_eq!(updated.sandbox.name, "omega");
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,10 @@
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
-use std::path::Path;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, LazyLock, Mutex};
+use std::time::SystemTime;
 
 use crate::backend::FileInjection;
 use crate::permissions::SecurityProfile;
@@ -16,6 +19,33 @@ use crate::permissions::SecurityProfile;
 /// "api.anthropic.com" = "ANTHROPIC_API_KEY"
 /// ```
 pub type LlmKeysConfig = std::collections::BTreeMap<String, String>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ConfigFingerprint {
+    modified: Option<SystemTime>,
+    len: u64,
+}
+
+impl ConfigFingerprint {
+    fn for_path(path: &Path) -> Option<Self> {
+        let metadata = std::fs::metadata(path).ok()?;
+        Some(Self {
+            modified: metadata.modified().ok(),
+            len: metadata.len(),
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CachedConfig {
+    fingerprint: ConfigFingerprint,
+    config: Arc<Config>,
+}
+
+static CONFIG_CACHE: LazyLock<Mutex<HashMap<PathBuf, CachedConfig>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+const MAX_CACHED_CONFIGS: usize = 64;
 
 /// File entry for injecting files into the sandbox at startup
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -961,6 +991,57 @@ impl Config {
         Self::from_str(&content)
     }
 
+    /// Load a configuration file through the process-local parsed-config cache.
+    ///
+    /// Commands commonly load the same `agentkernel.toml` more than once while
+    /// resolving an image, permissions, and file injections.  Keep those
+    /// repeated reads cheap without making a long-lived server blind to edits:
+    /// the cache entry is refreshed whenever the file's size or modification
+    /// timestamp changes.  A cloned value is returned so callers retain the
+    /// ownership and mutation semantics of [`Self::from_file`].
+    pub fn from_file_cached(path: &Path) -> Result<Self> {
+        let cache_path = if path.is_absolute() {
+            path.to_path_buf()
+        } else {
+            std::env::current_dir()?.join(path)
+        };
+        let fingerprint = ConfigFingerprint::for_path(&cache_path);
+
+        if let Some(fingerprint) = fingerprint.as_ref()
+            && let Some(entry) = CONFIG_CACHE
+                .lock()
+                .expect("config cache lock poisoned")
+                .get(&cache_path)
+            && entry.fingerprint == *fingerprint
+        {
+            return Ok((*entry.config).clone());
+        }
+
+        let config = Arc::new(Self::from_file(path)?);
+
+        // A file can disappear between metadata() and read_to_string().  In
+        // that case the load above returns an error and no stale entry is
+        // installed.  Successful loads always have a current fingerprint.
+        if let Some(fingerprint) = ConfigFingerprint::for_path(&cache_path) {
+            let mut cache = CONFIG_CACHE.lock().expect("config cache lock poisoned");
+            if cache.len() >= MAX_CACHED_CONFIGS
+                && !cache.contains_key(&cache_path)
+                && let Some(evicted) = cache.keys().next().cloned()
+            {
+                cache.remove(&evicted);
+            }
+            cache.insert(
+                cache_path,
+                CachedConfig {
+                    fingerprint,
+                    config: Arc::clone(&config),
+                },
+            );
+        }
+
+        Ok((*config).clone())
+    }
+
     /// Parse configuration from a TOML string.
     #[allow(clippy::should_implement_trait)]
     pub fn from_str(content: &str) -> Result<Self> {
@@ -1748,6 +1829,24 @@ mod tests {
         assert_eq!(config.enterprise.offline_mode, "cached_with_expiry");
         assert_eq!(config.enterprise.cache_max_age_hours, 24);
         assert!(config.enterprise.trust_anchors.keys.is_empty());
+    }
+
+    #[test]
+    fn test_cached_config_reloads_when_file_changes() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let path = temp_dir.path().join("agentkernel.toml");
+        std::fs::write(&path, "[sandbox]\nname = \"first\"\n").unwrap();
+
+        let first = Config::from_file_cached(&path).unwrap();
+        let cached = Config::from_file_cached(&path).unwrap();
+        assert_eq!(first.sandbox.name, "first");
+        assert_eq!(cached.sandbox.name, "first");
+
+        // Change the file size as well as its contents so this remains
+        // deterministic on filesystems with coarse timestamp resolution.
+        std::fs::write(&path, "[sandbox]\nname = \"updated-config\"\n").unwrap();
+        let updated = Config::from_file_cached(&path).unwrap();
+        assert_eq!(updated.sandbox.name, "updated-config");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -984,7 +984,7 @@ async fn main() -> Result<()> {
                     // Try loading from the project's agentkernel.toml if it exists
                     let project_config = PathBuf::from("agentkernel.toml");
                     if project_config.exists() {
-                        Config::from_file(&project_config)?
+                        Config::from_file_cached(&project_config)?
                     } else {
                         Config::minimal(&from, "claude")
                     }
@@ -1158,7 +1158,7 @@ memory_mb = 512
                 let devcontainer_config =
                     resolve_devcontainer(devcontainer.as_deref(), auto_devcontainer, project_dir)?;
                 let (mut cfg, config_base_dir) = if let Some(ref config_path) = config {
-                    let cfg = Config::from_file(config_path)?;
+                    let cfg = Config::from_file_cached(config_path)?;
                     let base_dir = config_path.parent().unwrap_or(Path::new(".")).to_path_buf();
                     (cfg, Some(base_dir))
                 } else if let Some(ref tmpl_name) = tmpl {
@@ -1632,7 +1632,7 @@ memory_mb = 512
                     .and_then(|extension| extension.to_str())
                     .is_some_and(|extension| matches!(extension, "json" | "jsonc"));
                 let (start_perms, start_files) = if config_path.exists() && !is_devcontainer_path {
-                    let cfg = Config::from_file(&config_path)?;
+                    let cfg = Config::from_file_cached(&config_path)?;
                     for warning in cfg.validate() {
                         eprintln!("Warning: {}", warning);
                     }
@@ -1973,7 +1973,7 @@ memory_mb = 512
                     bail!("Config file not found: {}", file.display());
                 }
 
-                let cfg = Config::from_file(&file)?;
+                let cfg = Config::from_file_cached(&file)?;
                 let name = as_name.unwrap_or_else(|| cfg.sandbox.name.clone());
                 validation::validate_sandbox_name(&name)?;
 
@@ -2312,7 +2312,7 @@ memory_mb = 512
                 let runtime = if let Some(ref img) = image {
                     languages::docker_image_to_firecracker_runtime(img).to_string()
                 } else if let Some(ref config_path) = config {
-                    let cfg = Config::from_file(config_path)?;
+                    let cfg = Config::from_file_cached(config_path)?;
                     languages::docker_image_to_firecracker_runtime(&cfg.docker_image()).to_string()
                 } else {
                     "base".to_string()
@@ -2356,7 +2356,7 @@ memory_mb = 512
             let (docker_image, cfg_for_build, honor_config_dockerfile) = if let Some(img) = image {
                 (img, None, false)
             } else if let Some(ref config_path) = config {
-                let cfg = Config::from_file(config_path)?;
+                let cfg = Config::from_file_cached(config_path)?;
                 (cfg.docker_image(), Some(cfg), true)
             } else if let Some(ref tmpl_name) = tmpl {
                 let resolved = template::resolve(tmpl_name)?;
@@ -2381,7 +2381,7 @@ memory_mb = 512
                 // Try current directory config
                 let default_config = PathBuf::from("agentkernel.toml");
                 if default_config.exists() {
-                    let cfg = Config::from_file(&default_config)?;
+                    let cfg = Config::from_file_cached(&default_config)?;
                     let has_build_settings = config_has_build_settings(&cfg);
                     (cfg.docker_image(), Some(cfg), has_build_settings)
                 } else {
@@ -2462,7 +2462,7 @@ memory_mb = 512
 
             // Apply config overrides if present and load files
             let files = if let Some(ref config_path) = config {
-                let cfg = Config::from_file(config_path)?;
+                let cfg = Config::from_file_cached(config_path)?;
                 for warning in cfg.validate() {
                     eprintln!("Warning: {}", warning);
                 }
@@ -2484,7 +2484,7 @@ memory_mb = 512
                 // Check for default config file and load files if present
                 let default_config = PathBuf::from("agentkernel.toml");
                 if default_config.exists() {
-                    let cfg = Config::from_file(&default_config)?;
+                    let cfg = Config::from_file_cached(&default_config)?;
                     cfg.load_files(std::path::Path::new("."))?
                 } else {
                     Vec::new()
@@ -4570,7 +4570,7 @@ async fn run_doctor() -> Result<()> {
         println!("\nPolicy Engine:");
         let config_path = std::path::PathBuf::from("agentkernel.toml");
         let cfg = if config_path.exists() {
-            Config::from_file(&config_path).ok()
+            Config::from_file_cached(&config_path).ok()
         } else {
             None
         };
@@ -4643,7 +4643,7 @@ async fn run_doctor() -> Result<()> {
     println!("\nConfig:");
     let config_path = std::path::PathBuf::from("agentkernel.toml");
     if config_path.exists() {
-        match Config::from_file(&config_path) {
+        match Config::from_file_cached(&config_path) {
             Ok(cfg) => {
                 let warnings = cfg.validate();
                 if warnings.is_empty() {
@@ -4721,7 +4721,7 @@ async fn handle_policy_command(action: PolicyAction) -> Result<()> {
             // Load config and initialize policy engine
             let config_path = std::path::PathBuf::from("agentkernel.toml");
             let cfg = if config_path.exists() {
-                Config::from_file(&config_path)?
+                Config::from_file_cached(&config_path)?
             } else {
                 Config::minimal("default", "claude")
             };
@@ -4776,7 +4776,7 @@ async fn handle_policy_command(action: PolicyAction) -> Result<()> {
         PolicyAction::Status => {
             let config_path = std::path::PathBuf::from("agentkernel.toml");
             let cfg = if config_path.exists() {
-                Config::from_file(&config_path)?
+                Config::from_file_cached(&config_path)?
             } else {
                 Config::minimal("default", "claude")
             };

--- a/src/vmm.rs
+++ b/src/vmm.rs
@@ -35,8 +35,6 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 #[cfg(feature = "enterprise")]
 use std::sync::{LazyLock, Mutex};
-#[cfg(feature = "enterprise")]
-use std::time::SystemTime;
 use tokio::sync::RwLock;
 
 /// Global proxy handle registry. Proxy handles must outlive individual VmManager
@@ -46,7 +44,7 @@ static PROXY_HANDLES: std::sync::LazyLock<RwLock<HashMap<String, ProxyHandle>>> 
 
 #[cfg(feature = "enterprise")]
 struct CachedPolicyEngine {
-    file_signature: Option<(Option<SystemTime>, u64)>,
+    file_signature: Option<crate::config::ConfigFingerprint>,
     engine: Option<Arc<crate::policy::PolicyEngine>>,
 }
 
@@ -59,9 +57,7 @@ fn cached_policy_engine() -> Option<Arc<crate::policy::PolicyEngine>> {
     let default_config = std::env::current_dir()
         .ok()
         .map(|dir| dir.join("agentkernel.toml"))?;
-    let file_signature = std::fs::metadata(&default_config)
-        .ok()
-        .map(|metadata| (metadata.modified().ok(), metadata.len()));
+    let file_signature = Config::file_fingerprint(&default_config);
 
     if let Some(entry) = POLICY_ENGINE_CACHE
         .lock()

--- a/src/vmm.rs
+++ b/src/vmm.rs
@@ -34,7 +34,9 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 #[cfg(feature = "enterprise")]
-use std::sync::LazyLock;
+use std::sync::{LazyLock, Mutex};
+#[cfg(feature = "enterprise")]
+use std::time::SystemTime;
 use tokio::sync::RwLock;
 
 /// Global proxy handle registry. Proxy handles must outlive individual VmManager
@@ -43,33 +45,61 @@ static PROXY_HANDLES: std::sync::LazyLock<RwLock<HashMap<String, ProxyHandle>>> 
     std::sync::LazyLock::new(|| RwLock::new(HashMap::new()));
 
 #[cfg(feature = "enterprise")]
-static POLICY_ENGINE_CACHE: LazyLock<Option<Arc<crate::policy::PolicyEngine>>> =
-    LazyLock::new(|| {
-        let default_config = PathBuf::from("agentkernel.toml");
-        if !default_config.exists() {
-            return None;
-        }
+struct CachedPolicyEngine {
+    file_signature: Option<(Option<SystemTime>, u64)>,
+    engine: Option<Arc<crate::policy::PolicyEngine>>,
+}
 
-        let cfg = match Config::from_file(&default_config) {
-            Ok(cfg) => cfg,
-            Err(_) => return None,
-        };
+#[cfg(feature = "enterprise")]
+static POLICY_ENGINE_CACHE: LazyLock<Mutex<HashMap<PathBuf, CachedPolicyEngine>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
 
-        if !cfg.enterprise.enabled {
-            return None;
-        }
+#[cfg(feature = "enterprise")]
+fn cached_policy_engine() -> Option<Arc<crate::policy::PolicyEngine>> {
+    let default_config = std::env::current_dir()
+        .ok()
+        .map(|dir| dir.join("agentkernel.toml"))?;
+    let file_signature = std::fs::metadata(&default_config)
+        .ok()
+        .map(|metadata| (metadata.modified().ok(), metadata.len()));
 
-        match crate::policy::PolicyEngine::new(&cfg.enterprise) {
-            Ok(engine) => {
-                eprintln!("[enterprise] Policy engine initialized");
-                Some(Arc::new(engine))
-            }
-            Err(e) => {
-                eprintln!("[enterprise] Failed to initialize policy engine: {}", e);
-                None
-            }
-        }
-    });
+    if let Some(entry) = POLICY_ENGINE_CACHE
+        .lock()
+        .expect("policy engine cache lock poisoned")
+        .get(&default_config)
+        && entry.file_signature == file_signature
+    {
+        return entry.engine.clone();
+    }
+
+    let engine = Config::from_file_cached(&default_config)
+        .ok()
+        .filter(|cfg| cfg.enterprise.enabled)
+        .and_then(
+            |cfg| match crate::policy::PolicyEngine::new(&cfg.enterprise) {
+                Ok(engine) => {
+                    eprintln!("[enterprise] Policy engine initialized");
+                    Some(Arc::new(engine))
+                }
+                Err(error) => {
+                    eprintln!("[enterprise] Failed to initialize policy engine: {error}");
+                    None
+                }
+            },
+        );
+
+    POLICY_ENGINE_CACHE
+        .lock()
+        .expect("policy engine cache lock poisoned")
+        .insert(
+            default_config,
+            CachedPolicyEngine {
+                file_signature,
+                engine: engine.clone(),
+            },
+        );
+    engine
+}
 use tokio::sync::OnceCell;
 
 /// Global container pool for fast ephemeral runs
@@ -440,9 +470,10 @@ impl VmManager {
         // Find next available CID
         let max_cid = sandboxes.values().map(|s| s.vsock_cid).max().unwrap_or(2);
 
-        // Initialize enterprise policy engine once per process when configured
+        // Reuse the enterprise policy engine for this working directory until
+        // its config file changes.
         #[cfg(feature = "enterprise")]
-        let policy_engine = POLICY_ENGINE_CACHE.clone();
+        let policy_engine = cached_policy_engine();
 
         let mut manager = Self {
             backend,
@@ -1702,7 +1733,7 @@ impl VmManager {
         if let Some(path) = git_config_path
             && !is_devcontainer_path
         {
-            match Config::from_file(&path) {
+            match Config::from_file_cached(&path) {
                 Ok(config) => env.extend(config.agent.git_config_env()),
                 Err(error) => eprintln!(
                     "Warning: Failed to load agent Git identity from {}: {}",
@@ -1835,7 +1866,7 @@ impl VmManager {
         {
             let config_path = std::path::PathBuf::from("agentkernel.toml");
             if config_path.exists()
-                && let Ok(toml_cfg) = Config::from_file(&config_path)
+                && let Ok(toml_cfg) = Config::from_file_cached(&config_path)
                 && !toml_cfg.llm_keys.is_empty()
             {
                 let vault = SecretVault::new(SecretBackend::default());
@@ -2376,7 +2407,7 @@ impl VmManager {
     /// Logs a PolicyViolation audit event and returns an error if blocked.
     fn enforce_command_policy(cmd: &[String]) -> Result<()> {
         if let Some(binary) = cmd.first()
-            && let Ok(cfg) = Config::from_file(&PathBuf::from("agentkernel.toml"))
+            && let Ok(cfg) = Config::from_file_cached(&PathBuf::from("agentkernel.toml"))
             && !cfg.security.commands.is_allowed(binary)
         {
             log_event(AuditEvent::PolicyViolation {


### PR DESCRIPTION
Summary
- cache parsed agentkernel.toml values per process with bounded, SHA-256 content-sensitive invalidation
- reuse enterprise policy engines per working directory until configuration content changes
- route repeated CLI and VM-manager config loads through the cache
- make end-to-end agentkernel run latency explicitly drive benchmark scoring

Validation
- cargo test --all-targets: 688 passed, 5 ignored
- cargo clippy --lib --all-features -- -D warnings -A clippy::result_large_err
- enterprise compile check
- same-length config rewrite regression test
- Docker benchmark: 180.42 ms average end-to-end run latency; total score 7.05

Bead: agentkernel-su2