### PR TITLE
feat(firecracker): add full-state pause, resume, and fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,12 @@ agentkernel snapshot take my-sandbox --name before-upgrade
 agentkernel snapshot list
 agentkernel snapshot restore before-upgrade --as rollback
 
+# Firecracker only: preserve memory and running processes
+agentkernel sandbox pause my-sandbox
+agentkernel sandbox fork my-sandbox --as candidate-b
+# candidate-b is running; the source remains paused and reusable
+agentkernel sandbox resume my-sandbox
+
 # Sessions: agent conversation lifecycle
 agentkernel session start --name feature-x --agent claude -B docker
 agentkernel session save feature-x
@@ -246,6 +252,15 @@ agentkernel session resume feature-x
 agentkernel session list
 agentkernel session delete feature-x
 ```
+
+The full-state lifecycle is distinct from filesystem snapshots. It initially
+requires Firecracker 1.16.1 on an exactly compatible x86_64 Linux/KVM host;
+other backends return an explicit unsupported error instead of silently losing
+process state. The CLI lifecycle commands require a running `agentkernel serve`
+process to own the Firecracker VMM. Forks duplicate guest memory and filesystem
+state, including userspace identifiers and any credentials already inside the
+guest. See the [Firecracker full-state operations
+guide](docs/operations/firecracker-full-state.md).
 
 ## Pipelines & Parallel Execution
 
@@ -405,15 +420,16 @@ agentkernel serve --api-key-file /etc/agentkernel/api-keys
 
 ### Authentication
 
-When `--api-key` or `--api-key-file` is set, all requests (except `GET /health`) must include an `Authorization: Bearer <key>` header. Multiple keys can be provided via repeated `--api-key` flags or a key file. Keys can also be set via the `AGENTKERNEL_API_KEY` env var or in `agentkernel.toml`.
+When `--api-key` or `--api-key-file` is set, requests must include an `Authorization: Bearer <key>` header except for the public operational endpoints `GET /health`, `GET /status`, `GET /metrics`, and `GET /stats`. Multiple keys can be provided via repeated `--api-key` flags or a key file. Keys can also be set via the `AGENTKERNEL_API_KEY` env var or in `agentkernel.toml`.
 
 ### Endpoints
 
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/health` | Health check (no auth required) |
-| GET | `/status` | Server version and backend info |
-| GET | `/stats` | Sandbox count, resource usage (CPU/memory/disk) |
+| GET | `/status` | Server version and backend info (no auth required) |
+| GET | `/metrics` | Prometheus metrics (no auth required) |
+| GET | `/stats` | Sandbox count and resource usage (no auth required) |
 | POST | `/run` | Run command in temporary sandbox |
 | GET | `/sandboxes` | List all sandboxes (supports `?label=key:value` filter) |
 | POST | `/sandboxes` | Create a sandbox (supports `labels`, `description`) |
@@ -666,6 +682,7 @@ See [BENCHMARK.md](BENCHMARK.md) for detailed Hyperlight benchmarks.
 - [API](docs/api/index.md) - HTTP API and MCP server
 - [SDKs](docs/sdks/index.md) - Node.js, Python, Go, Rust, Swift
 - [Operations](docs/operations/index.md) - Kubernetes, Nomad, deployment
+- [Firecracker full-state lifecycle](docs/operations/firecracker-full-state.md) - pause, resume, fork, compatibility, and native KVM validation
 - [Changelog](docs/changelog.md)
 
 ## Examples

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -28,6 +28,10 @@ servers:
   - url: http://localhost:18888
     description: Local development server
 
+security:
+  - {}
+  - BearerAuth: []
+
 tags:
   - name: Health
     description: Health check endpoint
@@ -65,6 +69,7 @@ paths:
       summary: Health check
       description: Returns 200 if the server is healthy.
       operationId: healthCheck
+      security: []
       responses:
         '200':
           description: Server is healthy
@@ -72,6 +77,21 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HealthResponse'
+
+  /metrics:
+    get:
+      tags: [Health]
+      summary: Prometheus metrics
+      description: Returns Prometheus metrics in the text exposition format.
+      operationId: getMetrics
+      security: []
+      responses:
+        '200':
+          description: Prometheus metrics
+          content:
+            text/plain:
+              schema:
+                type: string
 
   /llm/spend:
     get:
@@ -133,11 +153,13 @@ paths:
         and current usage. When enterprise quotas are disabled, `enabled` is
         false and usage is still returned for the authenticated tenant.
         Quota accounting covers persistent HTTP create, list, get, start,
-        stop, resize, delete, logs, snapshot restore, and config import.
-        Snapshot restore is created stopped and consumes total capacity; its
-        running slot is charged when started. Ephemeral `/run`, CLI/MCP,
-        scheduler, and background object/task entrypoints are not
-        quota-accounted. All sandbox-scoped HTTP routes are owner-filtered;
+        stop, pause, resume, fork, resize, delete, logs, snapshot restore, and
+        config import. Snapshot restore is created stopped and consumes total
+        capacity; its running slot is charged when started. Firecracker CLI
+        and MCP lifecycle operations delegate through these quota-enforced
+        HTTP routes. Ephemeral `/run`, direct CLI/MCP manager calls, scheduler,
+        and background object/task entrypoints are not quota-accounted. All
+        sandbox-scoped HTTP routes are owner-filtered;
         only an explicit JWT `admin` role may cross owners. Unauthorized and
         legacy unowned sandboxes return `404` without revealing ownership.
       operationId: getQuotas
@@ -295,6 +317,7 @@ paths:
       summary: Server status
       description: Returns server version, backend, and whether API key auth is configured.
       operationId: getStatus
+      security: []
       responses:
         '200':
           description: Server status
@@ -311,6 +334,7 @@ paths:
         Returns current sandbox count, resource usage (CPU, memory, disk),
         and server metadata. Designed for fleet load-balancing decisions.
       operationId: getStats
+      security: []
       responses:
         '200':
           description: Server statistics
@@ -374,7 +398,7 @@ paths:
     post:
       tags: [Sandboxes]
       summary: Garbage-collect expired sandboxes
-      description: Removes sandboxes that have exceeded their time-to-live.
+      description: Removes sandboxes that have exceeded their time-to-live. Enterprise deployments require an administrator identity.
       operationId: garbageCollect
       responses:
         '200':
@@ -383,6 +407,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GcResponse'
+        '403':
+          description: Enterprise fleet garbage collection requires an administrator identity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
   /lifecycle/reconcile:
     post:
@@ -391,6 +421,7 @@ paths:
       description: |
         Evaluates lifecycle policies for all sandboxes and applies any needed
         stop/archive/delete actions. Supports dry-run mode for previews.
+        Enterprise deployments require an administrator identity.
       operationId: reconcileLifecycle
       requestBody:
         required: false
@@ -415,6 +446,12 @@ paths:
                 $ref: '#/components/schemas/LifecycleReconcileResponse'
         '400':
           $ref: '#/components/responses/BadRequest'
+        '403':
+          description: Enterprise lifecycle reconciliation requires an administrator identity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           $ref: '#/components/responses/InternalError'
 
@@ -604,20 +641,212 @@ paths:
     post:
       tags: [Sandboxes]
       summary: Start a stopped sandbox
+      description: |
+        Starts a stopped sandbox. Omit the optional request body to use the
+        historical defaults (moderate permissions and no injected files). The
+        local CLI may select a private persisted configuration when delegating
+        a Firecracker VM to the long-running server. Capability values are
+        derived by the server and cannot be supplied in this request.
       operationId: startSandbox
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StartSandboxRequest'
       responses:
         '200':
           description: Sandbox started
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SandboxResponse'
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
         '429':
           $ref: '#/components/responses/QuotaExceeded'
         '500':
           $ref: '#/components/responses/InternalError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+
+  /sandboxes/{name}/stop:
+    parameters:
+      - $ref: '#/components/parameters/SandboxName'
+    post:
+      tags: [Sandboxes]
+      summary: Stop a running sandbox
+      description: |
+        Stops the sandbox while retaining its persisted configuration. The
+        long-running server owns the lifecycle task after accepting the
+        request, so an HTTP waiter disconnect does not cancel the stop. Use
+        full-state pause instead when Firecracker memory, processes, and the
+        writable disk must survive.
+      operationId: stopSandbox
+      responses:
+        '200':
+          description: Sandbox stopped
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/InternalError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+
+  /sandboxes/{name}/pause:
+    parameters:
+      - $ref: '#/components/parameters/SandboxName'
+    post:
+      tags: [Sandboxes]
+      summary: Pause a running Firecracker sandbox
+      description: |
+        Captures a durable full-VM checkpoint, including guest memory and
+        process state, then stops the Firecracker VM. This operation is only
+        supported by the Firecracker backend on x86_64 Linux/KVM. Enterprise policy
+        requires the Run action.
+      operationId: pauseSandbox
+      responses:
+        '200':
+          description: Sandbox paused
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '422':
+          description: The sandbox backend does not support full-state pause
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/InternalError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+
+  /sandboxes/{name}/resume:
+    parameters:
+      - $ref: '#/components/parameters/SandboxName'
+    post:
+      tags: [Sandboxes]
+      summary: Resume a paused Firecracker sandbox
+      description: Restores guest memory, processes, devices, and disk state from the sandbox's full-VM checkpoint. Enterprise policy requires the Run action.
+      operationId: resumeSandbox
+      responses:
+        '200':
+          description: Sandbox resumed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '422':
+          description: The sandbox backend does not support full-state resume
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          $ref: '#/components/responses/QuotaExceeded'
+        '500':
+          $ref: '#/components/responses/InternalError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
+
+  /sandboxes/{name}/fork:
+    parameters:
+      - $ref: '#/components/parameters/SandboxName'
+    post:
+      tags: [Sandboxes]
+      summary: Fork a paused Firecracker sandbox
+      description: |
+        Restores the paused source checkpoint into a new running sandbox. The
+        source remains paused and may be resumed or forked again.
+
+        Security warning: the fork copies guest memory and filesystem state.
+        Credentials captured in the checkpoint are duplicated and should be
+        rotated or revoked when appropriate. Enterprise policy requires Run on
+        the source plus Create and Run for the child.
+      operationId: forkSandbox
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ForkSandboxRequest'
+            example:
+              as_name: experiment-b
+      responses:
+        '201':
+          description: Running sandbox forked from the paused source
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForkSandboxResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '403':
+          description: The requested fork would cross an owner or tenant boundary
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '422':
+          description: The sandbox backend does not support full-state fork
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '429':
+          $ref: '#/components/responses/QuotaExceeded'
+        '500':
+          $ref: '#/components/responses/InternalError'
+        '503':
+          $ref: '#/components/responses/ServiceUnavailable'
 
   /sandboxes/{name}/resize:
     parameters:
@@ -2372,6 +2601,29 @@ components:
           description: Optional fixed IPv4 address for this sandbox. It cannot be changed after allocation.
           example: "172.30.0.10"
 
+    StartSandboxRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        configuration:
+          type: object
+          additionalProperties: false
+          required: [source, token]
+          description: |
+            Select the server-derived private start configuration previously
+            persisted by the local CLI. Callers cannot provide permission or
+            file-injection values in the HTTP request. The token is one-shot
+            and bound to the sandbox UUID, owner, request identity, and a
+            five-minute validity window.
+          properties:
+            source:
+              type: string
+              enum: [persisted]
+            token:
+              type: string
+              pattern: '^[0-9a-f]{64}$'
+              description: Opaque one-shot nonce generated by the local CLI.
+
     ResizeSandboxRequest:
       type: object
       properties:
@@ -2639,7 +2891,7 @@ components:
 
     BackendCapabilities:
       type: object
-      required: [mount_cwd, mount_home, attach, host_volumes, ssh, proxy_secret_bindings, secret_files, snapshots, resume, endpoints]
+      required: [mount_cwd, mount_home, attach, host_volumes, ssh, proxy_secret_bindings, secret_files, snapshots, resume, full_state_pause_resume, full_state_fork, endpoints]
       properties:
         mount_cwd: {type: boolean}
         mount_home: {type: boolean}
@@ -2650,6 +2902,12 @@ components:
         secret_files: {type: boolean}
         snapshots: {type: boolean}
         resume: {type: boolean}
+        full_state_pause_resume:
+          type: boolean
+          description: Preserves guest memory, process, and device state; currently Firecracker only
+        full_state_fork:
+          type: boolean
+          description: Restores independent running children from a paused full-state checkpoint; currently Firecracker only
         endpoints: {type: boolean}
 
     StatsResponse:
@@ -2796,7 +3054,7 @@ components:
           example: "019abc12-1234-7def-89ab-0123456789ab"
         status:
           type: string
-          enum: [running, stopped, archived]
+          enum: [running, paused, stopped, dormant, archived]
           example: "running"
         backend:
           type: string
@@ -2843,6 +3101,36 @@ components:
           example: true
         data:
           $ref: '#/components/schemas/SandboxInfo'
+
+    ForkSandboxRequest:
+      type: object
+      additionalProperties: false
+      required: [as_name]
+      properties:
+        as_name:
+          type: string
+          description: Name for the new running sandbox
+          example: "experiment-b"
+
+    ForkSandboxResult:
+      type: object
+      required: [sandbox, security_warning]
+      properties:
+        sandbox:
+          $ref: '#/components/schemas/SandboxInfo'
+        security_warning:
+          type: string
+          description: Warning that guest memory and filesystem state, including captured credentials, were cloned.
+          example: "Forking duplicates userspace memory. Rotate cached identifiers and cryptographic tokens in each child; prefer proxy-managed secrets that never enter the VM."
+
+    ForkSandboxResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+          example: true
+        data:
+          $ref: '#/components/schemas/ForkSandboxResult'
 
     SandboxListResponse:
       type: object
@@ -3435,14 +3723,14 @@ components:
             $ref: '#/components/schemas/ErrorResponse'
 
     Forbidden:
-      description: Authenticated identity is outside the requested scope
+      description: Authenticated identity lacks the required access or policy permission
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/ErrorResponse'
 
     ServiceUnavailable:
-      description: Durable aggregation storage is unavailable
+      description: A required service, policy engine, or durable store is unavailable
       content:
         application/json:
           schema:
@@ -3455,7 +3743,3 @@ components:
       description: |
         Optional API key authentication. When enabled, include the
         API key in the Authorization header as a Bearer token.
-
-# Security is optional - uncomment to require authentication
-# security:
-#   - BearerAuth: []

--- a/docs/api/http.md
+++ b/docs/api/http.md
@@ -41,7 +41,7 @@ agentkernel serve --otel-endpoint http://localhost:4318 \
 
 ## Authentication
 
-When API key authentication is enabled (via `--api-key`, `--api-key-file`, `AGENTKERNEL_API_KEY`, or `[api].api_key` in config), all requests require an `Authorization` header, except for `/health` and `/status`:
+When API key authentication is enabled (via `--api-key`, `--api-key-file`, `AGENTKERNEL_API_KEY`, or `[api].api_key` in config), all requests require an `Authorization` header, except for the public `GET /health`, `GET /status`, `GET /metrics`, and `GET /stats` endpoints:
 
 ```text
 Authorization: Bearer your-secret
@@ -91,9 +91,10 @@ oversubscribe a limit. Running multiple daemons against the same sandbox state
 is not yet a supported quota-enforcement topology.
 
 The quota-enforced surface is the persistent HTTP sandbox API: create, list,
-get, start, stop, resize, delete, logs, restore, and config import. Restore
+get, start, stop, pause, resume, fork, resize, delete, logs, restore, and config import. Restore
 and import consume total capacity (restore is created stopped; its running
-slot is charged only when started). All sandbox-scoped HTTP routes—including
+slot is charged only when started). Resume and fork charge a running slot; a
+successful pause releases one. All sandbox-scoped HTTP routes—including
 exec, files, detached commands, browser, Git, and config export—are filtered
 to the authenticated user and organization. An explicit JWT `admin` role may
 cross owners. Requests for an unauthorized or legacy unowned sandbox return
@@ -233,7 +234,8 @@ curl -X POST http://localhost:18888/gc
 }
 ```
 
-Removes sandboxes that have exceeded their time-to-live.
+Removes sandboxes that have exceeded their time-to-live. In enterprise mode,
+this fleet-wide destructive operation requires an administrator identity.
 
 ### Run Command
 
@@ -518,6 +520,49 @@ curl -X POST http://localhost:18888/sandboxes/my-sandbox/exec \
 }
 ```
 
+### Start Sandbox
+
+```text
+POST /sandboxes/{name}/start
+```
+
+An empty request body starts with the default moderate permissions and no file
+injections, preserving the original API contract:
+
+```bash
+curl -X POST http://localhost:18888/sandboxes/my-sandbox/start
+```
+
+The local CLI can select a private start configuration it previously persisted
+for this sandbox:
+
+```bash
+curl -X POST http://localhost:18888/sandboxes/my-sandbox/start \
+  -H "Content-Type: application/json" \
+  -d '{
+    "configuration": {
+      "source": "persisted",
+      "token": "<64-character one-shot nonce from the local CLI>"
+    }
+  }'
+```
+
+The server derives this configuration from a private, atomic host manifest. Its
+unguessable nonce is one-shot and the manifest is bound to the sandbox UUID,
+persisted owner, and authenticated request identity. It is consumed on the
+first attempt, expires after five minutes, is superseded by the next local start
+configuration, and is scrubbed on sandbox removal. This prevents replay after a
+config change or remove/recreate cycle. The HTTP request cannot contain
+permission or file-injection values, so an authenticated API caller cannot use
+start to enable host mounts, environment passthrough, privileged mode, or other
+capabilities. The CLI creates this reference automatically; API clients
+normally omit the body.
+
+For an unowned sandbox created by the local CLI, successful validation of this
+one-shot reference also authorizes the server's first ownership claim. This
+continues to work after a server restart or a prior `GET` imported the state;
+merely discovering or refreshing an unowned sandbox never authorizes a claim.
+
 ### Stop Sandbox
 
 ```
@@ -527,6 +572,88 @@ POST /sandboxes/{name}/stop
 ```bash
 curl -X POST http://localhost:18888/sandboxes/my-sandbox/stop
 ```
+
+### Pause a Firecracker Sandbox
+
+Capture a durable full-VM checkpoint containing guest memory, process state,
+virtual-device state, and disk state. The resulting sandbox status is
+`paused`.
+
+```text
+POST /sandboxes/{name}/pause
+```
+
+```bash
+curl -X POST http://localhost:18888/sandboxes/experiment-a/pause
+```
+
+```json
+{"success":true,"data":"Sandbox paused"}
+```
+
+Pause is supported only for Firecracker sandboxes on x86_64 Linux/KVM. Unsupported
+backends return `422`; a lifecycle state conflict, such as pausing an already
+paused sandbox, returns `409`. Enterprise policy requires the Run action.
+
+### Resume a Firecracker Sandbox
+
+```text
+POST /sandboxes/{name}/resume
+```
+
+```bash
+curl -X POST http://localhost:18888/sandboxes/experiment-a/resume
+```
+
+```json
+{"success":true,"data":"Sandbox resumed"}
+```
+
+Resume restores the captured memory and process state. Enterprise deployments
+require the Run action and return `429` if resuming would exceed a
+running-sandbox or resource quota.
+
+### Fork a Paused Firecracker Sandbox
+
+Create a new running sandbox from the paused source. The source remains paused
+and can be resumed or forked again.
+
+```text
+POST /sandboxes/{name}/fork
+```
+
+```bash
+curl -X POST http://localhost:18888/sandboxes/experiment-a/fork \
+  -H "Content-Type: application/json" \
+  -d '{"as_name":"experiment-b"}'
+```
+
+```json
+{
+  "success": true,
+  "data": {
+    "sandbox": {
+      "name": "experiment-b",
+      "status": "running",
+      "backend": "firecracker"
+    },
+    "security_warning": "Forking duplicates userspace memory. Rotate cached identifiers and cryptographic tokens in each child; prefer proxy-managed secrets that never enter the VM."
+  }
+}
+```
+
+The request body accepts exactly one required string field, `as_name`. A name
+collision or unpaused source returns `409`; a non-Firecracker source returns
+`422`; enterprise quota denial returns `429`. The child atomically inherits the
+source ownership metadata. A request whose authenticated owner or tenant does
+not match the source is rejected with `403` before any child VM is restored.
+Enterprise policy requires Run on the source plus both Create and Run for the
+child; Create permission alone cannot authorize access to the source memory or
+disk state.
+
+> **Security warning:** Forking duplicates guest memory and filesystem state,
+> including credentials captured in the checkpoint. Rotate or revoke cloned
+> credentials when appropriate.
 
 ### Delete Sandbox
 
@@ -579,7 +706,9 @@ curl -X POST http://localhost:18888/sandboxes/my-sandbox/recover
 
 ### Reconcile Lifecycle Policies
 
-Applies lifecycle policies across all sandboxes (or previews actions).
+Applies lifecycle policies across all sandboxes (or previews actions). In
+enterprise mode, both apply and dry-run requests require an administrator
+identity because evaluation spans every tenant.
 
 ```
 POST /lifecycle/reconcile

--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -60,6 +60,9 @@ Create a persistent sandbox.
 }
 ```
 
+When automatic backend selection chooses Firecracker, create delegates the
+start and any requested repository setup to the local API server.
+
 ### sandbox_exec
 
 Execute a command in a running sandbox.
@@ -98,6 +101,9 @@ Remove a sandbox.
 }
 ```
 
+Removing a Firecracker sandbox is delegated to the local API server so the
+server-owned VM is stopped before its state is deleted.
+
 ### sandbox_start / sandbox_stop
 
 Start or stop a sandbox.
@@ -110,6 +116,63 @@ Start or stop a sandbox.
   }
 }
 ```
+
+Firecracker start and stop operations are delegated to the local API server.
+Set `AGENTKERNEL_API_KEY` when that server requires bearer authentication.
+
+### sandbox_pause / sandbox_resume
+
+Pause and resume a Firecracker sandbox with guest memory and process state
+preserved. These operations require Firecracker on x86_64 Linux/KVM and a healthy
+local `agentkernel serve` process. The MCP server delegates Firecracker
+lifecycle operations to that long-running process so the VM survives after a
+tool call returns. `AGENTKERNEL_PORT` selects a non-default local API port.
+
+```json
+{
+  "name": "sandbox_pause",
+  "arguments": {
+    "name": "experiment-a"
+  }
+}
+```
+
+```json
+{
+  "name": "sandbox_resume",
+  "arguments": {
+    "name": "experiment-a"
+  }
+}
+```
+
+### sandbox_fork
+
+Fork a paused Firecracker sandbox into a new running sandbox. The source stays
+paused and reusable.
+
+```json
+{
+  "name": "sandbox_fork",
+  "arguments": {
+    "name": "experiment-a",
+    "as_name": "experiment-b"
+  }
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | Yes | Paused source sandbox |
+| `as_name` | string | Yes | Name for the new running sandbox |
+
+The response includes a security warning because the child receives a copy of
+guest memory and filesystem state. Credentials captured in the checkpoint are
+duplicated; rotate or revoke them when appropriate. Fork uses the existing
+`sandbox_create` interactive permission for the child name. Enterprise policy
+requires Run on the source plus both Create and Run for the child. The child
+inherits the source owner and tenant metadata; cross-owner or cross-tenant forks
+are rejected before restore.
 
 ### sandbox_file_write
 

--- a/docs/commands/index.md
+++ b/docs/commands/index.md
@@ -21,6 +21,9 @@ agentkernel provides a Docker-like CLI for managing sandboxes.
 | [`sandbox create`](create.md) | Create a new sandbox |
 | [`sandbox start`](start-stop.md) | Start a stopped sandbox |
 | [`sandbox stop`](start-stop.md) | Stop a running sandbox |
+| [`sandbox pause`](start-stop.md) | Checkpoint a Firecracker sandbox with guest memory and processes (`suspend` alias) |
+| [`sandbox resume`](start-stop.md) | Resume a full-state Firecracker checkpoint |
+| [`sandbox fork`](start-stop.md) | Start a new sandbox from a paused Firecracker checkpoint |
 | [`sandbox remove`](start-stop.md) | Remove a sandbox |
 | [`sandbox list`](list.md) | List all sandboxes (with IP addresses) |
 | `sandbox info` | Show detailed information about a sandbox (with IP) |

--- a/docs/commands/sessions.md
+++ b/docs/commands/sessions.md
@@ -23,10 +23,13 @@ agentkernel session start --name feature-x --agent claude -B docker
 # Output:
 # Session 'feature-x' started.
 #   Sandbox: session-feature-x
-# Attach with: agentkernel attach session-feature-x
+# Use: agentkernel attach session-feature-x
 ```
 
-The sandbox is named `session-<name>`. Use `exec` or `attach` to interact with it.
+The sandbox is named `session-<name>`. Use `exec` to interact with any supported
+backend. Interactive `attach` is available only on backends that support it;
+server-owned Firecracker sessions use `agentkernel exec session-<name> --
+<command>` or `agentkernel ssh session-<name>` when SSH is configured.
 
 ### List sessions
 
@@ -42,6 +45,7 @@ old-session          codex      stopped    3d                0
 
 ```bash
 agentkernel exec session-feature-x -- python3 -c "print('working')"
+# Docker and other interactive-attach backends only:
 agentkernel attach session-feature-x
 ```
 

--- a/docs/commands/start-stop.md
+++ b/docs/commands/start-stop.md
@@ -1,11 +1,31 @@
 
-# agentkernel sandbox start / stop
+# agentkernel sandbox start / stop / pause / resume / fork
 
 Manage the lifecycle of persistent sandboxes.
+
+`start` and `stop` are the portable lifecycle operations. Firecracker sandboxes
+on x86_64 Linux/KVM also support full-state `pause`, `resume`, and `fork`, which
+preserve guest memory and process state.
 
 ## start
 
 Start a stopped sandbox.
+
+Firecracker sandboxes are started through the long-running local API server so
+the VM process survives after the CLI exits. Run `agentkernel serve` first;
+`AGENTKERNEL_PORT` selects a non-default local port. If the server requires an
+API key, set `AGENTKERNEL_API_KEY` for delegated CLI requests.
+
+Before delegating, the CLI resolves the saved `agentkernel.toml` permissions
+and startup file injections. It stores that resolved configuration in a private
+host manifest and sends only an unguessable one-shot reference in the local
+start request. The manifest is bound to the sandbox UUID and owner, consumed on
+the first attempt, expires after five minutes, and is scrubbed on removal. A
+valid reference can authorize the server's first claim of an unowned local
+sandbox even after the server restarted or previously inspected it. This
+preserves the selected profile, network and mount behavior, resource limits, and
+file contents while the server retains VM ownership, without exposing a public
+capability-escalation payload.
 
 ### Usage
 
@@ -32,15 +52,28 @@ agentkernel sandbox list
 ### What Happens
 
 1. Loads sandbox configuration from disk
-2. Uses the backend that was used when creating the sandbox
-3. Starts the container/VM
-4. Sandbox is now ready for `exec` or `attach`
+2. Resolves its permissions and startup files
+3. Uses the backend that was used when creating the sandbox
+4. Starts the container/VM (through the local server for Firecracker)
+5. Sandbox is ready for `exec`; backends with interactive terminal support also allow `attach`
+
+Server-owned Firecracker sandboxes do not support interactive `attach`. Use
+`agentkernel exec <name> -- <command>` or `agentkernel ssh <name>` when SSH is
+configured.
 
 ---
 
 ## stop
 
-Stop a running sandbox. The sandbox state is preserved and can be started again.
+Stop a running sandbox. Container/provider backends preserve their normal
+backend state and can be started again.
+
+For Firecracker, the CLI delegates stop to the local API server that owns the
+VM process. A Firecracker VM restored or forked from a full-state checkpoint
+rejects ordinary `stop`, because its writable disk is currently tied to that
+runtime and a cold `start` would reset it. Use `pause` to preserve it or
+`remove` to discard it. Ordinary stop on a disposable Firecracker sandbox does
+not preserve writable disk changes.
 
 ### Usage
 
@@ -64,14 +97,99 @@ agentkernel sandbox list
 
 1. Sends stop signal to the container/VM
 2. Waits for graceful shutdown
-3. Sandbox state is preserved on disk
-4. Can be started again with `agentkernel sandbox start`
+3. Sandbox configuration is preserved on disk; backend persistence rules apply
+4. Can be started again when the backend's persistence contract allows it;
+   full-state Firecracker lineages use `pause` and `resume` instead
+
+---
+
+## pause (alias: suspend)
+
+Pause a running Firecracker sandbox into a durable full-VM checkpoint.
+
+### Usage
+
+```bash
+agentkernel sandbox pause <NAME>
+agentkernel sandbox suspend <NAME>
+```
+
+### Example
+
+```bash
+agentkernel sandbox pause experiment-a
+agentkernel sandbox list
+# NAME             STATUS    BACKEND
+# experiment-a     paused    firecracker
+```
+
+Unlike `stop`, pause captures guest memory, process state, virtual-device
+state, and an immutable disk checkpoint. The sandbox is not available for
+`exec` or `attach` while paused.
+
+This operation requires the Firecracker backend on x86_64 Linux/KVM. Other backends
+return an unsupported-operation error. CLI pause, resume, and fork commands
+also require a healthy local `agentkernel serve` process because it owns the
+Firecracker VM.
+
+---
+
+## resume
+
+Resume a paused Firecracker sandbox from its full-VM checkpoint.
+
+### Usage
+
+```bash
+agentkernel sandbox resume <NAME>
+```
+
+### Example
+
+```bash
+agentkernel sandbox resume experiment-a
+```
+
+The sandbox continues from the captured memory and process state instead of
+performing a fresh boot.
+
+---
+
+## fork
+
+Create a new running sandbox from a paused Firecracker sandbox.
+
+### Usage
+
+```bash
+agentkernel sandbox fork <SOURCE> --as <CHILD>
+```
+
+### Example
+
+```bash
+agentkernel sandbox pause experiment-a
+agentkernel sandbox fork experiment-a --as experiment-b
+```
+
+`experiment-b` starts immediately from the checkpoint. `experiment-a` stays
+paused, so it can be resumed or forked again. After the fork, source and child
+disk state diverge independently. The child inherits the source owner and tenant
+metadata atomically; cross-owner or cross-tenant forks are rejected before the
+child VM is restored.
+
+> **Security warning:** A fork copies guest memory and filesystem state. Any
+> credentials captured in the checkpoint are duplicated into the child;
+> rotate or revoke them when appropriate.
 
 ---
 
 ## remove
 
 Permanently delete a sandbox and its state.
+
+For Firecracker, removal is delegated to the local API server so a live VM is
+stopped before its persisted state is deleted.
 
 ### Usage
 
@@ -99,15 +217,18 @@ agentkernel sandbox remove my-sandbox
 
 ## Lifecycle Summary
 
-```
-create  ──>  start  ──>  stop  ──>  start  ──>  ...  ──>  remove
-              │                       │
-              └──── exec/attach ──────┘
+```text
+create -> start -> stop -> start -> ... -> remove
+            |
+            +-> pause -> resume
+                   |
+                   +-> fork -> running child
 ```
 
-| State | Can exec/attach? | Persisted? |
-|-------|------------------|------------|
-| Created (not started) | No | Yes |
-| Running | Yes | Yes |
-| Stopped | No | Yes |
-| Removed | - | No |
+| State | Can exec/attach? | Full guest memory preserved? | Persisted? |
+|-------|------------------|------------------------------|------------|
+| Created (not started) | No | No | Yes |
+| Running | Yes | In memory | Yes |
+| Paused (Firecracker) | No | Yes | Yes |
+| Stopped | No | No | Configuration only; filesystem persistence is backend-specific |
+| Removed | - | No | No |

--- a/docs/index.md
+++ b/docs/index.md
@@ -176,6 +176,11 @@ agentkernel sandbox create ci --template rust-ci
 agentkernel snapshot take my-sandbox --name before-upgrade
 agentkernel snapshot restore before-upgrade --as rollback
 
+# Firecracker full-state lifecycle: preserve memory and running processes
+agentkernel sandbox pause my-sandbox
+agentkernel sandbox fork my-sandbox --as candidate-b
+agentkernel sandbox resume my-sandbox
+
 # Sessions: tie sandbox lifecycle to agent conversations
 agentkernel session start --name feature-x --agent claude -B docker
 agentkernel session save feature-x
@@ -191,6 +196,14 @@ agentkernel parallel \
 ```
 
 Per-branch sandboxes, image cache management, secrets vault, sandbox export/import, TTL-based auto-expiry, and garbage collection round out the developer experience.
+
+Filesystem snapshots and Firecracker full-state checkpoints have different
+guarantees. Full-state pause/resume/fork is initially restricted to Firecracker
+1.16.1 on compatible x86_64 Linux/KVM hosts and never silently falls back on
+other backends. The CLI lifecycle commands delegate to a running
+`agentkernel serve` process that owns the VMM. Read the [full-state
+compatibility and operations guide](operations/firecracker-full-state.md) before
+relying on process continuity or branching a live agent.
 
 ## It's programmable
 

--- a/docs/operations/backend-compatibility.md
+++ b/docs/operations/backend-compatibility.md
@@ -23,6 +23,37 @@ backends. The normal CI workflow owns formatting, linting, unit tests, and
 release builds; these compatibility workflows do not change release artifacts
 or release triggers.
 
+## State preservation capabilities
+
+"Snapshot", "stop/start", and "full-state pause" are separate contracts.
+Filesystem and provider snapshots preserve selected files or disks and start
+new processes on restore. Full-state pause preserves guest memory and the point
+of execution.
+
+| Backend | Existing snapshot/restore | Full-state pause/resume/fork |
+| --- | --- | --- |
+| Firecracker 1.16.1, Linux x86_64 KVM | No Firecracker-specific cold-snapshot contract | Supported only on an exactly compatible host after the native KVM gate passes |
+| Docker / Podman | Container-filesystem image where implemented | Unsupported |
+| Apple Containers | Exported container filesystem rebuilt as an image | Unsupported |
+| Hyperlight | None | Unsupported |
+| Kubernetes / Nomad | No portable AgentKernel full-state format | Unsupported |
+| Daytona / Runloop / E2B / Modal | Provider-specific workspace, disk, or snapshot semantics | Unsupported unless a future provider contract explicitly proves process-memory continuity |
+| Agent Computer | Custom bridge contract only | Unsupported |
+
+Unsupported full-state operations must fail before mutating the sandbox or
+creating artifacts. The CLI and MCP return an explicit capability error; the
+HTTP API maps the same condition to `422 Unprocessable Entity`. There is no
+automatic fallback to a filesystem snapshot. Users can request that weaker
+behavior explicitly with the existing `snapshot take` and `snapshot restore`
+commands.
+
+Discover this contract through `full_state_pause_resume` and
+`full_state_fork` in `GET /backends`; only Firecracker reports them as true.
+Do not infer full-state support from the legacy `snapshots` or `resume`
+booleans, which do not promise that memory or live processes survive. See
+[Firecracker full-state lifecycle](firecracker-full-state.md) for the artifact,
+compatibility, upgrade, and test contract.
+
 ## Hosted provider contracts
 
 `scripts/test/provider-sdks.test.mjs` checks the maintained SDK exports and runs
@@ -72,7 +103,12 @@ The Firecracker lane uses an explicitly labelled, access-controlled self-hosted
 runner because GitHub-hosted runners do not expose the required KVM device and
 guest assets. The lane is scheduled and manually dispatchable; it is not silently
 treated as evidence on ordinary pull requests. Runtime maintainers (@thrashr888)
-own runner health and asset refreshes.
+own runner health and asset refreshes. A release that claims full-state
+pause/resume/fork must additionally demonstrate RAM-only process continuity,
+two concurrent divergent forks with independent writable disks, vsock
+reconnection, corrupt-artifact failure, and cleanup on this native runner. The
+current macOS development host and ordinary GitHub-hosted CI cannot supply that
+evidence.
 
 The Kubernetes and Nomad orchestrators provide internal service discovery for
 declared sandbox ports: Kubernetes creates a per-sandbox ClusterIP Service,

--- a/docs/operations/firecracker-full-state.md
+++ b/docs/operations/firecracker-full-state.md
@@ -1,0 +1,304 @@
+# Firecracker full-state pause, resume, and fork
+
+AgentKernel can preserve a Firecracker microVM's guest memory, process state,
+device state, and writable root filesystem, stop its VMM process, and later
+resume the sandbox. The same immutable checkpoint can also seed independent
+running children while the source remains paused and reusable.
+
+This is a different contract from `agentkernel snapshot`. Existing snapshots
+are filesystem or provider snapshots: they preserve files, but a restore boots
+new processes. Full-state pause preserves the point of execution.
+
+## Initial support boundary
+
+The initial full-state implementation is deliberately narrow:
+
+- Linux on x86_64 with readable and writable `/dev/kvm`;
+- Firecracker `v1.16.1`;
+- the AgentKernel `6.18.45` guest kernel; and
+- restore on an exactly compatible host, described below.
+
+Treat the capability as a preview until the native KVM gate at the end of this
+page has passed on the exact release build. Compilation and mocked state-machine
+tests on macOS are not evidence that guest memory, processes, or disks survive
+on KVM.
+
+Docker, Podman, Apple Containers, Hyperlight, Kubernetes, Nomad, and hosted
+backends do not implement this full-state contract. They return an explicit
+unsupported-capability error. AgentKernel never silently substitutes a
+filesystem snapshot, because that would discard live processes, open file
+descriptors, and guest memory while reporting success.
+
+On backends that implement them, use the existing `snapshot take` and
+`snapshot restore` commands when a cold, filesystem-level branch is acceptable.
+Those commands are not a Firecracker full-state fallback.
+
+## Lifecycle
+
+Firecracker VMM processes must be owned by a long-lived AgentKernel process.
+Start `agentkernel serve` first and keep it running; the CLI pause, resume, and
+fork commands delegate to that local server. A standalone CLI manager cannot
+safely retain or reconnect a Firecracker process after the command exits, so
+these operations fail with an actionable error when the server is unavailable.
+The server must also own the running source VM that will be paused.
+
+Firecracker `start`, `stop`, and `remove` requests also execute as server-owned
+tasks. If an HTTP client disconnects, cancellation of that waiter does not
+cancel the lifecycle mutation. `agentkernel run --keep ...` leaves its VM under
+daemon ownership; without `--keep`, cleanup is a server-owned remove rather
+than a lossy local stop.
+
+```bash
+# Keep this process running (18888 is the default port).
+agentkernel serve --host 127.0.0.1 --port 18888
+```
+
+The delegated CLI/MCP control path currently speaks plaintext HTTP on loopback.
+A TLS-only (`--require-tls`) listener is deliberately not mistaken for a healthy
+control endpoint; run the lifecycle daemon on a host-private loopback port
+without `--require-tls`. TLS-aware or Unix-socket delegation is tracked before
+this preview is suitable for a TLS-only service topology.
+
+Then, from another terminal:
+
+```bash
+# Capture memory, VM state, and disk, then stop compute.
+agentkernel sandbox pause research-agent
+# `suspend` is a visible alias for `pause`.
+
+# Create and immediately run an independent child from the source checkpoint.
+agentkernel sandbox fork research-agent --as candidate-b
+
+# The source remains paused, so it can seed another child or resume itself.
+agentkernel sandbox fork research-agent --as candidate-c
+agentkernel sandbox resume research-agent
+```
+
+`pause` is transactional while the owning service remains alive. AgentKernel
+first records a deterministic transition ID, pauses the running microVM, stages
+the full checkpoint, and publishes its manifest only after every required
+artifact is ready. A failure before publication retries the live source in
+place; an ambiguous double failure remains visibly paused under manager
+ownership so `resume` can retry it. A successful pause leaves the sandbox in
+the `paused` state and no longer consumes VMM compute.
+
+`fork` keeps the source paused and starts the child immediately. Each child gets
+a fresh Firecracker process, an independent writable disk, and unique API and
+vsock Unix sockets, then loads the saved VM state. The source checkpoint remains
+reusable for another fork or for resuming the source. Its immutable memory file
+may still back private, demand-paged mappings in running children.
+
+## Compatibility is exact, not best effort
+
+A Firecracker checkpoint contains KVM and emulated-device state. AgentKernel
+records the Firecracker version, CPU architecture, host kernel release, a
+SHA-256 host-identity fingerprint, a SHA-256 CPU/feature fingerprint, and the
+guest's exact `uname -r`. It refuses any mismatch before starting a VMM. Raw
+machine identity and `/proc/cpuinfo` contents are not written to the manifest.
+
+For the first release, treat all of these as restore requirements:
+
+| Dimension | Requirement |
+| --- | --- |
+| Backend | Firecracker only; never restore to a different backend |
+| Firecracker | Exact `v1.16.1` runtime |
+| Snapshot format | Firecracker snapshot format `10.0.0`, produced by the 1.16 line |
+| Architecture | `x86_64` only |
+| Host kernel | Exact release recorded at pause time |
+| Host identity | Exact machine-identity hash recorded at pause time (same-host restore) |
+| CPU | Exact fingerprint of vendor, family, model, stepping, microcode, and guest-visible feature flags |
+| Guest | Exact `6.18.45-agentkernel` release reported by the guest and the same device/boot configuration |
+
+Firecracker documents cross-host-kernel snapshot restore as unstable, and CPU
+compatibility depends on the features exposed to the guest. A same-architecture
+label alone is not a portability guarantee. The machine-identity check makes
+this initial contract intentionally same-host; portable CPU templates and a
+cross-host validation matrix remain future work.
+
+Firecracker `v1.16.0` and `v1.16.1` use the same snapshot format, but
+`v1.16.1` contains a vsock-after-restore fix. AgentKernel pins the exact patch
+release rather than inferring safety from the format version alone.
+
+Relevant upstream references:
+
+- [Firecracker snapshot support](https://github.com/firecracker-microvm/firecracker/blob/v1.16.1/docs/snapshotting/snapshot-support.md)
+- [Snapshot versioning and host/CPU compatibility](https://github.com/firecracker-microvm/firecracker/blob/v1.16.1/docs/snapshotting/versioning.md)
+- [Firecracker 1.16.1 changelog](https://github.com/firecracker-microvm/firecracker/blob/v1.16.1/CHANGELOG.md)
+
+## Artifact invariants
+
+A usable checkpoint is a set, not a single file:
+
+- `vmstate.bin` contains Firecracker and KVM device state;
+- `memory.bin` contains guest memory; and
+- `rootfs.ext4` is the disk state captured while the VM is paused.
+
+Firecracker does not package or manage the disk image. Its snapshot state also
+retains block-device paths. AgentKernel therefore launches snapshot-capable VMs
+from a per-sandbox runtime directory and uses a stable relative disk path. Each
+resume or fork resolves that path inside its own runtime directory, where it
+has an independent copy-on-write disk.
+
+The state, memory, and disk artifacts are immutable. Firecracker maps the
+memory file privately and reads pages on demand. AgentKernel records a SHA-256
+digest and byte length for every artifact and verifies both before restore. It
+keeps a paused source's checkpoint intact while it can still seed forks, and
+removes a consumed source checkpoint only after Firecracker has accepted its
+restore. Operators must not manually delete or replace reusable checkpoint
+files. Mutating a memory file can corrupt restored guests and produces
+undefined behavior.
+
+Full snapshots write the complete configured guest memory. Operators must
+budget snapshot storage by memory size plus disk size, account for concurrent
+forks, and leave headroom for failed staging attempts. Firecracker's CRC covers
+only the VM state file; it is not authentication for the memory or disk files.
+Checkpoint directories and their contents must be restricted to the AgentKernel
+service identity and protected like credentials when backed up or moved.
+
+Before pausing, AgentKernel reserves conservatively for configured RAM, the
+logical rootfs size, and 64 MiB of state/metadata overhead. The checkpoint store
+defaults to a 64 GiB global cap and requires 5 GiB of filesystem headroom. Set
+`AGENTKERNEL_FULL_STATE_MAX_BYTES` and
+`AGENTKERNEL_FULL_STATE_MIN_FREE_BYTES` to positive byte counts to tune those
+limits. The daemon serializes this check with checkpoint publication, so two
+pause requests cannot both pass against the same observed capacity. These are
+host-wide safety limits, not per-tenant storage accounting or garbage
+collection.
+
+Every VMM instance receives a private runtime directory under
+`/tmp/agentkernel-fc-<uid>` with mode `0700`. API and vsock Unix sockets are
+accepted only when they are real sockets owned by the service user; AgentKernel
+rejects symlinks and changes the socket mode to `0600` before connecting. This
+protects local control endpoints from other host users but does not replace
+normal service-host isolation.
+
+An interrupted transition remains in a deterministic
+`.staging-<checkpoint-id>` directory and is reported when the service starts.
+If a durable ready marker proves the original VMM had already terminated,
+`resume` or `fork` can finish publishing it. Ambiguous staging is neither
+restored nor deleted: safely reattaching to an orphaned Firecracker process
+requires the durable supervisor/reconnect protocol described under known
+limitations below.
+
+Differential Firecracker snapshots are outside this contract. Upstream still
+labels them developer preview, and a diff is generally not independently
+resumable until it is merged with its base.
+
+## Service ownership and crash recovery
+
+The long-running `agentkernel serve` process owns Firecracker child processes
+and their API/vsock sockets. CLI and MCP lifecycle commands delegate to that
+service. AgentKernel can recover an ambiguous pause while that manager remains
+alive and can identify deterministic staging after restart, but it cannot yet
+reattach to an orphaned Firecracker process after a service crash. A durable
+supervisor with PID identity, ownership locks, and startup reconciliation is
+required before calling this lifecycle crash-resilient.
+
+After a source is resumed or a child is forked, use `pause` rather than
+ordinary `stop` when its writable filesystem must survive. AgentKernel rejects
+ordinary stop for these full-state lineages until durable Firecracker disk
+lineage is implemented; `remove` remains the explicit discard operation.
+
+## Resume side effects and clone safety
+
+Full-state continuation does not mean every external connection survives:
+
+- Firecracker resets vsock across snapshot creation and restore. Existing
+  connections close; guest listen sockets remain and the AgentKernel guest
+  agent accepts a new host connection.
+- Network and vsock packet loss is expected, and established network
+  connections are not guaranteed to survive.
+- On x86_64, AgentKernel restores with Firecracker's `clock_realtime` option so
+  guest wall-clock time advances across the pause. That jump can surprise
+  software, so time behavior must still be tested for the workload.
+- Logging and metrics configuration are not part of the Firecracker snapshot
+  and must be recreated by the host.
+
+Firecracker updates VMGenID before resuming vCPUs. Linux 5.18 and newer uses
+that notification to reseed its in-kernel random-number generator; the supported
+6.18.45 guest is new enough for this path. VMGenID does **not** deduplicate
+userspace state. Cached random values, one-time tokens, application IDs,
+`/proc/sys/kernel/random/boot_id`, SSH host keys, and any credentials already in
+guest memory or on disk can be identical in every fork.
+
+Treat `fork` as an explicit security boundary. Workloads that consume unique or
+one-time state need a cooperative post-restore hook or a pre-snapshot quiescence
+protocol. The API and MCP responses warn that guest memory and filesystem state,
+including credentials, are cloned.
+
+Do not take a reusable checkpoint during early guest boot. Firecracker warns
+that VMGenID interrupt handling might not yet be ready and the restored guest
+can crash.
+
+## Host proxy limitation
+
+The AgentKernel secret and model-governance proxy runs on the host; it is not
+part of the microVM snapshot. Processes restored from memory retain their old
+environment and open sockets, while a restarted host proxy can have a different
+endpoint. Full-state continuation therefore cannot currently promise transparent
+proxy-secret or model-governance continuity.
+
+Until a stable endpoint and rebind protocol is implemented and KVM-tested,
+AgentKernel rejects full-state pause, resume, and fork for a sandbox with
+host-side secret bindings or a governance proxy. Secrets supplied directly as
+guest environment variables or files are even more sensitive: they are copied
+into the checkpoint and duplicated into every fork.
+
+## Upgrade and recovery policy
+
+Before replacing Firecracker, the host kernel, or CPU configuration:
+
+1. list paused sandboxes and their compatibility metadata;
+2. resume and shut down work that must survive the upgrade, or retain the exact
+   runtime required by those checkpoints;
+3. upgrade and run the native KVM gate; and
+4. only then make the new runtime the default for newly paused sandboxes.
+
+AgentKernel must not attempt an incompatible full-state load and then fall back
+to a cold boot. A mismatch should leave the checkpoint intact and return an
+actionable error. Firecracker terminates its process when snapshot load fails,
+so a retry must use a fresh VMM process.
+
+## Test matrix
+
+| Layer | Required coverage | Where it runs | Release meaning |
+| --- | --- | --- | --- |
+| API serialization | `PATCH /vm` pause/resume; full snapshot create; load with `mem_backend: File`, `vsock_override`, `resume_vm: false`, and the clock policy | Every pull request | Request shape only |
+| Compatibility contract | Manifest round trip; exact VMM, architecture, host identity, host kernel, CPU fingerprint, and guest-kernel rejection; legacy filesystem snapshot separation | Every pull request | Deterministic policy only |
+| Unsupported backends | Docker, Podman, Apple, Hyperlight, Kubernetes, Nomad, and hosted backends fail without creating checkpoint artifacts | Every pull request where the backend is compiled | No silent downgrade |
+| Transaction failures | Failure after pause, memory/state creation, disk clone, and manifest staging either resumes the source or retains explicit recovery ownership and deterministic staging | Unit tests with injected failures | State-machine safety |
+| Artifact lifecycle | Immutable memory/state/disk, SHA-256 validation, independent child disks, and reference-aware deletion | Linux filesystem tests | Storage safety without KVM |
+| Native resume | A RAM-only value and the same guest process survive pause/resume; filesystem and guest-agent/vsock access still work | Dedicated x86_64 Linux KVM runner | Required for the feature claim |
+| Native fork | Two children load concurrently from one checkpoint, receive unique host sockets, and diverge on independent disks without changing the source | Dedicated x86_64 Linux KVM runner | Required for the fork claim |
+| Failure recovery | Corrupt/missing artifacts fail cleanly, leave the checkpoint retryable, and do not strand a VMM | Dedicated x86_64 Linux KVM runner | Required before release |
+| Clone hygiene | VMGenID-capable guest, random reseed observation, documented duplicate userspace identity, clock behavior, and proxy limitation | Dedicated x86_64 Linux KVM runner | Security/operations evidence |
+
+Unit tests on macOS do not validate KVM, Firecracker API behavior, guest process
+continuity, or concurrent forks.
+
+### Opt-in native KVM gate
+
+The existing native test is ignored by default. On the access-controlled runner
+labelled `self-hosted,Linux,X64,agentkernel-kvm-safe`, provision the pinned
+binary and guest assets, then run:
+
+```bash
+AGENTKERNEL_KVM_SMOKE=1 \
+FIRECRACKER_BIN=/opt/agentkernel/bin/firecracker \
+AGENTKERNEL_KVM_KERNEL=/opt/agentkernel/images/kernel/vmlinux-6.18.45-agentkernel \
+AGENTKERNEL_KVM_ROOTFS=/opt/agentkernel/images/rootfs/base.ext4 \
+cargo test --locked --test firecracker_kvm_smoke -- --ignored --nocapture
+```
+
+The runner must have readable and writable `/dev/kvm`. The test must verify
+Firecracker reports `v1.16.1`, and its cleanup path must execute even when an
+assertion fails. Dispatching the repository workflow requires explicit runner
+confirmation:
+
+```bash
+gh workflow run firecracker-kvm-smoke.yml -f confirm_safe_runner=true
+```
+
+Record the successful run URL before marking native suspend/resume/fork as
+validated. A compiled ignored test, a queued workflow, or a macOS test run is
+not KVM runtime evidence.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -99,6 +99,7 @@ nav:
   - Operations:
     - Overview: operations/index.md
     - Backend compatibility: operations/backend-compatibility.md
+    - Firecracker full-state: operations/firecracker-full-state.md
     - Kubernetes: operations/kubernetes.md
     - Nomad: operations/nomad.md
     - Deployment: operations/deploy.md

--- a/sdk/golang/types.go
+++ b/sdk/golang/types.go
@@ -53,16 +53,18 @@ type SandboxInfo struct {
 
 // BackendCapabilities describes operations supported by a backend.
 type BackendCapabilities struct {
-	MountCWD            bool `json:"mount_cwd"`
-	MountHome           bool `json:"mount_home"`
-	Attach              bool `json:"attach"`
-	HostVolumes         bool `json:"host_volumes"`
-	SSH                 bool `json:"ssh"`
-	ProxySecretBindings bool `json:"proxy_secret_bindings"`
-	SecretFiles         bool `json:"secret_files"`
-	Snapshots           bool `json:"snapshots"`
-	Resume              bool `json:"resume"`
-	Endpoints           bool `json:"endpoints"`
+	MountCWD             bool `json:"mount_cwd"`
+	MountHome            bool `json:"mount_home"`
+	Attach               bool `json:"attach"`
+	HostVolumes          bool `json:"host_volumes"`
+	SSH                  bool `json:"ssh"`
+	ProxySecretBindings  bool `json:"proxy_secret_bindings"`
+	SecretFiles          bool `json:"secret_files"`
+	Snapshots            bool `json:"snapshots"`
+	Resume               bool `json:"resume"`
+	FullStatePauseResume bool `json:"full_state_pause_resume"`
+	FullStateFork        bool `json:"full_state_fork"`
+	Endpoints            bool `json:"endpoints"`
 }
 
 // BackendDescriptor describes one server backend.

--- a/sdk/nodejs/src/types.ts
+++ b/sdk/nodejs/src/types.ts
@@ -2,7 +2,12 @@
 export type SecurityProfile = "permissive" | "moderate" | "restrictive";
 
 /** Sandbox status. */
-export type SandboxStatus = "running" | "stopped";
+export type SandboxStatus =
+  | "running"
+  | "paused"
+  | "stopped"
+  | "dormant"
+  | "archived";
 
 /** SSE event types emitted by /run/stream. */
 export type StreamEventType = "started" | "progress" | "output" | "done" | "error";
@@ -92,6 +97,8 @@ export interface BackendCapabilities {
   secret_files: boolean;
   snapshots: boolean;
   resume: boolean;
+  full_state_pause_resume: boolean;
+  full_state_fork: boolean;
   endpoints: boolean;
 }
 

--- a/sdk/nodejs/tests/client.test.ts
+++ b/sdk/nodejs/tests/client.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
 import { http, HttpResponse } from "msw";
 import { setupServer } from "msw/node";
 import { AgentKernel } from "../src/client.js";
+import type { SandboxStatus } from "../src/types.js";
 import {
   AuthError,
   NotFoundError,
@@ -10,6 +11,13 @@ import {
 } from "../src/errors.js";
 
 const BASE_URL = "http://localhost:9999";
+const lifecycleStatuses: SandboxStatus[] = [
+  "running",
+  "paused",
+  "stopped",
+  "dormant",
+  "archived",
+];
 
 const handlers = [
   http.get(`${BASE_URL}/health`, () =>
@@ -83,6 +91,16 @@ function client(opts?: { apiKey?: string }) {
 }
 
 describe("AgentKernel", () => {
+  it("represents every sandbox lifecycle status", () => {
+    expect(lifecycleStatuses).toEqual([
+      "running",
+      "paused",
+      "stopped",
+      "dormant",
+      "archived",
+    ]);
+  });
+
   describe("health", () => {
     it("returns ok", async () => {
       expect(await client().health()).toBe("ok");

--- a/sdk/python/src/agentkernel/types.py
+++ b/sdk/python/src/agentkernel/types.py
@@ -7,7 +7,7 @@ from typing import Any, Literal
 from pydantic import BaseModel
 
 SecurityProfile = Literal["permissive", "moderate", "restrictive"]
-SandboxStatus = Literal["running", "stopped"]
+SandboxStatus = Literal["running", "paused", "stopped", "dormant", "archived"]
 StreamEventType = Literal["started", "progress", "output", "done", "error"]
 
 
@@ -40,6 +40,8 @@ class BackendCapabilities(BaseModel):
     secret_files: bool
     snapshots: bool
     resume: bool
+    full_state_pause_resume: bool
+    full_state_fork: bool
     endpoints: bool
 
 

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -61,13 +61,15 @@ class TestListSandboxes:
                 "data": [
                     {"name": "sb-1", "status": "running", "backend": "docker"},
                     {"name": "sb-2", "status": "stopped", "backend": "docker"},
+                    {"name": "sb-3", "status": "paused", "backend": "firecracker"},
                 ],
             }
         )
         result = make_client().list_sandboxes()
-        assert len(result) == 2
+        assert len(result) == 3
         assert all(isinstance(s, SandboxInfo) for s in result)
         assert result[0].name == "sb-1"
+        assert result[2].status == "paused"
 
 
 class TestCreateSandbox:

--- a/sdk/rust/src/types.rs
+++ b/sdk/rust/src/types.rs
@@ -52,6 +52,8 @@ pub struct BackendCapabilities {
     pub secret_files: bool,
     pub snapshots: bool,
     pub resume: bool,
+    pub full_state_pause_resume: bool,
+    pub full_state_fork: bool,
     pub endpoints: bool,
 }
 

--- a/sdk/swift/Sources/AgentKernel/Types.swift
+++ b/sdk/swift/Sources/AgentKernel/Types.swift
@@ -117,6 +117,8 @@ public struct BackendCapabilities: Codable, Sendable {
     public let secret_files: Bool
     public let snapshots: Bool
     public let resume: Bool
+    public let full_state_pause_resume: Bool
+    public let full_state_fork: Bool
     public let endpoints: Bool
 }
 

--- a/src/backend/firecracker.rs
+++ b/src/backend/firecracker.rs
@@ -2,15 +2,63 @@
 
 use anyhow::{Context, Result, bail};
 use async_trait::async_trait;
+use sha2::{Digest, Sha256};
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use tokio::time::{Duration, sleep};
+use uuid::Uuid;
 
-use super::{BackendType, ExecResult, Sandbox, SandboxConfig};
+use super::{
+    BackendType, ExecResult, FullStatePauseError, FullStateSnapshot, FullStateTerminationError,
+    Sandbox, SandboxConfig,
+};
 use crate::cow::{RootfsCow, RootfsCowStore};
-use crate::firecracker_client::{BootSource, Drive, FirecrackerClient, MachineConfig, VsockDevice};
+use crate::firecracker_client::{
+    BootSource, Drive, FirecrackerClient, MachineConfig, MemoryBackend, SnapshotCreateParams,
+    SnapshotLoadParams, VsockDevice, VsockOverride,
+};
+use crate::full_state::{MEMORY_FILE, ROOTFS_FILE, VMSTATE_FILE};
 use crate::languages::docker_image_to_firecracker_runtime;
 use crate::vsock::VsockClient;
+
+const SUPPORTED_FIRECRACKER_VERSION: &str = "1.16.1";
+const SUPPORTED_GUEST_KERNEL_RELEASE: &str = "6.18.45-agentkernel";
+
+fn canonical_firecracker_binary(path: impl AsRef<Path>) -> Result<PathBuf> {
+    let path = path.as_ref();
+    fs::canonicalize(path)
+        .with_context(|| format!("failed to resolve Firecracker binary {}", path.display()))
+}
+
+fn ensure_full_state_host_supported() -> Result<()> {
+    if !cfg!(all(target_os = "linux", target_arch = "x86_64")) {
+        bail!(
+            "Firecracker full-state pause/resume requires Linux x86_64 with KVM (host is {} {})",
+            std::env::consts::OS,
+            std::env::consts::ARCH
+        );
+    }
+    Ok(())
+}
+
+fn ensure_clock_realtime_kernel_supported(release: &str) -> Result<()> {
+    let mut parts = release.split(['.', '-']);
+    let major = parts
+        .next()
+        .and_then(|part| part.parse::<u32>().ok())
+        .ok_or_else(|| anyhow::anyhow!("unrecognized host kernel release '{release}'"))?;
+    let minor = parts
+        .next()
+        .and_then(|part| part.parse::<u32>().ok())
+        .ok_or_else(|| anyhow::anyhow!("unrecognized host kernel release '{release}'"))?;
+    if (major, minor) < (5, 16) {
+        bail!(
+            "Firecracker full-state restore with clock_realtime requires host Linux >= 5.16 (host is {release})"
+        );
+    }
+    Ok(())
+}
 
 /// Check if Firecracker is available
 pub fn firecracker_available() -> bool {
@@ -23,7 +71,7 @@ fn find_firecracker() -> Result<PathBuf> {
     if let Ok(path) = std::env::var("FIRECRACKER_BIN") {
         let path = PathBuf::from(path);
         if path.exists() {
-            return Ok(path);
+            return canonical_firecracker_binary(path);
         }
     }
 
@@ -34,13 +82,13 @@ fn find_firecracker() -> Result<PathBuf> {
         // ~/.local/bin/firecracker (common user install location)
         let local_bin = home.join(".local/bin/firecracker");
         if local_bin.exists() {
-            return Ok(local_bin);
+            return canonical_firecracker_binary(local_bin);
         }
 
         // ~/.local/share/agentkernel/bin/firecracker (agentkernel managed)
         let agentkernel_bin = home.join(".local/share/agentkernel/bin/firecracker");
         if agentkernel_bin.exists() {
-            return Ok(agentkernel_bin);
+            return canonical_firecracker_binary(agentkernel_bin);
         }
     }
 
@@ -54,7 +102,7 @@ fn find_firecracker() -> Result<PathBuf> {
     for loc in locations {
         let path = PathBuf::from(loc);
         if path.exists() {
-            return Ok(path);
+            return canonical_firecracker_binary(path);
         }
     }
 
@@ -64,16 +112,291 @@ fn find_firecracker() -> Result<PathBuf> {
     {
         let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
         if !path.is_empty() {
-            return Ok(PathBuf::from(path));
+            return canonical_firecracker_binary(path);
         }
     }
 
     bail!("Firecracker binary not found")
 }
 
+fn host_kernel_release() -> Result<String> {
+    let output = Command::new("uname")
+        .arg("-r")
+        .output()
+        .context("failed to inspect host kernel release")?;
+    if !output.status.success() {
+        bail!(
+            "failed to inspect host kernel release: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    let release = String::from_utf8(output.stdout)
+        .context("host kernel release is not valid UTF-8")?
+        .trim()
+        .to_string();
+    if release.is_empty() {
+        bail!("host kernel release is empty");
+    }
+    Ok(release)
+}
+
+fn sha256_hex(value: &[u8]) -> String {
+    hex::encode(Sha256::digest(value))
+}
+
+fn host_identity_sha256() -> Result<String> {
+    let machine_id = fs::read_to_string("/etc/machine-id")
+        .context("failed to read host machine identity from /etc/machine-id")?;
+    let machine_id = machine_id.trim();
+    if machine_id.is_empty() {
+        bail!("host machine identity is empty");
+    }
+    Ok(sha256_hex(machine_id.as_bytes()))
+}
+
+fn canonical_cpu_identity(cpuinfo: &str) -> Result<String> {
+    let stanza = cpuinfo
+        .split("\n\n")
+        .find(|stanza| stanza.lines().any(|line| line.starts_with("processor")))
+        .ok_or_else(|| anyhow::anyhow!("/proc/cpuinfo contains no processor stanza"))?;
+    let fields = [
+        "vendor_id",
+        "cpu family",
+        "model",
+        "model name",
+        "stepping",
+        "microcode",
+        "flags",
+    ];
+    let mut canonical = Vec::new();
+    for field in fields {
+        let Some((_, raw_value)) = stanza.lines().find_map(|line| {
+            let (key, value) = line.split_once(':')?;
+            (key.trim() == field).then_some((key, value))
+        }) else {
+            if matches!(
+                field,
+                "vendor_id" | "cpu family" | "model" | "stepping" | "flags"
+            ) {
+                bail!("/proc/cpuinfo is missing required CPU field '{field}'");
+            }
+            continue;
+        };
+        let value = if field == "flags" {
+            let mut flags: Vec<&str> = raw_value.split_whitespace().collect();
+            flags.sort_unstable();
+            flags.dedup();
+            flags.join(" ")
+        } else {
+            raw_value.split_whitespace().collect::<Vec<_>>().join(" ")
+        };
+        canonical.push(format!("{field}={value}"));
+    }
+    Ok(canonical.join("\n"))
+}
+
+fn cpu_fingerprint_sha256() -> Result<String> {
+    let cpuinfo = fs::read_to_string("/proc/cpuinfo").context("failed to read /proc/cpuinfo")?;
+    Ok(sha256_hex(canonical_cpu_identity(&cpuinfo)?.as_bytes()))
+}
+
+fn ensure_guest_kernel_supported(release: &str) -> Result<()> {
+    if release != SUPPORTED_GUEST_KERNEL_RELEASE {
+        bail!(
+            "Firecracker full-state requires guest kernel {}, guest is {}",
+            SUPPORTED_GUEST_KERNEL_RELEASE,
+            release
+        );
+    }
+    Ok(())
+}
+
+fn firecracker_binary_version(binary: &Path) -> Result<String> {
+    let output = Command::new(binary)
+        .arg("--version")
+        .output()
+        .with_context(|| format!("failed to run {} --version", binary.display()))?;
+    if !output.status.success() {
+        bail!(
+            "failed to inspect Firecracker version: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    let stdout = String::from_utf8(output.stdout)
+        .context("Firecracker version output is not valid UTF-8")?;
+    parse_firecracker_version(&stdout)
+}
+
+fn parse_firecracker_version(output: &str) -> Result<String> {
+    output
+        .split_whitespace()
+        .rev()
+        .find_map(|word| {
+            let version = word.strip_prefix('v').unwrap_or(word);
+            (version.chars().next().is_some_and(|c| c.is_ascii_digit()) && version.contains('.'))
+                .then(|| version.to_string())
+        })
+        .ok_or_else(|| anyhow::anyhow!("unrecognized Firecracker version output: {output:?}"))
+}
+
+fn ensure_checkpoint_artifact(checkpoint_dir: &Path, name: &str) -> Result<PathBuf> {
+    let path = checkpoint_dir.join(name);
+    let metadata = fs::symlink_metadata(&path)
+        .with_context(|| format!("checkpoint artifact is missing: {}", path.display()))?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() || metadata.len() == 0 {
+        bail!(
+            "checkpoint artifact must be a non-empty regular file: {}",
+            path.display()
+        );
+    }
+    fs::canonicalize(&path)
+        .with_context(|| format!("failed to resolve checkpoint artifact {}", path.display()))
+}
+
+fn validate_checkpoint_output_dir(checkpoint_dir: &Path) -> Result<PathBuf> {
+    let metadata = fs::symlink_metadata(checkpoint_dir).with_context(|| {
+        format!(
+            "full-state checkpoint directory is missing: {}",
+            checkpoint_dir.display()
+        )
+    })?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        bail!(
+            "full-state checkpoint path is not a directory: {}",
+            checkpoint_dir.display()
+        );
+    }
+    for file in [MEMORY_FILE, VMSTATE_FILE, ROOTFS_FILE] {
+        let path = checkpoint_dir.join(file);
+        if fs::symlink_metadata(&path).is_ok() {
+            bail!(
+                "refusing to overwrite checkpoint artifact {}",
+                path.display()
+            );
+        }
+    }
+    fs::canonicalize(checkpoint_dir).with_context(|| {
+        format!(
+            "failed to resolve full-state checkpoint directory {}",
+            checkpoint_dir.display()
+        )
+    })
+}
+
+fn cleanup_checkpoint_artifacts(checkpoint_dir: &Path) {
+    for file in [MEMORY_FILE, VMSTATE_FILE, ROOTFS_FILE] {
+        let _ = fs::remove_file(checkpoint_dir.join(file));
+    }
+}
+
+fn transition_cleanup_error(
+    phase: &str,
+    transition_error: &anyhow::Error,
+    cleanup_error: anyhow::Error,
+) -> anyhow::Error {
+    cleanup_error.context(format!(
+        "Firecracker {phase} failed ({transition_error:#}) and cleanup could not prove the VMM exited"
+    ))
+}
+
+#[cfg(unix)]
+fn ensure_private_owned_directory(path: &Path) -> Result<()> {
+    use std::os::unix::fs::{DirBuilderExt, MetadataExt, PermissionsExt};
+
+    match fs::DirBuilder::new().mode(0o700).create(path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("failed to create runtime directory {}", path.display()));
+        }
+    }
+    let metadata = fs::symlink_metadata(path)?;
+    if metadata.file_type().is_symlink()
+        || !metadata.is_dir()
+        || metadata.uid() != unsafe { libc::geteuid() }
+        || metadata.permissions().mode() & 0o777 != 0o700
+    {
+        bail!(
+            "Firecracker runtime directory must be a current-user-owned 0700 directory: {}",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn create_private_runtime_directory(runtime_id: &str) -> Result<PathBuf> {
+    // Keep the rendered path below macOS/Linux `sockaddr_un.sun_path` limits;
+    // the current-user-owned 0700 parent is the security boundary.
+    let user_root =
+        PathBuf::from("/tmp").join(format!("agentkernel-fc-{}", unsafe { libc::geteuid() }));
+    ensure_private_owned_directory(&user_root)?;
+    let runtime = user_root.join(runtime_id);
+    ensure_private_owned_directory(&runtime)?;
+    Ok(runtime)
+}
+
+#[cfg(not(unix))]
+fn create_private_runtime_directory(_runtime_id: &str) -> Result<PathBuf> {
+    bail!("Firecracker runtime sockets require a Unix host")
+}
+
+#[cfg(unix)]
+fn secure_runtime_socket(path: &Path) -> Result<()> {
+    use std::os::unix::fs::{FileTypeExt, MetadataExt, PermissionsExt};
+
+    let metadata = fs::symlink_metadata(path)
+        .with_context(|| format!("failed to inspect runtime socket {}", path.display()))?;
+    if metadata.file_type().is_symlink()
+        || !metadata.file_type().is_socket()
+        || metadata.uid() != unsafe { libc::geteuid() }
+    {
+        bail!(
+            "Firecracker runtime endpoint is not a current-user-owned Unix socket: {}",
+            path.display()
+        );
+    }
+    let mut permissions = metadata.permissions();
+    permissions.set_mode(0o600);
+    fs::set_permissions(path, permissions)
+        .with_context(|| format!("failed to secure runtime socket {}", path.display()))?;
+    let secured = fs::symlink_metadata(path)?;
+    if secured.file_type().is_symlink()
+        || !secured.file_type().is_socket()
+        || secured.uid() != unsafe { libc::geteuid() }
+        || secured.permissions().mode() & 0o777 != 0o600
+    {
+        bail!(
+            "Firecracker runtime socket permissions are not 0600: {}",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn secure_runtime_socket(_path: &Path) -> Result<()> {
+    bail!("Firecracker runtime sockets require a Unix host")
+}
+
+fn make_checkpoint_artifacts_readonly(checkpoint_dir: &Path) -> Result<()> {
+    for file in [MEMORY_FILE, VMSTATE_FILE, ROOTFS_FILE] {
+        let path = checkpoint_dir.join(file);
+        let mut permissions = fs::metadata(&path)
+            .with_context(|| format!("failed to inspect {}", path.display()))?
+            .permissions();
+        permissions.set_readonly(true);
+        fs::set_permissions(&path, permissions)
+            .with_context(|| format!("failed to make {} immutable", path.display()))?;
+    }
+    Ok(())
+}
+
 /// Firecracker microVM sandbox
 pub struct FirecrackerSandbox {
     name: String,
+    runtime_dir: PathBuf,
     socket_path: PathBuf,
     vsock_path: PathBuf,
     process: Option<Child>,
@@ -89,12 +412,13 @@ pub struct FirecrackerSandbox {
 impl FirecrackerSandbox {
     /// Create a new Firecracker sandbox
     pub fn new(name: &str) -> Result<Self> {
-        let socket_path = PathBuf::from(format!("/tmp/agentkernel-{}.sock", name));
-        let vsock_path = PathBuf::from(format!("/tmp/agentkernel-{}-vsock.sock", name));
-
-        // Clean up any existing sockets
-        let _ = std::fs::remove_file(&socket_path);
-        let _ = std::fs::remove_file(&vsock_path);
+        // Socket paths are runtime identities, not sandbox-name identities.
+        // A fresh nonce prevents a restored fork from colliding with its
+        // source or with another process that happens to use the same name.
+        let runtime_id = Uuid::new_v4().simple().to_string();
+        let runtime_dir = create_private_runtime_directory(&runtime_id)?;
+        let socket_path = runtime_dir.join("api.sock");
+        let vsock_path = runtime_dir.join("vsock.sock");
 
         // Generate a unique CID (use hash of name + timestamp)
         let vsock_cid = 100
@@ -106,6 +430,7 @@ impl FirecrackerSandbox {
 
         Ok(Self {
             name: name.to_string(),
+            runtime_dir,
             socket_path,
             vsock_path,
             process: None,
@@ -129,6 +454,16 @@ impl FirecrackerSandbox {
         self
     }
 
+    /// Firecracker API socket for this runtime instance.
+    pub fn api_socket_path(&self) -> &Path {
+        &self.socket_path
+    }
+
+    /// Host-side vsock UDS for this runtime instance.
+    pub fn vsock_socket_path(&self) -> &Path {
+        &self.vsock_path
+    }
+
     /// Return the private rootfs image currently attached to this sandbox.
     ///
     /// The path is only available after `start` has prepared the image. Call
@@ -150,19 +485,24 @@ impl FirecrackerSandbox {
 
     /// Find kernel path
     fn find_kernel() -> Result<PathBuf> {
-        // Helper to find first vmlinux in a directory
-        fn find_vmlinux_in(dir: &PathBuf) -> Option<PathBuf> {
-            if dir.exists()
-                && let Ok(entries) = std::fs::read_dir(dir)
-            {
-                for entry in entries.flatten() {
-                    let name = entry.file_name();
-                    if name.to_string_lossy().starts_with("vmlinux") {
-                        return Some(entry.path());
-                    }
-                }
+        fn find_vmlinux_in(dir: &Path) -> Option<PathBuf> {
+            let managed = dir.join(format!("vmlinux-{SUPPORTED_GUEST_KERNEL_RELEASE}"));
+            if managed.is_file() {
+                return Some(managed);
             }
-            None
+            let mut kernels: Vec<PathBuf> = std::fs::read_dir(dir)
+                .ok()?
+                .flatten()
+                .filter_map(|entry| {
+                    entry
+                        .file_name()
+                        .to_string_lossy()
+                        .starts_with("vmlinux")
+                        .then(|| entry.path())
+                })
+                .collect();
+            kernels.sort();
+            kernels.into_iter().next()
         }
 
         // Check local images/kernel/ (development)
@@ -221,12 +561,40 @@ impl FirecrackerSandbox {
     /// Wait for the API socket to be available
     async fn wait_for_socket(&self) -> Result<()> {
         for _ in 0..50 {
-            if self.socket_path.exists() {
-                return Ok(());
+            match fs::symlink_metadata(&self.socket_path) {
+                Ok(_) => {
+                    secure_runtime_socket(&self.socket_path)?;
+                    return Ok(());
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    return Err(error).context("failed to inspect Firecracker API socket");
+                }
             }
             sleep(Duration::from_millis(100)).await;
         }
         bail!("Firecracker API socket not available after 5 seconds")
+    }
+
+    fn spawn_firecracker(&mut self, firecracker_bin: &Path) -> Result<()> {
+        let working_directory = self
+            .sandbox_rootfs
+            .as_ref()
+            .map(RootfsCow::artifact_dir)
+            .ok_or_else(|| anyhow::anyhow!("sandbox rootfs has not been prepared"))?;
+        let process = Command::new(firecracker_bin)
+            .arg("--api-sock")
+            .arg(&self.socket_path)
+            .current_dir(working_directory)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .with_context(|| {
+                format!("Failed to start firecracker: {}", firecracker_bin.display())
+            })?;
+        self.process = Some(process);
+        Ok(())
     }
 
     /// Configure the VM via the Firecracker API
@@ -239,13 +607,11 @@ impl FirecrackerSandbox {
             .clone()
             .or_else(|| Self::find_kernel().ok())
             .ok_or_else(|| anyhow::anyhow!("Kernel path not set"))?;
+        let kernel_path = fs::canonicalize(&kernel_path)
+            .with_context(|| format!("failed to resolve kernel {}", kernel_path.display()))?;
 
-        let rootfs_path = self
-            .sandbox_rootfs
+        self.sandbox_rootfs
             .as_ref()
-            .map(|rootfs| rootfs.path().to_path_buf())
-            .or_else(|| self.rootfs_path.clone())
-            .or_else(|| Self::find_rootfs(&config.image).ok())
             .ok_or_else(|| anyhow::anyhow!("Rootfs path not set"))?;
 
         // Set boot source with optimized boot args
@@ -258,7 +624,10 @@ impl FirecrackerSandbox {
         // Set root drive
         let drive = Drive {
             drive_id: "rootfs".to_string(),
-            path_on_host: rootfs_path.to_string_lossy().to_string(),
+            // This relative path is part of the snapshot compatibility
+            // contract.  Every restored fork runs from its own RootfsCow
+            // artifact directory containing a private `rootfs.ext4`.
+            path_on_host: ROOTFS_FILE.to_string(),
             is_root_device: true,
             is_read_only: false,
         };
@@ -292,6 +661,13 @@ impl FirecrackerSandbox {
         let client = VsockClient::for_firecracker(&self.vsock_path);
 
         for i in 0..100 {
+            match fs::symlink_metadata(&self.vsock_path) {
+                Ok(_) => secure_runtime_socket(&self.vsock_path)?,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    return Err(error).context("failed to inspect Firecracker vsock endpoint");
+                }
+            }
             if client.ping().await.unwrap_or(false) {
                 return Ok(());
             }
@@ -304,60 +680,190 @@ impl FirecrackerSandbox {
         bail!("Guest agent not available after 10 seconds")
     }
 
-    fn abort_start(&mut self) {
-        if let Some(ref mut process) = self.process {
-            let _ = process.kill();
-            let _ = process.wait();
+    async fn guest_kernel_release(&self) -> Result<String> {
+        let client = VsockClient::for_firecracker(&self.vsock_path);
+        let result = client
+            .run_command(&["uname".to_string(), "-r".to_string()])
+            .await
+            .context("failed to query guest kernel release")?;
+        if result.exit_code != 0 {
+            bail!(
+                "failed to query guest kernel release (exit {}): {}",
+                result.exit_code,
+                result.stderr.trim()
+            );
         }
-        let _ = std::fs::remove_file(&self.socket_path);
-        let _ = std::fs::remove_file(&self.vsock_path);
-        if let Some(rootfs) = self.sandbox_rootfs.take() {
-            let _ = rootfs.cleanup();
+        let release = result.stdout.trim().to_string();
+        if release.is_empty() {
+            bail!("guest kernel release is empty");
         }
+        Ok(release)
+    }
+
+    fn abort_start(&mut self) -> Result<()> {
+        // Failed start/restore cleanup is a lifecycle proof boundary too. Do
+        // not hide kill/reap uncertainty behind best-effort cleanup: callers
+        // must retain this backend whenever the process may still exist.
+        self.terminate_paused_runtime()
+    }
+
+    /// Terminate a VM after all checkpoint artifacts have been durably
+    /// produced.  An error is only returned while the original process is
+    /// still available to resume. Cleanup errors after confirmed process exit
+    /// are still returned so normal stop callers can report leaked artifacts;
+    /// the lifecycle layer may safely publish a complete checkpoint after a
+    /// subsequent idempotent stop confirms no process remains.
+    fn terminate_paused_runtime(&mut self) -> Result<()> {
+        if let Some(mut process) = self.process.take() {
+            let status = match process.try_wait() {
+                Ok(status) => status,
+                Err(error) => {
+                    self.process = Some(process);
+                    return Err(FullStateTerminationError {
+                        process_may_be_running: true,
+                        detail: format!("failed to inspect paused Firecracker: {error}"),
+                    }
+                    .into());
+                }
+            };
+            match status {
+                Some(_) => {}
+                None => {
+                    if let Err(error) = process.kill() {
+                        self.process = Some(process);
+                        return Err(FullStateTerminationError {
+                            process_may_be_running: true,
+                            detail: format!("failed to terminate paused Firecracker: {error}"),
+                        }
+                        .into());
+                    }
+                    if let Err(error) = process.wait() {
+                        self.process = Some(process);
+                        return Err(FullStateTerminationError {
+                            process_may_be_running: true,
+                            detail: format!(
+                                "failed to confirm terminated Firecracker process exit: {error}"
+                            ),
+                        }
+                        .into());
+                    }
+                }
+            }
+        }
+
+        let _ = fs::remove_file(&self.socket_path);
+        let _ = fs::remove_file(&self.vsock_path);
+        let _ = fs::remove_dir(&self.runtime_dir);
+        let cleanup_result = self
+            .sandbox_rootfs
+            .take()
+            .map_or(Ok(()), |rootfs| rootfs.cleanup());
         self.running = false;
+        cleanup_result.map_err(|error| {
+            FullStateTerminationError {
+                process_may_be_running: false,
+                detail: format!(
+                    "Firecracker process exited, but runtime rootfs cleanup failed: {error:#}"
+                ),
+            }
+            .into()
+        })
+    }
+
+    async fn resume_after_snapshot_failure(
+        &mut self,
+        client: &FirecrackerClient,
+        checkpoint_dir: &Path,
+        snapshot: &FullStateSnapshot,
+        artifacts_complete: bool,
+        snapshot_error: anyhow::Error,
+    ) -> Result<FullStateSnapshot> {
+        match client.resume().await {
+            Ok(()) => {
+                self.running = true;
+                let agent_health = self.wait_for_agent().await;
+                self.finish_resumed_snapshot_failure(
+                    checkpoint_dir,
+                    snapshot,
+                    artifacts_complete,
+                    snapshot_error,
+                    agent_health,
+                )
+            }
+            Err(resume_error) => {
+                self.running = false;
+                Err(FullStatePauseError::source_resume_failed(
+                    snapshot.clone(),
+                    artifacts_complete,
+                    format!("{snapshot_error:#}"),
+                    format!("{resume_error:#}"),
+                )
+                .into())
+            }
+        }
+    }
+
+    fn finish_resumed_snapshot_failure(
+        &mut self,
+        checkpoint_dir: &Path,
+        snapshot: &FullStateSnapshot,
+        artifacts_complete: bool,
+        snapshot_error: anyhow::Error,
+        agent_health: Result<()>,
+    ) -> Result<FullStateSnapshot> {
+        match agent_health {
+            Ok(()) => {
+                // The Resume response alone is not enough: retain complete or
+                // partial artifacts until guest health proves the source is
+                // usable again.
+                cleanup_checkpoint_artifacts(checkpoint_dir);
+                Err(snapshot_error.context("full-state checkpoint failed; source VM resumed"))
+            }
+            Err(agent_error) => Err(FullStatePauseError::source_resume_failed(
+                snapshot.clone(),
+                artifacts_complete,
+                format!("{snapshot_error:#}"),
+                format!("Resume was accepted, but guest health was not confirmed: {agent_error:#}"),
+            )
+            .into()),
+        }
     }
 }
 
 #[async_trait]
 impl Sandbox for FirecrackerSandbox {
     async fn start(&mut self, config: &SandboxConfig) -> Result<()> {
+        if self.running || self.process.is_some() || self.sandbox_rootfs.is_some() {
+            bail!(
+                "Firecracker sandbox '{}' already has an active runtime",
+                self.name
+            );
+        }
         let firecracker_bin = find_firecracker()?;
 
         // Create a per-sandbox CoW rootfs for filesystem isolation.  The
         // helper explicitly detects reflink support and falls back to the
         // previous full-copy behavior.  Overlayfs is reported as a host
         // capability but is not suitable for Firecracker's ext4 drive file.
-        let base_rootfs = self
-            .rootfs_path
-            .clone()
-            .or_else(|| Self::find_rootfs(&config.image).ok());
-        if let Some(base) = base_rootfs {
-            let store = RootfsCowStore::open_default()?;
-            let rootfs = store
-                .prepare(&base)
-                .with_context(|| format!("failed to prepare writable rootfs for {}", self.name))?;
-            eprintln!(
-                "[firecracker] rootfs COW strategy={:?} path={}",
-                rootfs.strategy(),
-                rootfs.path().display()
-            );
-            self.sandbox_rootfs = Some(rootfs);
-        }
+        let base_rootfs = match self.rootfs_path.clone() {
+            Some(path) => path,
+            None => Self::find_rootfs(&config.image)?,
+        };
+        let store = RootfsCowStore::open_default()?;
+        let rootfs = store
+            .prepare(&base_rootfs)
+            .with_context(|| format!("failed to prepare writable rootfs for {}", self.name))?;
+        eprintln!(
+            "[firecracker] rootfs COW strategy={:?} path={}",
+            rootfs.strategy(),
+            rootfs.path().display()
+        );
+        self.sandbox_rootfs = Some(rootfs);
 
         let startup = async {
-            // Start firecracker process
-            let process = Command::new(&firecracker_bin)
-                .arg("--api-sock")
-                .arg(&self.socket_path)
-                .stdin(Stdio::null())
-                .stdout(Stdio::piped())
-                .stderr(Stdio::piped())
-                .spawn()
-                .with_context(|| {
-                    format!("Failed to start firecracker: {}", firecracker_bin.display())
-                })?;
-
-            self.process = Some(process);
+            // The root drive is configured as `rootfs.ext4`, so this process
+            // must run inside the private RootfsCow artifact directory.
+            self.spawn_firecracker(&firecracker_bin)?;
 
             // Wait for socket, configure, start, and wait for the guest agent.
             self.wait_for_socket().await?;
@@ -376,8 +882,12 @@ impl Sandbox for FirecrackerSandbox {
             Err(error) => {
                 // Do not leave a partially started VM or its rootfs behind if
                 // startup fails after the COW artifact was published.
-                self.abort_start();
-                Err(error)
+                match self.abort_start() {
+                    Ok(()) => Err(error),
+                    Err(cleanup_error) => {
+                        Err(transition_cleanup_error("startup", &error, cleanup_error))
+                    }
+                }
             }
         }
     }
@@ -406,22 +916,336 @@ impl Sandbox for FirecrackerSandbox {
         // Give it a moment to shutdown gracefully
         sleep(Duration::from_millis(500)).await;
 
-        // Kill the process if still running
-        if let Some(ref mut process) = self.process {
-            let _ = process.kill();
-            let _ = process.wait();
+        // The lifecycle layer relies on a successful stop as proof that a
+        // checkpoint cannot coexist with an untracked original VM. Preserve
+        // the child handle and return an error if kill/reap is ambiguous.
+        self.terminate_paused_runtime()
+    }
+
+    async fn pause_to(&mut self, checkpoint_dir: &Path) -> Result<FullStateSnapshot> {
+        ensure_full_state_host_supported()?;
+        if !self.running || self.process.is_none() {
+            bail!("Firecracker sandbox '{}' is not running", self.name);
+        }
+        let checkpoint_dir = validate_checkpoint_output_dir(checkpoint_dir)?;
+        if self.sandbox_rootfs.is_none() {
+            bail!("sandbox rootfs has not been prepared");
+        }
+        let client = FirecrackerClient::new(&self.socket_path);
+        let firecracker_version = client
+            .get_version()
+            .await
+            .context("failed to inspect running Firecracker version")?
+            .firecracker_version;
+        if firecracker_version != SUPPORTED_FIRECRACKER_VERSION {
+            bail!(
+                "full-state pause requires Firecracker {}, running process is {}",
+                SUPPORTED_FIRECRACKER_VERSION,
+                firecracker_version
+            );
+        }
+        let host_kernel_release = host_kernel_release()?;
+        ensure_clock_realtime_kernel_supported(&host_kernel_release)?;
+        let guest_kernel_release = self.guest_kernel_release().await?;
+        ensure_guest_kernel_supported(&guest_kernel_release)?;
+        let snapshot = FullStateSnapshot {
+            firecracker_version,
+            architecture: std::env::consts::ARCH.to_string(),
+            host_kernel_release,
+            host_identity_sha256: host_identity_sha256()?,
+            cpu_fingerprint_sha256: cpu_fingerprint_sha256()?,
+            guest_kernel_release,
+        };
+
+        if let Err(pause_error) = client.pause().await {
+            match client.get_instance_info().await {
+                Ok(instance) if instance.state == "Paused" => {
+                    return self
+                        .resume_after_snapshot_failure(
+                            &client,
+                            &checkpoint_dir,
+                            &snapshot,
+                            false,
+                            pause_error.context(
+                                "pause response was lost after Firecracker entered Paused state",
+                            ),
+                        )
+                        .await;
+                }
+                Ok(instance) => {
+                    return Err(pause_error).context(format!(
+                        "failed to pause Firecracker VM; observed instance state '{}'",
+                        instance.state
+                    ));
+                }
+                Err(inspect_error) => {
+                    // A transport failure can happen after Firecracker applied
+                    // the state change. Make one best-effort resume attempt so
+                    // the caller never silently treats a known-paused VM as
+                    // running.
+                    return self
+                        .resume_after_snapshot_failure(
+                            &client,
+                            &checkpoint_dir,
+                            &snapshot,
+                            false,
+                            pause_error.context(format!(
+                                "failed to confirm pause response because state inspection failed: {inspect_error:#}"
+                            )),
+                        )
+                        .await;
+                }
+            }
         }
 
-        // Clean up sockets and per-sandbox rootfs
-        let _ = std::fs::remove_file(&self.socket_path);
-        let _ = std::fs::remove_file(&self.vsock_path);
-        let cleanup_result = self
+        let rootfs = self
             .sandbox_rootfs
-            .take()
-            .map_or(Ok(()), |rootfs| rootfs.cleanup());
-        self.process = None;
-        self.running = false;
-        cleanup_result
+            .as_ref()
+            .expect("rootfs presence was validated before pausing");
+
+        let checkpoint_result = async {
+            let memory_path = checkpoint_dir.join(MEMORY_FILE);
+            let vmstate_path = checkpoint_dir.join(VMSTATE_FILE);
+            client
+                .create_snapshot(&SnapshotCreateParams {
+                    mem_file_path: memory_path.to_string_lossy().into_owned(),
+                    snapshot_path: vmstate_path.to_string_lossy().into_owned(),
+                    snapshot_type: "Full".to_string(),
+                })
+                .await
+                .context("Firecracker failed to create full VM snapshot")?;
+
+            let rootfs_path = checkpoint_dir.join(ROOTFS_FILE);
+            let strategy = rootfs.snapshot_to(&rootfs_path).with_context(|| {
+                format!(
+                    "failed to preserve paused rootfs in {}",
+                    checkpoint_dir.display()
+                )
+            })?;
+            eprintln!(
+                "[firecracker] checkpoint rootfs COW strategy={strategy:?} path={}",
+                rootfs_path.display()
+            );
+            make_checkpoint_artifacts_readonly(&checkpoint_dir)?;
+            Ok::<(), anyhow::Error>(())
+        }
+        .await;
+
+        if let Err(error) = checkpoint_result {
+            return self
+                .resume_after_snapshot_failure(&client, &checkpoint_dir, &snapshot, false, error)
+                .await;
+        }
+
+        if let Err(error) = self.terminate_paused_runtime() {
+            return self
+                .resume_after_snapshot_failure(&client, &checkpoint_dir, &snapshot, true, error)
+                .await;
+        }
+
+        Ok(snapshot)
+    }
+
+    fn full_state_reservation_bytes(&self, memory_mb: u64) -> Result<u64> {
+        let memory = memory_mb
+            .checked_mul(1024 * 1024)
+            .ok_or_else(|| anyhow::anyhow!("full-state memory reservation overflow"))?;
+        let rootfs = self
+            .sandbox_rootfs
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("sandbox rootfs has not been prepared"))?;
+        let rootfs_bytes = fs::metadata(rootfs.path())?.len();
+        memory
+            .checked_add(rootfs_bytes)
+            .and_then(|bytes| bytes.checked_add(64 * 1024 * 1024))
+            .ok_or_else(|| anyhow::anyhow!("full-state checkpoint reservation overflow"))
+    }
+
+    async fn retry_full_state_resume(&mut self) -> Result<()> {
+        ensure_full_state_host_supported()?;
+        if self.process.is_none() {
+            bail!(
+                "Firecracker sandbox '{}' has no live source process to resume",
+                self.name
+            );
+        }
+        let client = FirecrackerClient::new(&self.socket_path);
+        match client.get_instance_info().await {
+            Ok(instance) if instance.state == "Running" => {}
+            Ok(instance) if instance.state == "Paused" => {
+                if let Err(resume_error) = client.resume().await {
+                    match client.get_instance_info().await {
+                        Ok(observed) if observed.state == "Running" => {}
+                        Ok(observed) => {
+                            return Err(resume_error).context(format!(
+                                "failed to retry source resume; observed instance state '{}'",
+                                observed.state
+                            ));
+                        }
+                        Err(inspect_error) => {
+                            return Err(resume_error).context(format!(
+                                "failed to retry source resume and inspect final state: {inspect_error:#}"
+                            ));
+                        }
+                    }
+                }
+            }
+            Ok(instance) => {
+                bail!(
+                    "cannot retry Firecracker source resume from instance state '{}'",
+                    instance.state
+                );
+            }
+            Err(inspect_error) => {
+                client.resume().await.with_context(|| {
+                    format!(
+                        "failed to inspect source state ({inspect_error:#}) and best-effort resume failed"
+                    )
+                })?;
+            }
+        }
+
+        self.running = true;
+        self.wait_for_agent()
+            .await
+            .context("source VM resumed but guest agent did not reconnect")?;
+        Ok(())
+    }
+
+    async fn restore_from(
+        &mut self,
+        checkpoint_dir: &Path,
+        snapshot: &FullStateSnapshot,
+    ) -> Result<()> {
+        ensure_full_state_host_supported()?;
+        if self.running || self.process.is_some() || self.sandbox_rootfs.is_some() {
+            bail!(
+                "Firecracker sandbox '{}' already has an active runtime",
+                self.name
+            );
+        }
+        if snapshot.architecture != std::env::consts::ARCH {
+            bail!(
+                "Firecracker snapshot architecture mismatch: checkpoint={}, host={}",
+                snapshot.architecture,
+                std::env::consts::ARCH
+            );
+        }
+        if snapshot.firecracker_version != SUPPORTED_FIRECRACKER_VERSION {
+            bail!(
+                "full-state restore requires Firecracker {}, checkpoint uses {}",
+                SUPPORTED_FIRECRACKER_VERSION,
+                snapshot.firecracker_version
+            );
+        }
+        let kernel_release = host_kernel_release()?;
+        ensure_clock_realtime_kernel_supported(&kernel_release)?;
+        if snapshot.host_kernel_release != kernel_release {
+            bail!(
+                "Firecracker snapshot host kernel mismatch: checkpoint={}, host={}",
+                snapshot.host_kernel_release,
+                kernel_release
+            );
+        }
+        let host_identity = host_identity_sha256()?;
+        if snapshot.host_identity_sha256 != host_identity {
+            bail!("Firecracker snapshot host identity mismatch");
+        }
+        let cpu_fingerprint = cpu_fingerprint_sha256()?;
+        if snapshot.cpu_fingerprint_sha256 != cpu_fingerprint {
+            bail!("Firecracker snapshot CPU fingerprint mismatch");
+        }
+        ensure_guest_kernel_supported(&snapshot.guest_kernel_release)?;
+
+        let firecracker_bin = find_firecracker()?;
+        let binary_version = firecracker_binary_version(&firecracker_bin)?;
+        if snapshot.firecracker_version != binary_version {
+            bail!(
+                "Firecracker snapshot VMM mismatch: checkpoint={}, installed={}",
+                snapshot.firecracker_version,
+                binary_version
+            );
+        }
+
+        let memory_path = ensure_checkpoint_artifact(checkpoint_dir, MEMORY_FILE)?;
+        let vmstate_path = ensure_checkpoint_artifact(checkpoint_dir, VMSTATE_FILE)?;
+        let checkpoint_rootfs = ensure_checkpoint_artifact(checkpoint_dir, ROOTFS_FILE)?;
+
+        let store = RootfsCowStore::open_default()?;
+        let rootfs = store.prepare(&checkpoint_rootfs).with_context(|| {
+            format!(
+                "failed to prepare writable rootfs from checkpoint {}",
+                checkpoint_dir.display()
+            )
+        })?;
+        eprintln!(
+            "[firecracker] restored rootfs COW strategy={:?} path={}",
+            rootfs.strategy(),
+            rootfs.path().display()
+        );
+        self.sandbox_rootfs = Some(rootfs);
+
+        let restore = async {
+            self.spawn_firecracker(&firecracker_bin)?;
+            self.wait_for_socket().await?;
+            let client = FirecrackerClient::new(&self.socket_path);
+            let api_version = client
+                .get_version()
+                .await
+                .context("failed to inspect restore Firecracker version")?
+                .firecracker_version;
+            if api_version != snapshot.firecracker_version {
+                bail!(
+                    "Firecracker restore process version mismatch: checkpoint={}, process={}",
+                    snapshot.firecracker_version,
+                    api_version
+                );
+            }
+
+            client
+                .load_snapshot(&SnapshotLoadParams {
+                    mem_backend: MemoryBackend::file(&memory_path),
+                    snapshot_path: vmstate_path.to_string_lossy().into_owned(),
+                    resume_vm: false,
+                    vsock_override: VsockOverride {
+                        uds_path: self.vsock_path.to_string_lossy().into_owned(),
+                    },
+                    clock_realtime: cfg!(target_arch = "x86_64").then_some(true),
+                })
+                .await
+                .context("failed to load Firecracker full-state checkpoint")?;
+
+            let instance = client
+                .get_instance_info()
+                .await
+                .context("failed to inspect restored Firecracker VM")?;
+            if instance.state != "Paused" {
+                bail!(
+                    "Firecracker loaded snapshot in unexpected state '{}'",
+                    instance.state
+                );
+            }
+            client
+                .resume()
+                .await
+                .context("failed to resume restored Firecracker VM")?;
+            self.wait_for_agent().await?;
+            Ok::<(), anyhow::Error>(())
+        }
+        .await;
+
+        match restore {
+            Ok(()) => {
+                self.running = true;
+                Ok(())
+            }
+            Err(error) => match self.abort_start() {
+                Ok(()) => Err(error),
+                Err(cleanup_error) => {
+                    Err(transition_cleanup_error("restore", &error, cleanup_error))
+                }
+            },
+        }
     }
 
     fn name(&self) -> &str {
@@ -477,6 +1301,7 @@ impl Drop for FirecrackerSandbox {
         }
         let _ = std::fs::remove_file(&self.socket_path);
         let _ = std::fs::remove_file(&self.vsock_path);
+        let _ = std::fs::remove_dir(&self.runtime_dir);
         self.sandbox_rootfs.take();
     }
 }
@@ -484,6 +1309,241 @@ impl Drop for FirecrackerSandbox {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn runtime_socket_paths_are_unique_per_instance() {
+        #[cfg(unix)]
+        use std::os::unix::fs::PermissionsExt;
+
+        let first = FirecrackerSandbox::new("same-name").unwrap();
+        let second = FirecrackerSandbox::new("same-name").unwrap();
+        assert_ne!(first.api_socket_path(), second.api_socket_path());
+        assert_ne!(first.vsock_socket_path(), second.vsock_socket_path());
+        assert!(first.api_socket_path().is_absolute());
+        assert!(first.vsock_socket_path().is_absolute());
+        assert_eq!(
+            first.api_socket_path().parent(),
+            first.vsock_socket_path().parent()
+        );
+        #[cfg(unix)]
+        assert_eq!(
+            fs::metadata(first.api_socket_path().parent().unwrap())
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o700
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn runtime_socket_is_current_user_private_and_symlinks_are_rejected() {
+        use std::os::unix::fs::{MetadataExt, PermissionsExt, symlink};
+        use std::os::unix::net::UnixListener;
+
+        let sandbox = FirecrackerSandbox::new("private-runtime-socket").unwrap();
+        let listener = UnixListener::bind(sandbox.api_socket_path()).unwrap();
+        secure_runtime_socket(sandbox.api_socket_path()).unwrap();
+        let metadata = fs::symlink_metadata(sandbox.api_socket_path()).unwrap();
+        assert_eq!(metadata.uid(), unsafe { libc::geteuid() });
+        assert_eq!(metadata.permissions().mode() & 0o777, 0o600);
+
+        let outside = sandbox.runtime_dir.join("outside");
+        fs::write(&outside, b"not a socket").unwrap();
+        symlink(&outside, sandbox.vsock_socket_path()).unwrap();
+        assert!(secure_runtime_socket(sandbox.vsock_socket_path()).is_err());
+        drop(listener);
+        fs::remove_file(outside).unwrap();
+    }
+
+    #[test]
+    fn parses_pinned_firecracker_version_output() {
+        assert_eq!(
+            parse_firecracker_version("Firecracker v1.16.1\n").unwrap(),
+            SUPPORTED_FIRECRACKER_VERSION
+        );
+        assert!(parse_firecracker_version("Firecracker unknown").is_err());
+    }
+
+    #[test]
+    fn full_state_host_boundary_matches_linux_x86_64_contract() {
+        assert_eq!(
+            ensure_full_state_host_supported().is_ok(),
+            cfg!(all(target_os = "linux", target_arch = "x86_64"))
+        );
+    }
+
+    #[test]
+    fn clock_realtime_requires_linux_5_16_or_newer() {
+        assert!(ensure_clock_realtime_kernel_supported("5.15.99").is_err());
+        assert!(ensure_clock_realtime_kernel_supported("5.16.0").is_ok());
+        assert!(ensure_clock_realtime_kernel_supported("6.18.45-agentkernel").is_ok());
+        assert!(ensure_clock_realtime_kernel_supported("not-a-kernel").is_err());
+    }
+
+    #[test]
+    fn full_state_requires_the_managed_guest_kernel() {
+        assert!(ensure_guest_kernel_supported(SUPPORTED_GUEST_KERNEL_RELEASE).is_ok());
+        assert!(ensure_guest_kernel_supported("6.18.45").is_err());
+        assert!(ensure_guest_kernel_supported("6.12.0-agentkernel").is_err());
+    }
+
+    #[test]
+    fn cpu_identity_is_stable_across_flag_order_and_ignores_other_cpus() {
+        let first = "processor : 0\nvendor_id : GenuineIntel\ncpu family : 6\nmodel : 143\nmodel name : Test CPU\nstepping : 8\nmicrocode : 0x1\nflags : vmx sse aes\n\nprocessor : 1\nvendor_id : ignored\n";
+        let reordered = "processor : 0\nvendor_id : GenuineIntel\ncpu family : 6\nmodel : 143\nmodel name : Test CPU\nstepping : 8\nmicrocode : 0x1\nflags : aes vmx sse\n";
+        assert_eq!(
+            canonical_cpu_identity(first).unwrap(),
+            canonical_cpu_identity(reordered).unwrap()
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn failed_source_resume_retains_complete_or_partial_recovery_artifacts() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::UnixListener;
+
+        async fn reject_resume(listener: UnixListener) -> String {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = vec![0; 4096];
+            let bytes = stream.read(&mut request).await.unwrap();
+            let body = br#"{"fault_message":"resume rejected"}"#;
+            let headers = format!(
+                "HTTP/1.1 400 Bad Request\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            );
+            stream.write_all(headers.as_bytes()).await.unwrap();
+            stream.write_all(body).await.unwrap();
+            String::from_utf8(request[..bytes].to_vec()).unwrap()
+        }
+
+        for artifacts_complete in [false, true] {
+            let temp = tempfile::tempdir().unwrap();
+            let socket = temp.path().join("firecracker.sock");
+            let listener = UnixListener::bind(&socket).unwrap();
+            let request = tokio::spawn(reject_resume(listener));
+            let checkpoint = temp.path().join("checkpoint");
+            fs::create_dir(&checkpoint).unwrap();
+            fs::write(checkpoint.join(MEMORY_FILE), b"partial memory").unwrap();
+            if artifacts_complete {
+                fs::write(checkpoint.join(VMSTATE_FILE), b"vmstate").unwrap();
+                fs::write(checkpoint.join(ROOTFS_FILE), b"rootfs").unwrap();
+            }
+
+            let snapshot = FullStateSnapshot {
+                firecracker_version: SUPPORTED_FIRECRACKER_VERSION.to_string(),
+                architecture: "x86_64".to_string(),
+                host_kernel_release: "6.18.45-agentkernel".to_string(),
+                host_identity_sha256: "host-id".to_string(),
+                cpu_fingerprint_sha256: "cpu-id".to_string(),
+                guest_kernel_release: SUPPORTED_GUEST_KERNEL_RELEASE.to_string(),
+            };
+            let mut sandbox = FirecrackerSandbox::new("resume-recovery-test").unwrap();
+            let error = sandbox
+                .resume_after_snapshot_failure(
+                    &FirecrackerClient::new(&socket),
+                    &checkpoint,
+                    &snapshot,
+                    artifacts_complete,
+                    anyhow::anyhow!("checkpoint operation failed"),
+                )
+                .await
+                .unwrap_err();
+            let request = request.await.unwrap();
+            assert!(request.starts_with("PATCH /vm HTTP/1.1"));
+            assert!(request.contains(r#"{"state":"Resumed"}"#));
+
+            let recovery = error
+                .downcast_ref::<FullStatePauseError>()
+                .expect("resume failure is downcastable");
+            assert!(recovery.source_resume_failed);
+            assert_eq!(recovery.artifacts_complete, artifacts_complete);
+            assert_eq!(recovery.snapshot, snapshot);
+            assert!(
+                recovery
+                    .operation_error
+                    .contains("checkpoint operation failed")
+            );
+            assert!(
+                recovery
+                    .resume_error
+                    .as_deref()
+                    .unwrap()
+                    .contains("resume rejected")
+            );
+            assert!(checkpoint.join(MEMORY_FILE).is_file());
+            assert_eq!(checkpoint.join(VMSTATE_FILE).is_file(), artifacts_complete);
+            assert_eq!(checkpoint.join(ROOTFS_FILE).is_file(), artifacts_complete);
+        }
+    }
+
+    #[test]
+    fn accepted_resume_without_guest_health_retains_complete_checkpoint() {
+        let temp = tempfile::tempdir().unwrap();
+        let checkpoint = temp.path().join("checkpoint");
+        fs::create_dir(&checkpoint).unwrap();
+        fs::write(checkpoint.join(MEMORY_FILE), b"memory").unwrap();
+        fs::write(checkpoint.join(VMSTATE_FILE), b"vmstate").unwrap();
+        fs::write(checkpoint.join(ROOTFS_FILE), b"rootfs").unwrap();
+        let snapshot = FullStateSnapshot {
+            firecracker_version: SUPPORTED_FIRECRACKER_VERSION.to_string(),
+            architecture: "x86_64".to_string(),
+            host_kernel_release: "6.18.45-agentkernel".to_string(),
+            host_identity_sha256: "host-id".to_string(),
+            cpu_fingerprint_sha256: "cpu-id".to_string(),
+            guest_kernel_release: SUPPORTED_GUEST_KERNEL_RELEASE.to_string(),
+        };
+        let mut sandbox = FirecrackerSandbox::new("accepted-resume-unhealthy").unwrap();
+        sandbox.running = true;
+
+        let error = sandbox
+            .finish_resumed_snapshot_failure(
+                &checkpoint,
+                &snapshot,
+                true,
+                anyhow::anyhow!("snapshot failed after pause"),
+                Err(anyhow::anyhow!("guest agent did not reconnect")),
+            )
+            .unwrap_err();
+
+        let recovery = error
+            .downcast_ref::<FullStatePauseError>()
+            .expect("failed health confirmation remains a typed pause recovery");
+        assert!(recovery.source_resume_failed);
+        assert!(recovery.artifacts_complete);
+        assert!(
+            recovery
+                .resume_error
+                .as_deref()
+                .unwrap()
+                .contains("health was not confirmed")
+        );
+        assert!(checkpoint.join(MEMORY_FILE).is_file());
+        assert!(checkpoint.join(VMSTATE_FILE).is_file());
+        assert!(checkpoint.join(ROOTFS_FILE).is_file());
+    }
+
+    #[test]
+    fn restore_cleanup_preserves_typed_termination_uncertainty() {
+        let restore_error = anyhow::anyhow!("guest agent failed after snapshot load and resume");
+        let error = transition_cleanup_error(
+            "restore",
+            &restore_error,
+            FullStateTerminationError {
+                process_may_be_running: true,
+                detail: "kill succeeded but wait/reap was not confirmed".to_string(),
+            }
+            .into(),
+        );
+
+        let termination = error
+            .downcast_ref::<FullStateTerminationError>()
+            .expect("restore cleanup uncertainty remains downcastable");
+        assert!(termination.process_may_be_running);
+        assert!(error.to_string().contains("cleanup could not prove"));
+    }
 
     #[tokio::test]
     async fn stop_finalizes_state_when_rootfs_cleanup_fails() {
@@ -507,8 +1567,11 @@ mod tests {
         sandbox.sandbox_rootfs = Some(rootfs);
         sandbox.running = true;
 
-        let result = sandbox.stop().await;
-        assert!(result.is_err());
+        let error = sandbox.stop().await.unwrap_err();
+        let termination = error
+            .downcast_ref::<FullStateTerminationError>()
+            .expect("cleanup-only stop errors retain a typed termination outcome");
+        assert!(!termination.process_may_be_running);
         assert!(!sandbox.running);
         assert!(sandbox.sandbox_rootfs.is_none());
         assert!(sandbox.process.is_none());

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -223,6 +223,94 @@ pub struct RemoteSandboxContext {
     pub config_path: Option<String>,
 }
 
+/// Backend-specific compatibility metadata for a full VM state snapshot.
+///
+/// Filesystem-only snapshots do not use this type.  A backend that implements
+/// full-state pause/resume must persist enough information here to reject a
+/// restore on an incompatible VMM or host before loading guest memory.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FullStateSnapshot {
+    pub firecracker_version: String,
+    pub architecture: String,
+    pub host_kernel_release: String,
+    /// SHA-256 of the host machine identity; the raw identifier is never persisted.
+    pub host_identity_sha256: String,
+    /// SHA-256 of snapshot-relevant CPU identity and feature flags.
+    pub cpu_fingerprint_sha256: String,
+    /// Exact kernel release reported by the guest at snapshot time.
+    pub guest_kernel_release: String,
+}
+
+/// A full-state pause failed and the source VM could not be confirmed resumed.
+///
+/// Callers can downcast an [`anyhow::Error`] to this type to decide whether the
+/// staging directory must be retained. `artifacts_complete` means all memory,
+/// vmstate, and rootfs artifacts were durably produced; when it is false the
+/// directory may still contain useful partial recovery data and must not be
+/// discarded automatically.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FullStatePauseError {
+    pub source_resume_failed: bool,
+    pub artifacts_complete: bool,
+    pub snapshot: FullStateSnapshot,
+    pub operation_error: String,
+    pub resume_error: Option<String>,
+}
+
+impl FullStatePauseError {
+    pub fn source_resume_failed(
+        snapshot: FullStateSnapshot,
+        artifacts_complete: bool,
+        operation_error: impl fmt::Display,
+        resume_error: impl fmt::Display,
+    ) -> Self {
+        Self {
+            source_resume_failed: true,
+            artifacts_complete,
+            snapshot,
+            operation_error: operation_error.to_string(),
+            resume_error: Some(resume_error.to_string()),
+        }
+    }
+}
+
+impl fmt::Display for FullStatePauseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "full-state pause failed and source VM could not be resumed: {}",
+            self.operation_error
+        )?;
+        if let Some(resume_error) = &self.resume_error {
+            write!(f, "; resume failed: {resume_error}")?;
+        }
+        write!(
+            f,
+            "; checkpoint artifacts complete: {}",
+            self.artifacts_complete
+        )
+    }
+}
+
+impl std::error::Error for FullStatePauseError {}
+
+/// A Firecracker termination attempt failed after a full-state snapshot.
+/// `process_may_be_running` is false only when process exit was confirmed and
+/// the remaining failure is cleanup-only, so checkpoint publication is safe.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FullStateTerminationError {
+    pub process_may_be_running: bool,
+    pub detail: String,
+}
+
+impl fmt::Display for FullStateTerminationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.detail)
+    }
+}
+
+impl std::error::Error for FullStateTerminationError {}
+
 /// Outcome-level backend capabilities used for compatibility checks.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 pub struct BackendCapabilities {
@@ -235,6 +323,10 @@ pub struct BackendCapabilities {
     pub secret_files: bool,
     pub snapshots: bool,
     pub resume: bool,
+    /// Preserves guest memory/process/device state, not only the filesystem.
+    pub full_state_pause_resume: bool,
+    /// Restores multiple independent running children from one paused state.
+    pub full_state_fork: bool,
     pub endpoints: bool,
 }
 
@@ -250,14 +342,18 @@ pub fn backend_capabilities(backend: BackendType) -> BackendCapabilities {
             secret_files: true,
             snapshots: true,
             resume: true,
+            full_state_pause_resume: false,
+            full_state_fork: false,
             endpoints: true,
         };
     }
 
+    let full_state = backend == BackendType::Firecracker
+        && cfg!(all(target_os = "linux", target_arch = "x86_64"));
     BackendCapabilities {
         mount_cwd: true,
         mount_home: true,
-        attach: !matches!(backend, BackendType::Hyperlight),
+        attach: !matches!(backend, BackendType::Firecracker | BackendType::Hyperlight),
         // Named persistent volumes are currently translated into Docker/Podman
         // `-v` arguments by the VMM. Other local backends must reject them
         // rather than advertising support and silently dropping the mounts.
@@ -267,6 +363,8 @@ pub fn backend_capabilities(backend: BackendType) -> BackendCapabilities {
         secret_files: true,
         snapshots: !matches!(backend, BackendType::Hyperlight),
         resume: !matches!(backend, BackendType::Hyperlight),
+        full_state_pause_resume: full_state,
+        full_state_fork: full_state,
         endpoints: true,
     }
 }
@@ -540,6 +638,55 @@ pub trait Sandbox: Send + Sync {
 
     /// Stop the sandbox and clean up resources
     async fn stop(&mut self) -> Result<()>;
+
+    /// Pause a running sandbox into a durable, full-state checkpoint.
+    ///
+    /// Backends must attempt to leave the sandbox running if checkpoint
+    /// creation fails before the original runtime is terminated. If that
+    /// recovery cannot be confirmed, return [`FullStatePauseError`] and retain
+    /// ownership so the caller can publish complete artifacts or retry the
+    /// live source in place. The default is deliberately unsupported so
+    /// filesystem snapshot support is not mistaken for full VM state support.
+    async fn pause_to(&mut self, _checkpoint_dir: &Path) -> Result<FullStateSnapshot> {
+        anyhow::bail!(
+            "Backend '{}' does not support full-state pause/resume",
+            self.backend_type()
+        )
+    }
+
+    /// Conservative bytes to reserve before creating a full-state checkpoint.
+    /// Backends with a writable disk should include its logical size in
+    /// addition to configured guest memory and snapshot metadata overhead.
+    fn full_state_reservation_bytes(&self, memory_mb: u64) -> Result<u64> {
+        memory_mb
+            .checked_mul(1024 * 1024)
+            .and_then(|bytes| bytes.checked_add(64 * 1024 * 1024))
+            .ok_or_else(|| anyhow::anyhow!("full-state checkpoint reservation overflow"))
+    }
+
+    /// Retry resuming the still-live source after a failed full-state pause.
+    ///
+    /// This exists for the recovery path represented by
+    /// [`FullStatePauseError`]. Callers must retain the backend object while a
+    /// partial checkpoint is not independently restorable.
+    async fn retry_full_state_resume(&mut self) -> Result<()> {
+        anyhow::bail!(
+            "Backend '{}' does not support in-place full-state resume",
+            self.backend_type()
+        )
+    }
+
+    /// Restore a sandbox from a previously-created full-state checkpoint.
+    async fn restore_from(
+        &mut self,
+        _checkpoint_dir: &Path,
+        _snapshot: &FullStateSnapshot,
+    ) -> Result<()> {
+        anyhow::bail!(
+            "Backend '{}' does not support full-state pause/resume",
+            self.backend_type()
+        )
+    }
 
     /// Permanently delete the sandbox and provider-side resources.
     async fn remove(&mut self) -> Result<()> {
@@ -1364,6 +1511,20 @@ mod tests {
         assert!(caps.snapshots);
         assert!(!caps.proxy_secret_bindings);
         assert!(!caps.host_volumes);
+        assert!(!caps.full_state_pause_resume);
+        assert!(!caps.full_state_fork);
+    }
+
+    #[test]
+    fn full_state_capabilities_match_the_linux_x86_64_firecracker_boundary() {
+        for backend in BackendType::all() {
+            let capabilities = backend_capabilities(backend);
+            let expected = backend == BackendType::Firecracker
+                && cfg!(all(target_os = "linux", target_arch = "x86_64"));
+            assert_eq!(capabilities.full_state_pause_resume, expected, "{backend}");
+            assert_eq!(capabilities.full_state_fork, expected, "{backend}");
+        }
+        assert!(!backend_capabilities(BackendType::Firecracker).attach);
     }
 
     #[test]

--- a/src/cow.rs
+++ b/src/cow.rs
@@ -231,6 +231,19 @@ impl RootfsCowStore {
             RootfsCowStrategy::FullCopy
         };
 
+        // Base images (especially immutable checkpoint artifacts) may be
+        // read-only.  The private clone is Firecracker's writable root drive,
+        // so do not inherit the source file's restrictive mode.
+        #[cfg(unix)]
+        fs::set_permissions(&staging_path, fs::Permissions::from_mode(0o600))
+            .with_context(|| format!("failed to make {} writable", staging_path.display()))?;
+        #[cfg(not(unix))]
+        {
+            let mut permissions = fs::metadata(&staging_path)?.permissions();
+            permissions.set_readonly(false);
+            fs::set_permissions(&staging_path, permissions)?;
+        }
+
         // Ensure the staged image is durable before exposing it as a complete
         // artifact.  This is best-effort on platforms where sync is unusual,
         // but a failure is safer than publishing a partial rootfs.
@@ -636,8 +649,104 @@ impl RootfsCow {
         &self.rootfs_path
     }
 
+    /// Directory that must be used as Firecracker's working directory.
+    ///
+    /// The drive is deliberately configured as the relative path
+    /// `rootfs.ext4`.  A restored VM can therefore use an independent writable
+    /// COW image in a different directory without changing the path embedded in
+    /// Firecracker's vmstate file.
+    pub fn artifact_dir(&self) -> &Path {
+        &self.artifact_dir
+    }
+
     pub fn strategy(&self) -> RootfsCowStrategy {
         self.strategy
+    }
+
+    /// Copy the paused root drive into a checkpoint directory.
+    ///
+    /// A reflink is attempted first and a portable full copy is used when the
+    /// source and checkpoint stores do not share reflink-capable storage.  The
+    /// destination is published by rename only after its contents are synced.
+    pub fn snapshot_to(&self, destination: &Path) -> Result<RootfsCowStrategy> {
+        // Firecracker has stopped issuing guest I/O while paused, but its host
+        // file can still have dirty pages. Flush the source before reflinking
+        // or copying so a published checkpoint is durable as a complete set.
+        File::options()
+            .read(true)
+            .write(true)
+            .open(&self.rootfs_path)
+            .with_context(|| format!("failed to open {}", self.rootfs_path.display()))?
+            .sync_all()
+            .with_context(|| format!("failed to sync {}", self.rootfs_path.display()))?;
+
+        if fs::symlink_metadata(destination).is_ok() {
+            bail!(
+                "refusing to overwrite checkpoint rootfs {}",
+                destination.display()
+            );
+        }
+        let parent = destination.parent().ok_or_else(|| {
+            anyhow::anyhow!(
+                "checkpoint rootfs has no parent directory: {}",
+                destination.display()
+            )
+        })?;
+        let parent_metadata = fs::symlink_metadata(parent).with_context(|| {
+            format!(
+                "failed to inspect checkpoint directory {}",
+                parent.display()
+            )
+        })?;
+        if parent_metadata.file_type().is_symlink() || !parent_metadata.is_dir() {
+            bail!(
+                "checkpoint rootfs parent is not a directory: {}",
+                parent.display()
+            );
+        }
+
+        let staging = parent.join(format!(".rootfs.ext4.partial-{}", Uuid::new_v4().simple()));
+        let reflink_succeeded = reflink_copy(&self.rootfs_path, &staging).unwrap_or(false);
+        let strategy = if reflink_succeeded {
+            RootfsCowStrategy::Reflink
+        } else {
+            let _ = fs::remove_file(&staging);
+            if let Err(error) = full_copy(&self.rootfs_path, &staging) {
+                let _ = fs::remove_file(&staging);
+                return Err(error).with_context(|| {
+                    format!(
+                        "failed to copy paused rootfs {} -> {}",
+                        self.rootfs_path.display(),
+                        staging.display()
+                    )
+                });
+            }
+            RootfsCowStrategy::FullCopy
+        };
+
+        let publish = (|| -> Result<()> {
+            File::open(&staging)
+                .with_context(|| format!("failed to open {}", staging.display()))?
+                .sync_all()
+                .with_context(|| format!("failed to sync {}", staging.display()))?;
+            fs::rename(&staging, destination).with_context(|| {
+                format!(
+                    "failed to publish checkpoint rootfs {} -> {}",
+                    staging.display(),
+                    destination.display()
+                )
+            })?;
+            File::open(parent)
+                .with_context(|| format!("failed to open {}", parent.display()))?
+                .sync_all()
+                .with_context(|| format!("failed to sync {}", parent.display()))?;
+            Ok(())
+        })();
+        if let Err(error) = publish {
+            let _ = fs::remove_file(&staging);
+            return Err(error);
+        }
+        Ok(strategy)
     }
 
     /// Keep this rootfs as an input for a durable Firecracker snapshot.
@@ -1416,6 +1525,42 @@ mod tests {
             }
         );
         assert_eq!(fs::read(path).unwrap(), b"snapshot rootfs");
+    }
+
+    #[test]
+    fn paused_rootfs_snapshot_is_independent_and_never_overwritten() {
+        let (tmp, store) = store();
+        let base = tmp.path().join("base.ext4");
+        fs::write(&base, b"checkpoint contents").unwrap();
+        let rootfs = store.prepare(&base).unwrap();
+        assert_eq!(rootfs.path().parent(), Some(rootfs.artifact_dir()));
+
+        let checkpoint = tmp.path().join("checkpoint");
+        fs::create_dir(&checkpoint).unwrap();
+        let destination = checkpoint.join(ROOTFS_FILE);
+        rootfs.snapshot_to(&destination).unwrap();
+        fs::write(rootfs.path(), b"mutated live rootfs").unwrap();
+
+        assert_eq!(fs::read(&destination).unwrap(), b"checkpoint contents");
+        assert!(rootfs.snapshot_to(&destination).is_err());
+        assert!(fs::read_dir(&checkpoint).unwrap().all(|entry| {
+            !entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .starts_with(".rootfs.ext4.partial-")
+        }));
+
+        let mut permissions = fs::metadata(&destination).unwrap().permissions();
+        permissions.set_readonly(true);
+        fs::set_permissions(&destination, permissions).unwrap();
+        let restored = store.prepare(&destination).unwrap();
+        assert!(
+            !fs::metadata(restored.path())
+                .unwrap()
+                .permissions()
+                .readonly()
+        );
     }
 
     #[cfg(unix)]

--- a/src/firecracker_client.rs
+++ b/src/firecracker_client.rs
@@ -9,10 +9,24 @@ use hyper::{Method, Request};
 use hyper_util::rt::TokioIo;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
+use std::time::Duration;
 use tokio::net::UnixStream;
+
+const FIRECRACKER_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+const FIRECRACKER_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Firecracker API client
 pub struct FirecrackerClient {
+    socket_path: String,
+    connect_timeout: Duration,
+    request_timeout: Duration,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("Firecracker API {stage} timed out after {timeout:?} for {socket_path}")]
+pub struct FirecrackerApiTimeout {
+    stage: &'static str,
+    timeout: Duration,
     socket_path: String,
 }
 
@@ -58,6 +72,18 @@ pub struct InstanceAction {
     pub action_type: String,
 }
 
+/// Runtime state accepted by Firecracker's `PATCH /vm` endpoint.
+#[derive(Debug, Clone, Copy, Serialize)]
+pub enum VmState {
+    Paused,
+    Resumed,
+}
+
+#[derive(Debug, Serialize)]
+struct VmStatePatch {
+    state: VmState,
+}
+
 /// Network interface configuration
 #[derive(Debug, Serialize)]
 pub struct NetworkInterface {
@@ -82,14 +108,38 @@ pub struct VsockOverride {
     pub uds_path: String,
 }
 
+/// Snapshot memory backend supported by Firecracker 1.16.
+#[derive(Debug, Clone, Copy, Serialize)]
+pub enum MemoryBackendType {
+    File,
+}
+
+/// Memory source used while lazily restoring a Firecracker snapshot.
+#[derive(Debug, Serialize)]
+pub struct MemoryBackend {
+    pub backend_type: MemoryBackendType,
+    pub backend_path: String,
+}
+
+impl MemoryBackend {
+    pub fn file(path: impl AsRef<Path>) -> Self {
+        Self {
+            backend_type: MemoryBackendType::File,
+            backend_path: path.as_ref().to_string_lossy().into_owned(),
+        }
+    }
+}
+
 /// Snapshot restoration parameters supported by Firecracker 1.16.
 #[derive(Debug, Serialize)]
 #[allow(dead_code)]
 pub struct SnapshotLoadParams {
-    pub mem_file_path: String,
+    pub mem_backend: MemoryBackend,
     pub snapshot_path: String,
     pub resume_vm: bool,
     pub vsock_override: VsockOverride,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub clock_realtime: Option<bool>,
 }
 
 /// Instance info response
@@ -101,11 +151,32 @@ pub struct InstanceInfo {
     pub vmm_version: String,
 }
 
+/// Firecracker version response.
+#[derive(Debug, Deserialize)]
+pub struct FirecrackerVersion {
+    pub firecracker_version: String,
+}
+
 impl FirecrackerClient {
     /// Create a new Firecracker API client
     pub fn new(socket_path: impl AsRef<Path>) -> Self {
         Self {
             socket_path: socket_path.as_ref().to_string_lossy().to_string(),
+            connect_timeout: FIRECRACKER_CONNECT_TIMEOUT,
+            request_timeout: FIRECRACKER_REQUEST_TIMEOUT,
+        }
+    }
+
+    #[cfg(test)]
+    fn with_timeouts(
+        socket_path: impl AsRef<Path>,
+        connect_timeout: Duration,
+        request_timeout: Duration,
+    ) -> Self {
+        Self {
+            socket_path: socket_path.as_ref().to_string_lossy().to_string(),
+            connect_timeout,
+            request_timeout,
         }
     }
 
@@ -120,6 +191,12 @@ impl FirecrackerClient {
     pub async fn get_instance_info(&self) -> Result<InstanceInfo> {
         let response = self.request(Method::GET, "/", None::<&()>).await?;
         serde_json::from_slice(&response).context("Failed to parse instance info")
+    }
+
+    /// Get the running Firecracker VMM version.
+    pub async fn get_version(&self) -> Result<FirecrackerVersion> {
+        let response = self.request(Method::GET, "/version", None::<&()>).await?;
+        serde_json::from_slice(&response).context("Failed to parse Firecracker version")
     }
 
     /// Set boot source configuration
@@ -172,19 +249,18 @@ impl FirecrackerClient {
     /// Pause the VM
     #[allow(dead_code)]
     pub async fn pause(&self) -> Result<()> {
-        let action = InstanceAction {
-            action_type: "Pause".to_string(),
-        };
-        self.put("/actions", &action).await
+        self.set_vm_state(VmState::Paused).await
     }
 
     /// Resume the VM
     #[allow(dead_code)]
     pub async fn resume(&self) -> Result<()> {
-        let action = InstanceAction {
-            action_type: "Resume".to_string(),
-        };
-        self.put("/actions", &action).await
+        self.set_vm_state(VmState::Resumed).await
+    }
+
+    /// Update the state of a running VM.
+    pub async fn set_vm_state(&self, state: VmState) -> Result<()> {
+        self.patch("/vm", &VmStatePatch { state }).await
     }
 
     /// Create a full VM snapshot. The VM must be paused first.
@@ -205,6 +281,12 @@ impl FirecrackerClient {
         Ok(())
     }
 
+    /// Make a PATCH request.
+    async fn patch<T: Serialize>(&self, path: &str, body: &T) -> Result<()> {
+        let _ = self.request(Method::PATCH, path, Some(body)).await?;
+        Ok(())
+    }
+
     /// Make an HTTP request to the Firecracker API
     async fn request<T: Serialize>(
         &self,
@@ -213,21 +295,35 @@ impl FirecrackerClient {
         body: Option<&T>,
     ) -> Result<Bytes> {
         // Connect to Unix socket
-        let stream = UnixStream::connect(&self.socket_path)
-            .await
-            .with_context(|| {
-                format!(
-                    "Failed to connect to Firecracker socket: {}",
-                    self.socket_path
-                )
-            })?;
+        let stream =
+            tokio::time::timeout(self.connect_timeout, UnixStream::connect(&self.socket_path))
+                .await
+                .map_err(|_| FirecrackerApiTimeout {
+                    stage: "connect",
+                    timeout: self.connect_timeout,
+                    socket_path: self.socket_path.clone(),
+                })?
+                .with_context(|| {
+                    format!(
+                        "Failed to connect to Firecracker socket: {}",
+                        self.socket_path
+                    )
+                })?;
 
         let io = TokioIo::new(stream);
 
         // Create HTTP connection
-        let (mut sender, conn) = hyper::client::conn::http1::handshake(io)
-            .await
-            .context("Failed to create HTTP connection")?;
+        let (mut sender, conn) = tokio::time::timeout(
+            self.connect_timeout,
+            hyper::client::conn::http1::handshake(io),
+        )
+        .await
+        .map_err(|_| FirecrackerApiTimeout {
+            stage: "HTTP handshake",
+            timeout: self.connect_timeout,
+            socket_path: self.socket_path.clone(),
+        })?
+        .context("Failed to create HTTP connection")?;
 
         // Spawn connection handler
         tokio::spawn(async move {
@@ -245,23 +341,31 @@ impl FirecrackerClient {
 
         let req = Request::builder()
             .method(method)
-            .uri(format!("http://localhost{}", path))
+            .uri(path)
+            .header("Host", "localhost")
             .header("Content-Type", "application/json")
             .header("Accept", "application/json")
             .body(Full::new(Bytes::from(body_bytes)))
             .context("Failed to build request")?;
 
         // Send request
-        let response = sender
-            .send_request(req)
+        let response = tokio::time::timeout(self.request_timeout, sender.send_request(req))
             .await
+            .map_err(|_| FirecrackerApiTimeout {
+                stage: "response",
+                timeout: self.request_timeout,
+                socket_path: self.socket_path.clone(),
+            })?
             .context("Failed to send request to Firecracker")?;
 
         let status = response.status();
-        let body = response
-            .into_body()
-            .collect()
+        let body = tokio::time::timeout(self.request_timeout, response.into_body().collect())
             .await
+            .map_err(|_| FirecrackerApiTimeout {
+                stage: "response body",
+                timeout: self.request_timeout,
+                socket_path: self.socket_path.clone(),
+            })?
             .context("Failed to read response body")?
             .to_bytes();
 
@@ -306,20 +410,91 @@ mod tests {
     #[test]
     fn test_snapshot_load_serializes_vsock_override() {
         let snapshot = SnapshotLoadParams {
-            mem_file_path: "/tmp/vm.mem".to_string(),
+            mem_backend: MemoryBackend::file("/tmp/vm.mem"),
             snapshot_path: "/tmp/vm.state".to_string(),
-            resume_vm: true,
+            resume_vm: false,
             vsock_override: VsockOverride {
                 uds_path: "/tmp/restored-vsock.sock".to_string(),
             },
+            clock_realtime: Some(true),
         };
 
         let value = serde_json::to_value(snapshot).unwrap();
-        assert_eq!(value["resume_vm"], true);
+        assert_eq!(value["resume_vm"], false);
+        assert_eq!(value["mem_backend"]["backend_type"], "File");
+        assert_eq!(value["mem_backend"]["backend_path"], "/tmp/vm.mem");
+        assert!(value.get("mem_file_path").is_none());
         assert_eq!(
             value["vsock_override"]["uds_path"],
             "/tmp/restored-vsock.sock"
         );
+        assert_eq!(value["clock_realtime"], true);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn pause_and_resume_patch_vm_state() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::UnixListener;
+
+        async fn capture_request(listener: UnixListener) -> String {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = vec![0; 4096];
+            let bytes = stream.read(&mut request).await.unwrap();
+            stream
+                .write_all(
+                    b"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                )
+                .await
+                .unwrap();
+            String::from_utf8(request[..bytes].to_vec()).unwrap()
+        }
+
+        let temp = tempfile::tempdir().unwrap();
+        let socket = temp.path().join("firecracker.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+        let request = tokio::spawn(capture_request(listener));
+        FirecrackerClient::new(&socket).pause().await.unwrap();
+        let request = request.await.unwrap();
+        assert!(
+            request.starts_with("PATCH /vm HTTP/1.1"),
+            "unexpected request: {request:?}"
+        );
+        assert!(request.contains(r#"{"state":"Paused"}"#));
+
+        std::fs::remove_file(&socket).unwrap();
+        let listener = UnixListener::bind(&socket).unwrap();
+        let request = tokio::spawn(capture_request(listener));
+        FirecrackerClient::new(&socket).resume().await.unwrap();
+        let request = request.await.unwrap();
+        assert!(request.starts_with("PATCH /vm HTTP/1.1"));
+        assert!(request.contains(r#"{"state":"Resumed"}"#));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn request_times_out_when_vmm_accepts_but_never_replies() {
+        use tokio::net::UnixListener;
+
+        let temp = tempfile::tempdir().unwrap();
+        let socket = temp.path().join("wedged-firecracker.sock");
+        let listener = UnixListener::bind(&socket).unwrap();
+        let server = tokio::spawn(async move {
+            let (_stream, _) = listener.accept().await.unwrap();
+            std::future::pending::<()>().await;
+        });
+
+        let client = FirecrackerClient::with_timeouts(
+            &socket,
+            Duration::from_millis(100),
+            Duration::from_millis(25),
+        );
+        let error = client.get_version().await.unwrap_err();
+        assert!(
+            error.downcast_ref::<FirecrackerApiTimeout>().is_some(),
+            "unexpected error: {error:#}"
+        );
+        server.abort();
     }
 
     #[test]

--- a/src/full_state.rs
+++ b/src/full_state.rs
@@ -667,7 +667,11 @@ fn available_space_bytes(path: &Path) -> Result<u64> {
     }
     // SAFETY: statvfs returned success and initialized the structure.
     let stats = unsafe { stats.assume_init() };
-    Ok((stats.f_bavail as u64).saturating_mul(stats.f_frsize))
+    // `fsblkcnt_t` is u32 on Apple targets and u64 on Linux targets. Keep the
+    // widening cast for the former even though it is a no-op on the latter.
+    #[allow(clippy::unnecessary_cast)]
+    let available_blocks = stats.f_bavail as u64;
+    Ok(available_blocks.saturating_mul(stats.f_frsize))
 }
 
 #[cfg(not(unix))]

--- a/src/full_state.rs
+++ b/src/full_state.rs
@@ -1,0 +1,849 @@
+//! Durable full-VM checkpoints used by Firecracker pause, resume, and fork.
+//!
+//! Firecracker writes the memory and device-state files, while AgentKernel
+//! supplies an immutable disk image and owns the surrounding artifact
+//! lifecycle. Checkpoint identifiers, rather than caller-provided paths, are
+//! persisted in sandbox state so deletion can remain confined to the private
+//! checkpoint store.
+
+use crate::backend::{BackendType, FullStateSnapshot};
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::fs::{self, File, OpenOptions};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use uuid::Uuid;
+
+pub const FORMAT_VERSION: u32 = 1;
+pub const MEMORY_FILE: &str = "memory.bin";
+pub const VMSTATE_FILE: &str = "vmstate.bin";
+pub const ROOTFS_FILE: &str = "rootfs.ext4";
+const MANIFEST_FILE: &str = "manifest.json";
+const READY_FILE: &str = "recovery-ready.json";
+const STAGING_PREFIX: &str = ".staging-";
+const DEFAULT_GLOBAL_CAP_BYTES: u64 = 64 * 1024 * 1024 * 1024;
+const DEFAULT_MIN_FREE_BYTES: u64 = 5 * 1024 * 1024 * 1024;
+const GLOBAL_CAP_ENV: &str = "AGENTKERNEL_FULL_STATE_MAX_BYTES";
+const MIN_FREE_ENV: &str = "AGENTKERNEL_FULL_STATE_MIN_FREE_BYTES";
+
+/// Firecracker warns that userspace identifiers, cached random values, and
+/// cryptographic tokens can be duplicated when the same VM state is resumed
+/// more than once. VMGenID reseeds the supported Linux kernel RNG, but cannot
+/// repair arbitrary userspace state.
+pub const FORK_SECURITY_WARNING: &str = "Forking duplicates userspace memory. Rotate cached identifiers and cryptographic tokens in each child; prefer proxy-managed secrets that never enter the VM.";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CheckpointArtifact {
+    pub file: String,
+    pub bytes: u64,
+    pub sha256: String,
+}
+
+/// Versioned manifest stored inside an AgentKernel-owned checkpoint directory.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FullStateCheckpoint {
+    pub format_version: u32,
+    pub id: String,
+    pub source_sandbox: String,
+    pub created_at: String,
+    pub backend: BackendType,
+    pub vcpus: u32,
+    pub memory_mb: u64,
+    pub backend_snapshot: FullStateSnapshot,
+    pub memory: CheckpointArtifact,
+    pub vmstate: CheckpointArtifact,
+    pub rootfs: CheckpointArtifact,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct RecoveryReady {
+    format_version: u32,
+    id: String,
+    source_sandbox: String,
+    vcpus: u32,
+    memory_mb: u64,
+    backend_snapshot: FullStateSnapshot,
+}
+
+pub struct CheckpointStaging {
+    id: String,
+    directory: PathBuf,
+}
+
+impl CheckpointStaging {
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.directory
+    }
+
+    /// Return the deterministic recovery path. Staging directories are
+    /// deliberately persistent until explicitly committed or discarded so a
+    /// cancelled async request cannot erase the only copy of paused state.
+    pub fn preserve(self) -> PathBuf {
+        self.directory
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FullStateCheckpointStore {
+    root: PathBuf,
+}
+
+impl FullStateCheckpointStore {
+    pub fn new(data_dir: &Path) -> Result<Self> {
+        let root = data_dir.join("full-state-checkpoints");
+        ensure_private_directory(&root)?;
+        Ok(Self { root })
+    }
+
+    pub fn begin(&self) -> Result<CheckpointStaging> {
+        let id = Uuid::new_v4().to_string();
+        let directory = self.root.join(format!("{STAGING_PREFIX}{id}"));
+        fs::create_dir(&directory)
+            .context("failed to create full-state checkpoint staging directory")?;
+        make_private(&directory)?;
+        File::open(&self.root)?.sync_all()?;
+        Ok(CheckpointStaging { id, directory })
+    }
+
+    /// Fail before pausing a VM unless the checkpoint store has both global
+    /// quota capacity and filesystem headroom for the conservative snapshot
+    /// reservation. Daemon lifecycle operations hold the authoritative VMM
+    /// write lock across this check and checkpoint publication.
+    pub fn ensure_capacity(&self, reservation_bytes: u64) -> Result<()> {
+        let cap = capacity_setting(GLOBAL_CAP_ENV, DEFAULT_GLOBAL_CAP_BYTES)?;
+        let min_free = capacity_setting(MIN_FREE_ENV, DEFAULT_MIN_FREE_BYTES)?;
+        let used = directory_usage_bytes(&self.root)?;
+        let available = available_space_bytes(&self.root)?;
+        check_capacity(used, reservation_bytes, available, cap, min_free)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn commit(
+        &self,
+        staging: &CheckpointStaging,
+        source_sandbox: &str,
+        vcpus: u32,
+        memory_mb: u64,
+        backend_snapshot: FullStateSnapshot,
+    ) -> Result<FullStateCheckpoint> {
+        validate_id(staging.id())?;
+        let memory = inspect_artifact(staging.path(), MEMORY_FILE)?;
+        let vmstate = inspect_artifact(staging.path(), VMSTATE_FILE)?;
+        let rootfs = inspect_artifact(staging.path(), ROOTFS_FILE)?;
+
+        let manifest = FullStateCheckpoint {
+            format_version: FORMAT_VERSION,
+            id: staging.id.clone(),
+            source_sandbox: source_sandbox.to_string(),
+            created_at: chrono::Utc::now().to_rfc3339(),
+            backend: BackendType::Firecracker,
+            vcpus,
+            memory_mb,
+            backend_snapshot,
+            memory,
+            vmstate,
+            rootfs,
+        };
+        let manifest_path = staging.path().join(MANIFEST_FILE);
+        let contents = serde_json::to_vec_pretty(&manifest)?;
+        fs::write(&manifest_path, contents)
+            .with_context(|| format!("failed to write {}", manifest_path.display()))?;
+        File::open(&manifest_path)?.sync_all()?;
+        File::open(staging.path())?.sync_all()?;
+
+        let destination = self.root.join(&manifest.id);
+        if destination.exists() {
+            bail!("checkpoint '{}' already exists", manifest.id);
+        }
+        fs::rename(staging.path(), &destination).with_context(|| {
+            format!(
+                "failed to publish full-state checkpoint {} -> {}",
+                staging.path().display(),
+                destination.display()
+            )
+        })?;
+        // The checkpoint is already atomically visible after rename. A
+        // directory fsync failure is worth reporting, but must not turn a
+        // recoverable paused VM into an unpublished state artifact.
+        if let Err(error) = File::open(&self.root).and_then(|root| root.sync_all()) {
+            eprintln!("Warning: failed to sync checkpoint store directory: {error}");
+        }
+        Ok(manifest)
+    }
+
+    /// Mark a complete staging set as safe to publish after a restart.
+    ///
+    /// Callers may create this marker only after the original Firecracker
+    /// process has been terminated. Its absence therefore keeps ambiguous
+    /// staging diagnostic-only instead of risking two live copies of a VM.
+    pub fn mark_recovery_ready(
+        &self,
+        staging: &CheckpointStaging,
+        source_sandbox: &str,
+        vcpus: u32,
+        memory_mb: u64,
+        backend_snapshot: FullStateSnapshot,
+    ) -> Result<()> {
+        validate_id(staging.id())?;
+        // Validate and sync the full artifact set before publishing the marker.
+        // Digests are computed once during commit/recovery publication rather
+        // than twice while the source is paused.
+        sync_artifact(staging.path(), MEMORY_FILE)?;
+        sync_artifact(staging.path(), VMSTATE_FILE)?;
+        sync_artifact(staging.path(), ROOTFS_FILE)?;
+        let ready = RecoveryReady {
+            format_version: FORMAT_VERSION,
+            id: staging.id.clone(),
+            source_sandbox: source_sandbox.to_string(),
+            vcpus,
+            memory_mb,
+            backend_snapshot,
+        };
+        let path = staging.path().join(READY_FILE);
+        let contents = serde_json::to_vec_pretty(&ready)?;
+        let temporary = staging
+            .path()
+            .join(format!(".{READY_FILE}.tmp-{}", Uuid::new_v4()));
+        let publish = (|| -> Result<()> {
+            let mut file = OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&temporary)
+                .with_context(|| format!("failed to create {}", temporary.display()))?;
+            file.write_all(&contents)
+                .with_context(|| format!("failed to write {}", temporary.display()))?;
+            file.sync_all()?;
+            fs::rename(&temporary, &path).with_context(|| {
+                format!(
+                    "failed to atomically publish recovery marker {} -> {}",
+                    temporary.display(),
+                    path.display()
+                )
+            })?;
+            File::open(staging.path())?.sync_all()?;
+            Ok(())
+        })();
+        if publish.is_err() {
+            let _ = fs::remove_file(&temporary);
+        }
+        publish?;
+        Ok(())
+    }
+
+    /// Publish a deterministic staging directory whose ready marker proves
+    /// the source runtime had already been terminated before interruption.
+    pub fn recover_ready(
+        &self,
+        id: &str,
+        source_sandbox: &str,
+        vcpus: u32,
+        memory_mb: u64,
+    ) -> Result<(FullStateCheckpoint, PathBuf)> {
+        let staging_path = self.staging_path(id)?;
+        ensure_owned_directory(&staging_path)?;
+        let ready_path = staging_path.join(READY_FILE);
+        ensure_regular_file(&ready_path)?;
+        let ready: RecoveryReady = serde_json::from_slice(&fs::read(&ready_path)?)?;
+        if ready.format_version != FORMAT_VERSION
+            || ready.id != id
+            || ready.source_sandbox != source_sandbox
+            || ready.vcpus != vcpus
+            || ready.memory_mb != memory_mb
+        {
+            bail!("recovery-ready metadata does not match sandbox state");
+        }
+        let staging = CheckpointStaging {
+            id: id.to_string(),
+            directory: staging_path,
+        };
+        let checkpoint = self.commit(
+            &staging,
+            source_sandbox,
+            vcpus,
+            memory_mb,
+            ready.backend_snapshot,
+        )?;
+        let path = self.checkpoint_dir(id)?;
+        Ok((checkpoint, path))
+    }
+
+    pub fn recovery_is_ready(&self, id: &str) -> Result<bool> {
+        let path = self.staging_path(id)?.join(READY_FILE);
+        match fs::symlink_metadata(&path) {
+            Ok(metadata) => {
+                if metadata.file_type().is_symlink() || !metadata.is_file() {
+                    bail!("recovery marker is not a regular file: {}", path.display());
+                }
+                let ready: RecoveryReady = serde_json::from_slice(&fs::read(&path)?)
+                    .with_context(|| format!("invalid recovery marker for checkpoint '{id}'"))?;
+                if ready.format_version != FORMAT_VERSION || ready.id != id {
+                    bail!("recovery-ready marker does not match checkpoint '{id}'");
+                }
+                Ok(true)
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+            Err(error) => {
+                Err(error).with_context(|| format!("failed to inspect recovery marker for '{id}'"))
+            }
+        }
+    }
+
+    /// Validate a checkpoint once and return both its manifest and directory.
+    pub fn load(&self, id: &str) -> Result<(FullStateCheckpoint, PathBuf)> {
+        let directory = self.checkpoint_dir(id)?;
+        let manifest_path = directory.join(MANIFEST_FILE);
+        ensure_regular_file(&manifest_path)?;
+        let manifest: FullStateCheckpoint = serde_json::from_slice(
+            &fs::read(&manifest_path)
+                .with_context(|| format!("failed to read {}", manifest_path.display()))?,
+        )?;
+        if manifest.format_version != FORMAT_VERSION {
+            bail!(
+                "checkpoint '{}' uses unsupported format version {} (expected {})",
+                id,
+                manifest.format_version,
+                FORMAT_VERSION
+            );
+        }
+        if manifest.id != id || manifest.backend != BackendType::Firecracker {
+            bail!(
+                "checkpoint '{}' manifest identity does not match its directory",
+                id
+            );
+        }
+        validate_artifact(&directory, &manifest.memory, MEMORY_FILE)?;
+        validate_artifact(&directory, &manifest.vmstate, VMSTATE_FILE)?;
+        validate_artifact(&directory, &manifest.rootfs, ROOTFS_FILE)?;
+        Ok((manifest, directory))
+    }
+
+    /// Deterministic unpublished path for a checkpoint transition.
+    pub fn staging_path(&self, id: &str) -> Result<PathBuf> {
+        validate_id(id)?;
+        Ok(self.root.join(format!("{STAGING_PREFIX}{id}")))
+    }
+
+    /// Reopen deterministic staging retained by an in-process recovery owner.
+    pub fn open_staging(&self, id: &str) -> Result<CheckpointStaging> {
+        let directory = self.staging_path(id)?;
+        ensure_owned_directory(&directory)?;
+        Ok(CheckpointStaging {
+            id: id.to_string(),
+            directory,
+        })
+    }
+
+    /// Check whether an atomically published checkpoint directory exists
+    /// without hashing its potentially multi-gigabyte artifacts.
+    pub fn contains(&self, id: &str) -> Result<bool> {
+        validate_id(id)?;
+        let directory = self.root.join(id);
+        match fs::symlink_metadata(&directory) {
+            Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_dir() => {
+                bail!("checkpoint '{}' is not an owned directory", id)
+            }
+            Ok(_) => Ok(true),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+            Err(error) => {
+                Err(error).with_context(|| format!("failed to inspect checkpoint directory '{id}'"))
+            }
+        }
+    }
+
+    /// Enumerate unpublished transitions without following directory entries.
+    /// Callers use this at startup to report interrupted or orphaned pauses;
+    /// automatic deletion would be unsafe while another manager may be live.
+    pub fn staging_entries(&self) -> Result<Vec<(Option<String>, PathBuf)>> {
+        let mut entries = Vec::new();
+        for entry in fs::read_dir(&self.root)? {
+            let entry = entry?;
+            let path = entry.path();
+            let metadata = fs::symlink_metadata(&path)?;
+            if metadata.file_type().is_symlink() || !metadata.is_dir() {
+                continue;
+            }
+            let Some(name) = entry.file_name().to_str().map(ToOwned::to_owned) else {
+                continue;
+            };
+            let Some(raw_id) = name.strip_prefix(STAGING_PREFIX) else {
+                continue;
+            };
+            let id = validate_id(raw_id).is_ok().then(|| raw_id.to_string());
+            entries.push((id, path));
+        }
+        entries.sort_by(|left, right| left.1.cmp(&right.1));
+        Ok(entries)
+    }
+
+    pub fn delete(&self, id: &str) -> Result<()> {
+        validate_id(id)?;
+        let directory = self.root.join(id);
+        let metadata = match fs::symlink_metadata(&directory) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => {
+                return Err(error)
+                    .with_context(|| format!("failed to inspect checkpoint '{}'", id));
+            }
+        };
+        // A canonical UUID directory directly beneath the private,
+        // current-user-owned store is the deletion boundary. Do not require
+        // valid artifacts here: removal is also the recovery path for corrupt
+        // or partial checkpoints.
+        if metadata.file_type().is_symlink() || !metadata.is_dir() {
+            bail!("checkpoint '{}' is not an owned directory", id);
+        }
+        fs::remove_dir_all(&directory).with_context(|| {
+            format!(
+                "failed to delete checkpoint directory {}",
+                directory.display()
+            )
+        })?;
+        // The directory is already gone. A failed durability sync must not
+        // make callers retain state that references a consumed checkpoint.
+        if let Err(error) = File::open(&self.root).and_then(|root| root.sync_all()) {
+            eprintln!("Warning: failed to sync checkpoint deletion: {error}");
+        }
+        Ok(())
+    }
+
+    /// Delete an unpublished staging directory retained after an ambiguous
+    /// pause failure.
+    ///
+    /// The path comes from [`CheckpointStaging::preserve`], but the same
+    /// containment and file-type boundary is revalidated here before any
+    /// recursive removal.
+    pub fn discard_staging(&self, path: &Path) -> Result<()> {
+        let staging_id = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .and_then(|name| name.strip_prefix(STAGING_PREFIX));
+        if path.parent() != Some(self.root.as_path())
+            || staging_id.is_none_or(|id| validate_id(id).is_err())
+        {
+            bail!(
+                "full-state recovery path is outside the checkpoint staging boundary: {}",
+                path.display()
+            );
+        }
+        let metadata = match fs::symlink_metadata(path) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!("failed to inspect recovery staging path {}", path.display())
+                });
+            }
+        };
+        if metadata.file_type().is_symlink() || !metadata.is_dir() {
+            bail!(
+                "full-state recovery path is not an owned directory: {}",
+                path.display()
+            );
+        }
+        fs::remove_dir_all(path).with_context(|| {
+            format!(
+                "failed to delete recovery staging directory {}",
+                path.display()
+            )
+        })?;
+        if let Err(error) = File::open(&self.root).and_then(|root| root.sync_all()) {
+            eprintln!("Warning: failed to sync recovery staging deletion: {error}");
+        }
+        Ok(())
+    }
+
+    fn checkpoint_dir(&self, id: &str) -> Result<PathBuf> {
+        validate_id(id)?;
+        let directory = self.root.join(id);
+        let metadata = fs::symlink_metadata(&directory)
+            .with_context(|| format!("checkpoint '{}' not found", id))?;
+        if metadata.file_type().is_symlink() || !metadata.is_dir() {
+            bail!("checkpoint '{}' is not an owned directory", id);
+        }
+        Ok(directory)
+    }
+}
+
+fn ensure_owned_directory(path: &Path) -> Result<()> {
+    let metadata = fs::symlink_metadata(path)
+        .with_context(|| format!("checkpoint directory is missing: {}", path.display()))?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        bail!(
+            "checkpoint path is not an owned directory: {}",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
+fn inspect_artifact(directory: &Path, file: &str) -> Result<CheckpointArtifact> {
+    let path = directory.join(file);
+    ensure_regular_file(&path)?;
+    let bytes = fs::metadata(&path)?.len();
+    if bytes == 0 {
+        bail!("checkpoint artifact '{}' is empty", file);
+    }
+    File::open(&path)?.sync_all()?;
+    Ok(CheckpointArtifact {
+        file: file.to_string(),
+        bytes,
+        sha256: sha256_file(&path)?,
+    })
+}
+
+fn sync_artifact(directory: &Path, file: &str) -> Result<()> {
+    let path = directory.join(file);
+    ensure_regular_file(&path)?;
+    if fs::metadata(&path)?.len() == 0 {
+        bail!("checkpoint artifact '{}' is empty", file);
+    }
+    File::open(path)?.sync_all()?;
+    Ok(())
+}
+
+fn validate_artifact(
+    directory: &Path,
+    artifact: &CheckpointArtifact,
+    expected_file: &str,
+) -> Result<()> {
+    if artifact.file != expected_file {
+        bail!("checkpoint artifact name mismatch for '{}'", expected_file);
+    }
+    let path = directory.join(expected_file);
+    ensure_regular_file(&path)?;
+    let bytes = fs::metadata(&path)?.len();
+    if bytes != artifact.bytes || bytes == 0 {
+        bail!("checkpoint artifact '{}' size changed", expected_file);
+    }
+    let sha256 = sha256_file(&path)?;
+    if sha256 != artifact.sha256 {
+        bail!("checkpoint artifact '{}' digest changed", expected_file);
+    }
+    Ok(())
+}
+
+fn sha256_file(path: &Path) -> Result<String> {
+    let mut file = File::open(path)?;
+    let mut hasher = Sha256::new();
+    let mut buffer = vec![0_u8; 1024 * 1024];
+    loop {
+        let bytes = file.read(&mut buffer)?;
+        if bytes == 0 {
+            break;
+        }
+        hasher.update(&buffer[..bytes]);
+    }
+    Ok(hex::encode(hasher.finalize()))
+}
+
+fn validate_id(id: &str) -> Result<()> {
+    let parsed = Uuid::parse_str(id).context("invalid full-state checkpoint id")?;
+    if parsed.to_string() != id {
+        bail!("full-state checkpoint id must use canonical UUID form");
+    }
+    Ok(())
+}
+
+fn ensure_regular_file(path: &Path) -> Result<()> {
+    let metadata = fs::symlink_metadata(path)
+        .with_context(|| format!("checkpoint artifact is missing: {}", path.display()))?;
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        bail!(
+            "checkpoint artifact is not a regular file: {}",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
+fn ensure_private_directory(path: &Path) -> Result<()> {
+    if !path.exists() {
+        fs::create_dir_all(path)
+            .with_context(|| format!("failed to create checkpoint store {}", path.display()))?;
+        make_private(path)?;
+    }
+    let metadata = fs::symlink_metadata(path)?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        bail!("checkpoint store is not a directory: {}", path.display());
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+        if metadata.uid() != unsafe { libc::geteuid() } {
+            bail!("checkpoint store is not owned by the current user");
+        }
+        if metadata.permissions().mode() & 0o777 != 0o700 {
+            bail!(
+                "existing checkpoint store must have mode 0700: {}",
+                path.display()
+            );
+        }
+    }
+    Ok(())
+}
+
+fn capacity_setting(name: &str, default: u64) -> Result<u64> {
+    match std::env::var(name) {
+        Ok(value) => value
+            .parse::<u64>()
+            .with_context(|| format!("{name} must be an unsigned byte count")),
+        Err(std::env::VarError::NotPresent) => Ok(default),
+        Err(error) => Err(error).with_context(|| format!("failed to read {name}")),
+    }
+}
+
+fn check_capacity(
+    used: u64,
+    reservation: u64,
+    available: u64,
+    cap: u64,
+    min_free: u64,
+) -> Result<()> {
+    if used.saturating_add(reservation) > cap {
+        bail!(
+            "full-state checkpoint storage cap exceeded: used={} bytes, requested={} bytes, cap={} bytes; remove checkpoints or raise {}",
+            used,
+            reservation,
+            cap,
+            GLOBAL_CAP_ENV
+        );
+    }
+    if reservation > available.saturating_sub(min_free) {
+        bail!(
+            "insufficient checkpoint filesystem headroom: available={} bytes, requested={} bytes, required free reserve={} bytes; free space or lower {}",
+            available,
+            reservation,
+            min_free,
+            MIN_FREE_ENV
+        );
+    }
+    Ok(())
+}
+
+fn directory_usage_bytes(root: &Path) -> Result<u64> {
+    let mut total = 0_u64;
+    let mut pending = vec![root.to_path_buf()];
+    while let Some(directory) = pending.pop() {
+        for entry in fs::read_dir(&directory).with_context(|| {
+            format!(
+                "failed to inspect checkpoint usage in {}",
+                directory.display()
+            )
+        })? {
+            let entry = entry?;
+            let metadata = fs::symlink_metadata(entry.path())?;
+            if metadata.file_type().is_symlink() {
+                continue;
+            }
+            if metadata.is_dir() {
+                pending.push(entry.path());
+            } else if metadata.is_file() {
+                total = total.saturating_add(metadata.len());
+            }
+        }
+    }
+    Ok(total)
+}
+
+#[cfg(unix)]
+fn available_space_bytes(path: &Path) -> Result<u64> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let path = CString::new(path.as_os_str().as_bytes())
+        .context("checkpoint store path contains an interior NUL")?;
+    let mut stats = std::mem::MaybeUninit::<libc::statvfs>::uninit();
+    // SAFETY: `path` is a NUL-terminated CString and `stats` points to valid,
+    // writable storage initialized by a successful statvfs call.
+    if unsafe { libc::statvfs(path.as_ptr(), stats.as_mut_ptr()) } != 0 {
+        return Err(std::io::Error::last_os_error())
+            .context("failed to inspect checkpoint filesystem capacity");
+    }
+    // SAFETY: statvfs returned success and initialized the structure.
+    let stats = unsafe { stats.assume_init() };
+    Ok((stats.f_bavail as u64).saturating_mul(stats.f_frsize))
+}
+
+#[cfg(not(unix))]
+fn available_space_bytes(_path: &Path) -> Result<u64> {
+    bail!("full-state checkpoint capacity checks require a Unix host")
+}
+
+fn make_private(path: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o700))?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn backend_snapshot() -> FullStateSnapshot {
+        FullStateSnapshot {
+            firecracker_version: "1.16.1".to_string(),
+            architecture: std::env::consts::ARCH.to_string(),
+            host_kernel_release: "test-kernel".to_string(),
+            host_identity_sha256: "test-host-id".to_string(),
+            cpu_fingerprint_sha256: "test-cpu-id".to_string(),
+            guest_kernel_release: "6.18.45-agentkernel".to_string(),
+        }
+    }
+
+    fn write_artifacts(directory: &Path) {
+        fs::write(directory.join(MEMORY_FILE), b"memory").unwrap();
+        fs::write(directory.join(VMSTATE_FILE), b"state").unwrap();
+        fs::write(directory.join(ROOTFS_FILE), b"rootfs").unwrap();
+    }
+
+    #[test]
+    fn commit_get_and_delete_round_trip() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = FullStateCheckpointStore::new(temp.path()).unwrap();
+        let staging = store.begin().unwrap();
+        write_artifacts(staging.path());
+        let manifest = store
+            .commit(&staging, "source", 2, 1024, backend_snapshot())
+            .unwrap();
+        let (loaded, path) = store.load(&manifest.id).unwrap();
+        assert_eq!(loaded, manifest);
+        assert!(path.join(ROOTFS_FILE).is_file());
+        store.delete(&manifest.id).unwrap();
+        assert!(store.load(&manifest.id).is_err());
+    }
+
+    #[test]
+    fn refuses_size_tampering_and_noncanonical_ids() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = FullStateCheckpointStore::new(temp.path()).unwrap();
+        let staging = store.begin().unwrap();
+        write_artifacts(staging.path());
+        let manifest = store
+            .commit(&staging, "source", 1, 512, backend_snapshot())
+            .unwrap();
+        fs::write(store.root.join(&manifest.id).join(MEMORY_FILE), b"changed").unwrap();
+        assert!(store.load(&manifest.id).is_err());
+        assert!(store.load("../escape").is_err());
+
+        // Corruption must not strand a sandbox that the caller is removing,
+        // and a retry after successful removal is harmless.
+        store.delete(&manifest.id).unwrap();
+        store.delete(&manifest.id).unwrap();
+    }
+
+    #[test]
+    fn refuses_same_size_artifact_tampering() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = FullStateCheckpointStore::new(temp.path()).unwrap();
+        let staging = store.begin().unwrap();
+        write_artifacts(staging.path());
+        let manifest = store
+            .commit(&staging, "source", 1, 512, backend_snapshot())
+            .unwrap();
+        fs::write(store.root.join(&manifest.id).join(MEMORY_FILE), b"MEMORY").unwrap();
+
+        let error = store.load(&manifest.id).unwrap_err();
+        assert!(error.to_string().contains("digest changed"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn refuses_symlinked_artifacts() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let store = FullStateCheckpointStore::new(temp.path()).unwrap();
+        let staging = store.begin().unwrap();
+        fs::write(staging.path().join(MEMORY_FILE), b"memory").unwrap();
+        fs::write(staging.path().join(VMSTATE_FILE), b"state").unwrap();
+        let outside = temp.path().join("outside");
+        fs::write(&outside, b"rootfs").unwrap();
+        symlink(&outside, staging.path().join(ROOTFS_FILE)).unwrap();
+        assert!(
+            store
+                .commit(&staging, "source", 1, 512, backend_snapshot())
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn discards_only_owned_staging_directories() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = FullStateCheckpointStore::new(temp.path()).unwrap();
+        let staging = store.begin().unwrap();
+        let staging_path = staging.preserve();
+
+        store.discard_staging(&staging_path).unwrap();
+        assert!(!staging_path.exists());
+        assert!(store.discard_staging(temp.path()).is_err());
+    }
+
+    #[test]
+    fn staging_path_is_deterministic_and_scannable() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = FullStateCheckpointStore::new(temp.path()).unwrap();
+        let staging = store.begin().unwrap();
+        let id = staging.id().to_string();
+        let path = staging.path().to_path_buf();
+        assert_eq!(store.staging_path(&id).unwrap(), path);
+
+        drop(staging);
+        assert!(path.is_dir(), "staging must survive async cancellation");
+        assert_eq!(store.staging_entries().unwrap(), vec![(Some(id), path)]);
+    }
+
+    #[test]
+    fn recovery_ready_marker_can_publish_interrupted_checkpoint() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = FullStateCheckpointStore::new(temp.path()).unwrap();
+        let staging = store.begin().unwrap();
+        let id = staging.id().to_string();
+        write_artifacts(staging.path());
+        store
+            .mark_recovery_ready(&staging, "source", 2, 1024, backend_snapshot())
+            .unwrap();
+        let _ = staging.preserve();
+
+        let (checkpoint, path) = store.recover_ready(&id, "source", 2, 1024).unwrap();
+        assert_eq!(checkpoint.id, id);
+        assert!(path.is_dir());
+        assert!(store.load(&id).is_ok());
+    }
+
+    #[test]
+    fn malformed_recovery_marker_fails_closed_and_preserves_staging() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = FullStateCheckpointStore::new(temp.path()).unwrap();
+        let staging = store.begin().unwrap();
+        let id = staging.id().to_string();
+        let staging_path = staging.path().to_path_buf();
+        write_artifacts(staging.path());
+        fs::write(staging.path().join(READY_FILE), b"{\"id\":").unwrap();
+        let _ = staging.preserve();
+
+        assert!(store.recovery_is_ready(&id).is_err());
+        assert!(store.recover_ready(&id, "source", 2, 1024).is_err());
+        assert!(staging_path.is_dir());
+        assert!(!store.contains(&id).unwrap());
+    }
+
+    #[test]
+    fn capacity_guard_reserves_global_cap_and_free_space_headroom() {
+        assert!(check_capacity(40, 10, 100, 50, 20).is_ok());
+
+        let cap_error = check_capacity(41, 10, 100, 50, 20).unwrap_err();
+        assert!(cap_error.to_string().contains("storage cap exceeded"));
+
+        let headroom_error = check_capacity(0, 81, 100, 1_000, 20).unwrap_err();
+        assert!(headroom_error.to_string().contains("filesystem headroom"));
+    }
+}

--- a/src/http_api.rs
+++ b/src/http_api.rs
@@ -33,7 +33,8 @@ use tokio::time::{Duration, sleep};
 
 use crate::asciicast::{self, AsciicastEvent, AsciicastHeader, EventType};
 use crate::backend::{
-    BackendCapabilities, BackendType, backend_capabilities, backend_readiness, detect_best_backend,
+    BackendCapabilities, BackendType, FileInjection, backend_capabilities, backend_readiness,
+    detect_best_backend,
 };
 use crate::job_scheduler::{JobScheduleStatus, JobScheduler, JobSchedulerHandle};
 use crate::languages;
@@ -44,7 +45,7 @@ use crate::orchestration_store::{
     DurableStoreQueryResult, OrchestrationEvent, OrchestrationRecord, OrchestrationStatus,
     OrchestrationStore, ScheduleRecord, UpdateOrchestration,
 };
-use crate::permissions::SecurityProfile;
+use crate::permissions::{Permissions, SecurityProfile};
 use crate::secrets::{SecretBackend, SecretVault};
 use crate::task_worker::TaskWorker;
 use crate::task_worker_vmm::VmTaskExecutor;
@@ -344,6 +345,376 @@ struct CreateRequest {
     /// Lifecycle automation policy.
     #[serde(default)]
     lifecycle: Option<LifecyclePolicyRequest>,
+}
+
+/// Optional request body for starting a sandbox.
+///
+/// An omitted or empty body preserves the historical API behavior: moderate
+/// permissions and no startup file injections. The CLI may select a private
+/// host-side manifest when it delegates ownership of a Firecracker VM to the
+/// long-running server. Callers never supply capability values in this body.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct StartSandboxRequest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    configuration: Option<PersistedStartReference>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct PersistedStartReference {
+    source: StartConfigurationSource,
+    token: String,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum StartConfigurationSource {
+    Persisted,
+}
+
+/// Private on-disk start configuration written by the local CLI.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct PersistedStartConfiguration {
+    sandbox_name: String,
+    sandbox_uuid: String,
+    sandbox_state_sha256: String,
+    tenant_id: Option<String>,
+    owner_user_id: Option<String>,
+    owner_org_id: Option<String>,
+    request_owner_id: String,
+    expires_at: String,
+    permissions: Permissions,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    files: Vec<StartFileInjectionRequest>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PersistedStartBinding {
+    sandbox_name: String,
+    sandbox_uuid: String,
+    tenant_id: Option<String>,
+    owner_user_id: Option<String>,
+    owner_org_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct StartFileInjectionRequest {
+    dest: String,
+    content_base64: String,
+}
+
+impl StartSandboxRequest {
+    fn into_runtime(
+        self,
+        data_dir: &Path,
+        binding: &PersistedStartBinding,
+        request_owner_id: &str,
+    ) -> Result<(Permissions, Vec<FileInjection>, Option<String>)> {
+        match self.configuration {
+            None => Ok((Permissions::default(), Vec::new(), None)),
+            Some(reference) => {
+                let configuration = take_persisted_start_configuration(data_dir, &reference)?;
+                configuration.validate_binding(binding, request_owner_id)?;
+                let state_sha256 = configuration.sandbox_state_sha256.clone();
+                let (permissions, files) = configuration.into_runtime()?;
+                Ok((permissions, files, Some(state_sha256)))
+            }
+        }
+    }
+}
+
+impl PersistedStartConfiguration {
+    fn from_runtime(
+        sandbox: &crate::vmm::SandboxState,
+        request_owner_id: String,
+        permissions: &Permissions,
+        files: &[FileInjection],
+    ) -> Result<Self> {
+        Ok(Self {
+            sandbox_name: sandbox.name.clone(),
+            sandbox_uuid: sandbox.uuid.clone(),
+            sandbox_state_sha256: sandbox_state_sha256(sandbox)?,
+            tenant_id: sandbox.tenant_id.clone(),
+            owner_user_id: sandbox.owner_user_id.clone(),
+            owner_org_id: sandbox.owner_org_id.clone(),
+            request_owner_id,
+            expires_at: (chrono::Utc::now() + chrono::Duration::minutes(5)).to_rfc3339(),
+            permissions: permissions.clone(),
+            files: files
+                .iter()
+                .map(|file| StartFileInjectionRequest {
+                    dest: file.dest.clone(),
+                    content_base64: base64::Engine::encode(
+                        &base64::engine::general_purpose::STANDARD,
+                        &file.content,
+                    ),
+                })
+                .collect(),
+        })
+    }
+
+    fn validate_binding(
+        &self,
+        binding: &PersistedStartBinding,
+        request_owner_id: &str,
+    ) -> Result<()> {
+        let expires_at = chrono::DateTime::parse_from_rfc3339(&self.expires_at)
+            .context("persisted start configuration has an invalid expiration")?;
+        if chrono::Utc::now() > expires_at {
+            anyhow::bail!("persisted start configuration has expired");
+        }
+        if self.sandbox_name != binding.sandbox_name
+            || self.sandbox_uuid != binding.sandbox_uuid
+            || self.tenant_id != binding.tenant_id
+            || self.owner_user_id != binding.owner_user_id
+            || self.owner_org_id != binding.owner_org_id
+            || self.request_owner_id != request_owner_id
+        {
+            anyhow::bail!(
+                "persisted start configuration does not belong to this sandbox generation and owner"
+            );
+        }
+        Ok(())
+    }
+
+    fn into_runtime(self) -> Result<(Permissions, Vec<FileInjection>)> {
+        let files = self
+            .files
+            .into_iter()
+            .map(|file| {
+                let content = base64::Engine::decode(
+                    &base64::engine::general_purpose::STANDARD,
+                    &file.content_base64,
+                )
+                .with_context(|| {
+                    format!("invalid base64 content for startup file '{}'", file.dest)
+                })?;
+                Ok(FileInjection {
+                    content,
+                    dest: file.dest,
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        Ok((self.permissions, files))
+    }
+}
+
+fn sandbox_state_sha256(sandbox: &crate::vmm::SandboxState) -> Result<String> {
+    let value = serde_json::to_value(sandbox).context("failed to encode sandbox state")?;
+    let mut encoded = Vec::new();
+    write_canonical_json(&value, &mut encoded)?;
+    Ok(hex::encode(Sha256::digest(encoded)))
+}
+
+fn write_canonical_json(value: &serde_json::Value, output: &mut Vec<u8>) -> Result<()> {
+    match value {
+        serde_json::Value::Null => output.extend_from_slice(b"null"),
+        serde_json::Value::Bool(value) => {
+            output.extend_from_slice(if *value { b"true" } else { b"false" })
+        }
+        serde_json::Value::Number(value) => output.extend_from_slice(value.to_string().as_bytes()),
+        serde_json::Value::String(value) => serde_json::to_writer(output, value)?,
+        serde_json::Value::Array(values) => {
+            output.push(b'[');
+            for (index, value) in values.iter().enumerate() {
+                if index > 0 {
+                    output.push(b',');
+                }
+                write_canonical_json(value, output)?;
+            }
+            output.push(b']');
+        }
+        serde_json::Value::Object(values) => {
+            output.push(b'{');
+            let mut keys = values.keys().collect::<Vec<_>>();
+            keys.sort_unstable();
+            for (index, key) in keys.into_iter().enumerate() {
+                if index > 0 {
+                    output.push(b',');
+                }
+                serde_json::to_writer(&mut *output, key)?;
+                output.push(b':');
+                write_canonical_json(&values[key], output)?;
+            }
+            output.push(b'}');
+        }
+    }
+    Ok(())
+}
+
+impl PersistedStartBinding {
+    fn from_state(sandbox: &crate::vmm::SandboxState) -> Self {
+        Self {
+            sandbox_name: sandbox.name.clone(),
+            sandbox_uuid: sandbox.uuid.clone(),
+            tenant_id: sandbox.tenant_id.clone(),
+            owner_user_id: sandbox.owner_user_id.clone(),
+            owner_org_id: sandbox.owner_org_id.clone(),
+        }
+    }
+}
+
+fn persisted_start_configuration_dir(data_dir: &Path) -> PathBuf {
+    data_dir.join("delegated-start")
+}
+
+fn validate_persisted_start_token(token: &str) -> Result<()> {
+    if token.len() != 64
+        || !token
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        anyhow::bail!("invalid persisted start configuration token");
+    }
+    Ok(())
+}
+
+fn persisted_start_configuration_path(data_dir: &Path, token: &str) -> Result<PathBuf> {
+    validate_persisted_start_token(token)?;
+    Ok(persisted_start_configuration_dir(data_dir).join(format!("{token}.json")))
+}
+
+pub(crate) fn persist_start_configuration(
+    data_dir: &Path,
+    sandbox: &crate::vmm::SandboxState,
+    permissions: &Permissions,
+    files: &[FileInjection],
+) -> Result<StartSandboxRequest> {
+    validation::validate_sandbox_name(&sandbox.name)?;
+    // A newer resolved configuration supersedes every unused token for this
+    // sandbox, so tightened settings cannot be bypassed with a stale request.
+    remove_persisted_start_configurations_for_sandbox(data_dir, &sandbox.name)?;
+    let token = hex::encode(rand::random::<[u8; 32]>());
+    let path = persisted_start_configuration_path(data_dir, &token)?;
+    crate::secure_fs::write_private_json(
+        &path,
+        &PersistedStartConfiguration::from_runtime(
+            sandbox,
+            local_start_request_owner_id(),
+            permissions,
+            files,
+        )?,
+    )
+    .with_context(|| {
+        format!(
+            "failed to persist start configuration for sandbox '{}'",
+            sandbox.name
+        )
+    })?;
+    Ok(StartSandboxRequest {
+        configuration: Some(PersistedStartReference {
+            source: StartConfigurationSource::Persisted,
+            token,
+        }),
+    })
+}
+
+pub(crate) fn discard_persisted_start_configuration(
+    data_dir: &Path,
+    request: &StartSandboxRequest,
+) -> Result<()> {
+    let Some(reference) = request.configuration.as_ref() else {
+        return Ok(());
+    };
+    let path = persisted_start_configuration_path(data_dir, &reference.token)?;
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error).context("failed to discard persisted start configuration"),
+    }
+}
+
+fn take_persisted_start_configuration(
+    data_dir: &Path,
+    reference: &PersistedStartReference,
+) -> Result<PersistedStartConfiguration> {
+    let StartConfigurationSource::Persisted = reference.source;
+    let path = persisted_start_configuration_path(data_dir, &reference.token)?;
+    let consuming = persisted_start_configuration_dir(data_dir)
+        .join(format!(".consuming-{}", uuid::Uuid::now_v7()));
+    std::fs::rename(&path, &consuming)
+        .context("persisted start configuration is unavailable or already consumed")?;
+    let bytes = std::fs::read(&consuming)
+        .context("failed to read persisted start configuration after claiming it");
+    let removed = std::fs::remove_file(&consuming)
+        .context("failed to delete consumed persisted start configuration");
+    let bytes = bytes?;
+    removed?;
+    serde_json::from_slice(&bytes).context("persisted start configuration is invalid")
+}
+
+fn remove_persisted_start_configurations_for_sandbox(data_dir: &Path, name: &str) -> Result<()> {
+    let directory = persisted_start_configuration_dir(data_dir);
+    let entries = match std::fs::read_dir(&directory) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => {
+            return Err(error).context("failed to inspect persisted start configurations");
+        }
+    };
+    for entry in entries {
+        let entry = entry?;
+        let path = entry.path();
+        let file_name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or_default();
+        if path.extension().and_then(|extension| extension.to_str()) != Some("json")
+            && !file_name.starts_with(".consuming-")
+        {
+            continue;
+        }
+        let matches = std::fs::read(&path)
+            .ok()
+            .and_then(|bytes| serde_json::from_slice::<PersistedStartConfiguration>(&bytes).ok())
+            .is_some_and(|configuration| configuration.sandbox_name == name);
+        if matches {
+            match std::fs::remove_file(&path) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    return Err(error)
+                        .context("failed to remove persisted start configuration for sandbox");
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn local_start_request_owner_id() -> String {
+    std::env::var("AGENTKERNEL_API_KEY")
+        .ok()
+        .filter(|key| !key.is_empty())
+        .map(|key| api_key_owner_id(&key))
+        .unwrap_or_else(|| "anonymous".to_string())
+}
+
+fn start_request_owner_id(req: &Request<Incoming>) -> String {
+    req.headers()
+        .get(hyper::header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|header| header.strip_prefix("Bearer "))
+        .filter(|token| !token.is_empty())
+        .map(api_key_owner_id)
+        .unwrap_or_else(|| "anonymous".to_string())
+}
+
+fn parse_start_sandbox_request(body: &[u8]) -> Result<StartSandboxRequest> {
+    if body.is_empty() {
+        return Ok(StartSandboxRequest::default());
+    }
+    serde_json::from_slice(body).context("invalid start request JSON")
+}
+
+/// Request to fork a paused full-state sandbox.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ForkSandboxRequest {
+    /// Name for the forked sandbox.
+    as_name: String,
 }
 
 /// Parse and validate the persistent volume mounts accepted by sandbox create.
@@ -763,6 +1134,13 @@ struct SandboxInfo {
     lifecycle: Option<crate::vmm::SandboxLifecyclePolicy>,
 }
 
+/// Response data for a full-state sandbox fork.
+#[derive(Debug, Serialize)]
+struct ForkSandboxResult {
+    sandbox: SandboxInfo,
+    security_warning: String,
+}
+
 #[derive(Debug, Serialize)]
 struct BackendDiscovery {
     /// Backend selected by automatic sandbox creation, when one is ready.
@@ -920,6 +1298,22 @@ struct AppState {
 }
 
 impl AppState {
+    fn authentication_required(&self) -> bool {
+        #[cfg(feature = "enterprise")]
+        {
+            !self.api_keys.is_empty()
+                || self
+                    .enterprise_config
+                    .as_ref()
+                    .and_then(|config| config.jwks_url.as_deref())
+                    .is_some()
+        }
+        #[cfg(not(feature = "enterprise"))]
+        {
+            !self.api_keys.is_empty()
+        }
+    }
+
     fn new(
         api_keys_override: Vec<String>,
         otel_endpoint: Option<String>,
@@ -1183,6 +1577,15 @@ impl AppState {
             .ok_or_else(|| anyhow::anyhow!("VmManager could not be initialized"))
     }
 
+    /// Return an owned handle for daemon-owned lifecycle tasks.
+    ///
+    /// Unlike `get_manager`, this can be moved into a spawned task so dropping
+    /// an HTTP request future cannot cancel a mutation while it owns the only
+    /// live Firecracker handle.
+    fn manager_handle(&self) -> Result<Arc<tokio::sync::RwLock<VmManager>>> {
+        self.ensure_manager()
+    }
+
     /// Load, validate, and attach user schedules before the listener starts.
     /// Invalid schedule IDs and targets therefore fail daemon startup instead
     /// of silently disabling automation.
@@ -1289,9 +1692,13 @@ impl AppState {
 
     /// Check if a request is authenticated
     #[allow(clippy::result_large_err)]
-    fn check_auth(&self, req: &Request<Incoming>) -> Result<(), Response<BoxBody>> {
-        // If no API keys configured, allow all requests
-        if self.api_keys.is_empty() {
+    async fn check_auth(&self, req: &Request<Incoming>) -> Result<(), Response<BoxBody>> {
+        #[cfg(feature = "enterprise")]
+        let jwks_url = self
+            .enterprise_config
+            .as_ref()
+            .and_then(|config| config.jwks_url.as_deref());
+        if !self.authentication_required() {
             return Ok(());
         }
 
@@ -1305,13 +1712,20 @@ impl AppState {
             Some(header) if header.starts_with("Bearer ") => {
                 let token = &header[7..];
                 if self.api_keys.iter().any(|key| constant_time_eq(token, key)) {
-                    Ok(())
-                } else {
-                    Err(json_response(
-                        StatusCode::UNAUTHORIZED,
-                        &ApiResponse::<()>::error("Invalid API key"),
-                    ))
+                    return Ok(());
                 }
+
+                #[cfg(feature = "enterprise")]
+                if let Some(jwks_url) = jwks_url
+                    && crate::identity::validate_jwt(token, jwks_url).await.is_ok()
+                {
+                    return Ok(());
+                }
+
+                Err(json_response(
+                    StatusCode::UNAUTHORIZED,
+                    &ApiResponse::<()>::error("Invalid bearer token"),
+                ))
             }
             Some(_) => Err(json_response(
                 StatusCode::UNAUTHORIZED,
@@ -1566,6 +1980,13 @@ async fn handle_request(
         return Ok(json_response(StatusCode::OK, &ApiResponse::success("ok")));
     }
 
+    // Status intentionally remains public like health so local clients can
+    // distinguish a reachable daemon from an unavailable backend before they
+    // have credentials or attempt a lifecycle mutation.
+    if method == Method::GET && segments.as_slice() == ["status"] {
+        return Ok(handle_status(state).await);
+    }
+
     // Prometheus metrics endpoint (no auth, like health)
     if method == Method::GET && segments.as_slice() == ["metrics"] {
         let body = crate::metrics::gather();
@@ -1582,7 +2003,7 @@ async fn handle_request(
     }
 
     // Check authentication for all other endpoints
-    if let Err(resp) = state.check_auth(&req) {
+    if let Err(resp) = state.check_auth(&req).await {
         if segments.first() == Some(&"scim") {
             return Ok(crate::scim::authentication_required());
         }
@@ -1610,6 +2031,12 @@ async fn handle_request(
         && !(method == Method::POST
             && segments.len() == 3
             && segments.get(2) == Some(&"config"))
+        // Start performs its ownership check after it has consumed and
+        // validated the one-shot, UUID-bound first-claim token. Owned starts
+        // and unowned starts without a valid token are still denied there.
+        && !(method == Method::POST
+            && segments.len() == 3
+            && segments.get(2) == Some(&"start"))
         && let Ok(manager) = state.get_manager().await
         && let Some(sandbox) = manager.get_state(name)
     {
@@ -1939,6 +2366,19 @@ async fn handle_request(
         // Stop a running sandbox
         (Method::POST, ["sandboxes", name, "stop"]) => handle_stop_sandbox(req, name, state).await,
 
+        // Pause a running Firecracker sandbox with full guest state preserved
+        (Method::POST, ["sandboxes", name, "pause"]) => {
+            handle_pause_sandbox(req, name, state).await
+        }
+
+        // Resume a full-state paused Firecracker sandbox
+        (Method::POST, ["sandboxes", name, "resume"]) => {
+            handle_resume_sandbox(req, name, state).await
+        }
+
+        // Fork a paused Firecracker sandbox into a new running sandbox
+        (Method::POST, ["sandboxes", name, "fork"]) => handle_fork_sandbox(req, name, state).await,
+
         // Extend sandbox TTL
         (Method::POST, ["sandboxes", name, "extend"]) => handle_extend_ttl(req, name, state).await,
 
@@ -1999,7 +2439,7 @@ async fn handle_request(
         (Method::DELETE, ["llm", "keys", provider]) => handle_llm_keys_remove(provider).await,
 
         // Garbage collection
-        (Method::POST, ["gc"]) => handle_gc(state).await,
+        (Method::POST, ["gc"]) => handle_gc(req, state).await,
 
         // Lifecycle policy reconciliation
         (Method::POST, ["lifecycle", "reconcile"]) => handle_reconcile_lifecycle(req, state).await,
@@ -3684,8 +4124,6 @@ async fn handle_cancel_task(task_id: &str, state: Arc<AppState>) -> Response<Box
 async fn handle_list_sandboxes(req: Request<Incoming>, state: Arc<AppState>) -> Response<BoxBody> {
     #[cfg(feature = "enterprise")]
     let identity = extract_identity(&req, &state).await;
-    #[cfg(not(feature = "enterprise"))]
-    let _ = &req;
 
     // Parse label filters from query string: ?label=key:value&label=env:prod
     let label_filters: Vec<(String, String)> = req
@@ -4369,7 +4807,7 @@ async fn handle_get_sandbox(
         );
     }
 
-    let manager = match state.get_manager().await {
+    let mut manager = match state.get_manager().await {
         Ok(m) => m,
         Err(e) => {
             return json_response(
@@ -4378,6 +4816,10 @@ async fn handle_get_sandbox(
             );
         }
     };
+
+    if let Err(response) = refresh_sandbox_state(&mut manager, name) {
+        return response;
+    }
 
     let sandboxes = manager.list();
     for (sandbox_name, running, backend) in &sandboxes {
@@ -5447,12 +5889,10 @@ async fn handle_delete_sandbox(
     #[cfg(not(feature = "enterprise"))]
     let _ = &req;
     #[cfg(feature = "enterprise")]
+    if let Err(response) =
+        enforce_policy(&state, &identity, crate::policy::Action::Create, name).await
     {
-        if let Err(resp) =
-            enforce_policy(&state, &identity, crate::policy::Action::Create, name).await
-        {
-            return resp;
-        }
+        return response;
     }
 
     // Validate sandbox name (security: prevents command injection)
@@ -5476,6 +5916,16 @@ async fn handle_delete_sandbox(
         }
     };
 
+    if let Err(response) = refresh_sandbox_state(&mut manager, name) {
+        return response;
+    }
+    if !manager.exists(name) {
+        return json_response(
+            StatusCode::NOT_FOUND,
+            &ApiResponse::<()>::error("Sandbox not found"),
+        );
+    }
+
     #[cfg(feature = "enterprise")]
     if let Some(sandbox) = manager.get_state(name)
         && let Err(response) = require_sandbox_access(&state, &identity, sandbox)
@@ -5488,26 +5938,67 @@ async fn handle_delete_sandbox(
         .get_state(name)
         .map(|s| s.labels.clone())
         .unwrap_or_default();
-
-    match manager.remove(name).await {
-        Ok(_) => {
-            crate::events::emit(
-                state.event_bus.as_ref(),
-                crate::events::SandboxEvent {
-                    event: "sandbox.deleted".to_string(),
-                    timestamp: chrono::Utc::now(),
-                    sandbox: name.to_string(),
-                    labels: event_labels,
-                    metadata: serde_json::json!({}),
-                },
+    let expected_binding = manager
+        .get_state(name)
+        .map(PersistedStartBinding::from_state);
+    let manager_handle = match state.manager_handle() {
+        Ok(manager) => manager,
+        Err(error) => {
+            return json_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &ApiResponse::<()>::error(error.to_string()),
             );
-            json_response(StatusCode::OK, &ApiResponse::success("Sandbox removed"))
         }
-        Err(e) => json_response(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            &ApiResponse::<()>::error(e.to_string()),
-        ),
-    }
+    };
+    drop(manager);
+    #[cfg(feature = "enterprise")]
+    drop(_quota_guard);
+    let name = name.to_string();
+    let task_state = Arc::clone(&state);
+    let task = tokio::spawn(async move {
+        #[cfg(feature = "enterprise")]
+        let _quota_guard = task_state.quota_controller.lock().await;
+        let mut manager = manager_handle.write().await;
+        if manager
+            .get_state(&name)
+            .map(PersistedStartBinding::from_state)
+            != expected_binding
+        {
+            return json_response(
+                StatusCode::CONFLICT,
+                &ApiResponse::<()>::error(
+                    "Sandbox identity or ownership changed before the server-owned removal began",
+                ),
+            );
+        }
+        match manager.remove(&name).await {
+            Ok(_) => {
+                if let Err(error) =
+                    remove_persisted_start_configurations_for_sandbox(manager.get_data_dir(), &name)
+                {
+                    return json_response(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        &ApiResponse::<()>::error(format!(
+                            "Sandbox was removed, but its pending start configuration could not be scrubbed: {error}"
+                        )),
+                    );
+                }
+                crate::events::emit(
+                    task_state.event_bus.as_ref(),
+                    crate::events::SandboxEvent {
+                        event: "sandbox.deleted".to_string(),
+                        timestamp: chrono::Utc::now(),
+                        sandbox: name,
+                        labels: event_labels,
+                        metadata: serde_json::json!({}),
+                    },
+                );
+                json_response(StatusCode::OK, &ApiResponse::success("Sandbox removed"))
+            }
+            Err(error) => sandbox_lifecycle_error("remove", error),
+        }
+    });
+    await_server_owned_lifecycle("remove", task).await
 }
 
 async fn handle_start_sandbox(
@@ -5518,16 +6009,11 @@ async fn handle_start_sandbox(
     // Enterprise policy enforcement
     #[cfg(feature = "enterprise")]
     let identity = extract_identity(&req, &state).await;
+    // Bind the private handoff to the exact bearer presented by the local CLI.
+    // This works for both API keys and JWTs without persisting either secret.
+    let request_owner_id = start_request_owner_id(&req);
     #[cfg(not(feature = "enterprise"))]
-    let _ = &req;
-    #[cfg(feature = "enterprise")]
-    {
-        if let Err(resp) =
-            enforce_policy(&state, &identity, crate::policy::Action::Create, name).await
-        {
-            return resp;
-        }
-    }
+    let trusted_start_owner = trusted_owner_identity(&req, &state);
 
     // Validate sandbox name (security: prevents command injection)
     if let Err(e) = validation::validate_sandbox_name(name) {
@@ -5537,6 +6023,33 @@ async fn handle_start_sandbox(
         );
     }
 
+    let body = match read_body_bytes(req).await {
+        Ok(body) => body,
+        Err(response) => return response,
+    };
+    let start_request = match parse_start_sandbox_request(&body) {
+        Ok(request) => request,
+        Err(error) => {
+            return json_response(
+                StatusCode::BAD_REQUEST,
+                &ApiResponse::<()>::error(format!("{error:#}")),
+            );
+        }
+    };
+    #[cfg(feature = "enterprise")]
+    {
+        if let Err(response) =
+            enforce_policy(&state, &identity, crate::policy::Action::Run, name).await
+        {
+            return response;
+        }
+        if start_request.configuration.is_some()
+            && let Err(response) =
+                enforce_policy(&state, &identity, crate::policy::Action::Create, name).await
+        {
+            return response;
+        }
+    }
     #[cfg(feature = "enterprise")]
     let quota_guard = state.quota_controller.lock().await;
 
@@ -5549,6 +6062,85 @@ async fn handle_start_sandbox(
             );
         }
     };
+
+    if let Err(response) = refresh_sandbox_state(&mut manager, name) {
+        return response;
+    }
+    let start_binding = match manager.get_state(name) {
+        Some(sandbox) => PersistedStartBinding::from_state(sandbox),
+        None => {
+            return json_response(
+                StatusCode::NOT_FOUND,
+                &ApiResponse::<()>::error("Sandbox not found"),
+            );
+        }
+    };
+    let token_authorizes_first_claim = start_request.configuration.is_some();
+    let (permissions, files, expected_state_sha256) =
+        match start_request.into_runtime(manager.get_data_dir(), &start_binding, &request_owner_id)
+        {
+            Ok(runtime) => runtime,
+            Err(error) => {
+                return json_response(
+                    StatusCode::BAD_REQUEST,
+                    &ApiResponse::<()>::error(error.to_string()),
+                );
+            }
+        };
+
+    if let Some(expected_state_sha256) = expected_state_sha256 {
+        if let Err(error) = manager.refresh_stopped_sandbox_from_disk(name) {
+            return json_response(
+                StatusCode::CONFLICT,
+                &ApiResponse::<()>::error(format!(
+                    "Failed to adopt the final persisted sandbox configuration: {error}"
+                )),
+            );
+        }
+        let actual_state_sha256 = match manager.get_state(name).map(sandbox_state_sha256) {
+            Some(Ok(hash)) => hash,
+            Some(Err(error)) => {
+                return json_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    &ApiResponse::<()>::error(error.to_string()),
+                );
+            }
+            None => {
+                return json_response(
+                    StatusCode::NOT_FOUND,
+                    &ApiResponse::<()>::error("Sandbox not found"),
+                );
+            }
+        };
+        if actual_state_sha256 != expected_state_sha256 {
+            return json_response(
+                StatusCode::CONFLICT,
+                &ApiResponse::<()>::error(
+                    "Persisted sandbox configuration changed after the start handoff was created",
+                ),
+            );
+        }
+    }
+
+    #[cfg(feature = "enterprise")]
+    if let Err(response) = claim_unowned_start_sandbox(
+        &mut manager,
+        name,
+        token_authorizes_first_claim,
+        &identity,
+        &state,
+    ) {
+        return response;
+    }
+    #[cfg(not(feature = "enterprise"))]
+    if let Err(response) = claim_unowned_local_start_sandbox(
+        &mut manager,
+        name,
+        token_authorizes_first_claim,
+        trusted_start_owner.as_ref(),
+    ) {
+        return response;
+    }
 
     #[cfg(feature = "enterprise")]
     if let Some(sandbox) = manager.get_state(name)
@@ -5578,13 +6170,72 @@ async fn handle_start_sandbox(
         return quota_denial(name, &subject, "start", error);
     }
 
-    match manager.start(name).await {
-        Ok(_) => json_response(StatusCode::OK, &ApiResponse::success("Sandbox started")),
-        Err(e) => json_response(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            &ApiResponse::<()>::error(e.to_string()),
-        ),
-    }
+    let expected_binding = manager
+        .get_state(name)
+        .map(PersistedStartBinding::from_state)
+        .expect("sandbox presence was validated before server-owned start");
+    let manager_handle = match state.manager_handle() {
+        Ok(manager) => manager,
+        Err(error) => {
+            return json_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &ApiResponse::<()>::error(error.to_string()),
+            );
+        }
+    };
+    drop(manager);
+    #[cfg(feature = "enterprise")]
+    drop(quota_guard);
+    let name = name.to_string();
+    #[cfg(feature = "enterprise")]
+    let task_state = Arc::clone(&state);
+    let task = tokio::spawn(async move {
+        #[cfg(feature = "enterprise")]
+        let quota_guard = task_state.quota_controller.lock().await;
+        let mut manager = manager_handle.write().await;
+        let Some(current) = manager.get_state(&name) else {
+            return json_response(
+                StatusCode::NOT_FOUND,
+                &ApiResponse::<()>::error("Sandbox not found"),
+            );
+        };
+        if PersistedStartBinding::from_state(current) != expected_binding {
+            return json_response(
+                StatusCode::CONFLICT,
+                &ApiResponse::<()>::error(
+                    "Sandbox identity or ownership changed before the server-owned start began",
+                ),
+            );
+        }
+        #[cfg(feature = "enterprise")]
+        if let Err(error) = quota_guard.check_start(&manager, &name) {
+            let subject = manager
+                .get_state(&name)
+                .map(|sandbox| crate::quota::QuotaSubject {
+                    user_id: sandbox
+                        .owner_user_id
+                        .clone()
+                        .unwrap_or_else(|| "anonymous".to_string()),
+                    org_id: sandbox
+                        .owner_org_id
+                        .clone()
+                        .unwrap_or_else(|| "default".to_string()),
+                })
+                .unwrap_or(crate::quota::QuotaSubject {
+                    user_id: "anonymous".to_string(),
+                    org_id: "default".to_string(),
+                });
+            return quota_denial(&name, &subject, "start", error);
+        }
+        match manager
+            .start_with_permissions_and_files_authorized(&name, &permissions, &files)
+            .await
+        {
+            Ok(_) => json_response(StatusCode::OK, &ApiResponse::success("Sandbox started")),
+            Err(error) => sandbox_lifecycle_error("start", error),
+        }
+    });
+    await_server_owned_lifecycle("start", task).await
 }
 
 async fn handle_stop_sandbox(
@@ -5598,8 +6249,7 @@ async fn handle_stop_sandbox(
     let _ = &req;
     #[cfg(feature = "enterprise")]
     {
-        if let Err(resp) =
-            enforce_policy(&state, &identity, crate::policy::Action::Create, name).await
+        if let Err(resp) = enforce_policy(&state, &identity, crate::policy::Action::Run, name).await
         {
             return resp;
         }
@@ -5615,7 +6265,7 @@ async fn handle_stop_sandbox(
     #[cfg(feature = "enterprise")]
     let _quota_guard = state.quota_controller.lock().await;
 
-    let mut manager = match state.get_manager().await {
+    let manager = match state.get_manager().await {
         Ok(m) => m,
         Err(e) => {
             return json_response(
@@ -5632,13 +6282,576 @@ async fn handle_stop_sandbox(
         return response;
     }
 
-    match manager.stop(name).await {
-        Ok(_) => json_response(StatusCode::OK, &ApiResponse::success("Sandbox stopped")),
-        Err(e) => json_response(
+    let expected_binding = manager
+        .get_state(name)
+        .map(PersistedStartBinding::from_state);
+    let manager_handle = match state.manager_handle() {
+        Ok(manager) => manager,
+        Err(error) => {
+            return json_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &ApiResponse::<()>::error(error.to_string()),
+            );
+        }
+    };
+    drop(manager);
+    #[cfg(feature = "enterprise")]
+    drop(_quota_guard);
+    let name = name.to_string();
+    #[cfg(feature = "enterprise")]
+    let task_state = Arc::clone(&state);
+    let task = tokio::spawn(async move {
+        #[cfg(feature = "enterprise")]
+        let _quota_guard = task_state.quota_controller.lock().await;
+        let mut manager = manager_handle.write().await;
+        if manager
+            .get_state(&name)
+            .map(PersistedStartBinding::from_state)
+            != expected_binding
+        {
+            return json_response(
+                StatusCode::CONFLICT,
+                &ApiResponse::<()>::error(
+                    "Sandbox identity or ownership changed before the server-owned stop began",
+                ),
+            );
+        }
+        match manager.stop(&name).await {
+            Ok(_) => json_response(StatusCode::OK, &ApiResponse::success("Sandbox stopped")),
+            Err(error) => sandbox_lifecycle_error("stop", error),
+        }
+    });
+    await_server_owned_lifecycle("stop", task).await
+}
+
+#[allow(clippy::result_large_err)]
+fn require_full_state_firecracker(
+    manager: &VmManager,
+    name: &str,
+) -> Result<(), Response<BoxBody>> {
+    let Some(sandbox) = manager.get_state(name) else {
+        return Err(json_response(
+            StatusCode::NOT_FOUND,
+            &ApiResponse::<()>::error("Sandbox not found"),
+        ));
+    };
+    let backend = recorded_backend(sandbox.backend, manager.backend());
+    if backend != BackendType::Firecracker {
+        return Err(json_response(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            &ApiResponse::<()>::error(format!(
+                "Backend '{}' does not support full-state pause, resume, or fork; use the Firecracker backend",
+                backend
+            )),
+        ));
+    }
+    Ok(())
+}
+
+#[allow(clippy::result_large_err)]
+fn refresh_sandbox_state(manager: &mut VmManager, name: &str) -> Result<bool, Response<BoxBody>> {
+    manager.refresh_sandbox_if_missing(name).map_err(|error| {
+        json_response(
             StatusCode::INTERNAL_SERVER_ERROR,
-            &ApiResponse::<()>::error(e.to_string()),
+            &ApiResponse::<()>::error(format!(
+                "Failed to refresh sandbox state for '{name}': {error}"
+            )),
+        )
+    })
+}
+
+#[cfg(feature = "enterprise")]
+#[allow(clippy::result_large_err)]
+fn claim_unowned_start_sandbox(
+    manager: &mut VmManager,
+    name: &str,
+    token_authorizes_first_claim: bool,
+    identity: &crate::identity::AgentIdentity,
+    state: &AppState,
+) -> Result<(), Response<BoxBody>> {
+    // A refresh is not an authorization event: the server may have loaded the
+    // same unowned state during startup or a prior GET. Only a valid, consumed
+    // local start token bound to this UUID/generation may authorize first claim.
+    let Some(sandbox) = manager.get_state(name) else {
+        return Ok(());
+    };
+    if sandbox.owner_user_id.is_some() || sandbox.owner_org_id.is_some() {
+        return Ok(());
+    }
+    if !token_authorizes_first_claim {
+        return Err(sandbox_access_denied());
+    }
+
+    let trusted_identity = trusted_owner_identity(identity, state).is_some()
+        || (!identity.is_authenticated() && state.api_keys.is_empty());
+    if !trusted_identity {
+        return Err(json_response(
+            StatusCode::FORBIDDEN,
+            &ApiResponse::<()>::error(
+                "A trusted identity is required to claim a CLI-created sandbox",
+            ),
+        ));
+    }
+
+    let subject = quota_subject(state, identity);
+    manager
+        .set_trusted_ownership(
+            name,
+            trusted_tenant_for_sandbox(identity, state),
+            Some(&subject.user_id),
+            Some(&subject.org_id),
+        )
+        .map_err(|error| {
+            json_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &ApiResponse::<()>::error(format!(
+                    "Failed to atomically persist refreshed sandbox ownership: {error}"
+                )),
+            )
+        })
+}
+
+#[cfg(not(feature = "enterprise"))]
+#[allow(clippy::result_large_err)]
+fn claim_unowned_local_start_sandbox(
+    manager: &mut VmManager,
+    name: &str,
+    token_authorizes_first_claim: bool,
+    trusted_owner: Option<&(String, String)>,
+) -> Result<(), Response<BoxBody>> {
+    if !token_authorizes_first_claim {
+        return Ok(());
+    }
+    let Some(sandbox) = manager.get_state(name) else {
+        return Ok(());
+    };
+    if sandbox.owner_user_id.is_some() || sandbox.owner_org_id.is_some() {
+        return Ok(());
+    }
+    let Some((tenant, user)) = trusted_owner else {
+        // With no configured API authentication there is no durable identity
+        // to stamp; the unowned local-only behavior remains unchanged.
+        return Ok(());
+    };
+    manager
+        .set_owner_identity(name, tenant, user)
+        .map_err(|error| {
+            json_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &ApiResponse::<()>::error(format!(
+                    "Failed to persist refreshed sandbox ownership: {error}"
+                )),
+            )
+        })
+}
+
+fn sandbox_lifecycle_error(operation: &str, error: anyhow::Error) -> Response<BoxBody> {
+    // Full-state operations reject proxy-backed secret workloads before they
+    // reach the backend. Their remaining error chains contain lifecycle and
+    // checkpoint diagnostics (including actionable recovery paths), not secret
+    // values, so preserve the complete anyhow context for operators.
+    let message = format!("{error:#}");
+    let normalized = message.to_ascii_lowercase();
+    let status = if normalized.contains("not found") {
+        StatusCode::NOT_FOUND
+    } else if normalized.contains("not support")
+        || normalized.contains("unsupported")
+        || normalized.contains("requires firecracker")
+        || normalized.contains("requires linux x86_64")
+        || normalized.contains("firecracker backend")
+    {
+        StatusCode::UNPROCESSABLE_ENTITY
+    } else if normalized.contains("already")
+        || normalized.contains("must be")
+        || normalized.contains("not running")
+        || normalized.contains("not paused")
+        || normalized.contains("is paused")
+        || normalized.contains("cold start")
+        || normalized.contains("refusing to stop")
+        || normalized.contains("cannot pause")
+        || normalized.contains("cannot resume")
+        || normalized.contains("cannot fork")
+    {
+        StatusCode::CONFLICT
+    } else {
+        StatusCode::INTERNAL_SERVER_ERROR
+    };
+    json_response(
+        status,
+        &ApiResponse::<()>::error(format!("Failed to {operation} sandbox: {message}")),
+    )
+}
+
+async fn await_server_owned_lifecycle(
+    operation: &'static str,
+    task: tokio::task::JoinHandle<Response<BoxBody>>,
+) -> Response<BoxBody> {
+    match task.await {
+        Ok(response) => response,
+        Err(error) => json_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            &ApiResponse::<()>::error(format!(
+                "Server-owned {operation} task failed unexpectedly: {error}"
+            )),
         ),
     }
+}
+
+#[cfg(feature = "enterprise")]
+const FULL_STATE_RUNTIME_POLICY_ACTION: crate::policy::Action = crate::policy::Action::Run;
+
+#[cfg(feature = "enterprise")]
+const FORK_SOURCE_POLICY_ACTION: crate::policy::Action = FULL_STATE_RUNTIME_POLICY_ACTION;
+
+#[cfg(feature = "enterprise")]
+const FORK_CHILD_POLICY_ACTIONS: [crate::policy::Action; 2] =
+    [crate::policy::Action::Create, crate::policy::Action::Run];
+
+fn fork_identity_matches_source(
+    source: &crate::vmm::SandboxState,
+    tenant_id: Option<&str>,
+    owner_user_id: Option<&str>,
+    owner_org_id: Option<&str>,
+) -> bool {
+    source.tenant_id.as_deref() == tenant_id
+        && source.owner_user_id.as_deref() == owner_user_id
+        && source.owner_org_id.as_deref() == owner_org_id
+}
+
+#[allow(clippy::result_large_err)]
+fn sandbox_info_from_manager(
+    manager: &VmManager,
+    name: &str,
+) -> Result<SandboxInfo, Response<BoxBody>> {
+    let Some(state_info) = manager.get_state(name) else {
+        return Err(json_response(
+            StatusCode::NOT_FOUND,
+            &ApiResponse::<()>::error("Sandbox not found"),
+        ));
+    };
+    let running = manager.is_running(name);
+    let ip = running.then(|| manager.get_container_ip(name)).flatten();
+    Ok(SandboxInfo {
+        name: name.to_string(),
+        uuid: state_info.uuid.clone(),
+        status: state_info.status(running).to_string(),
+        backend: recorded_backend(state_info.backend, manager.backend()).to_string(),
+        ip,
+        image: Some(state_info.image.clone()),
+        vcpus: Some(state_info.vcpus),
+        memory_mb: Some(state_info.memory_mb),
+        created_at: Some(state_info.created_at.clone()),
+        created_from_template: state_info.created_from_template.clone(),
+        template_help_text: state_info.template_help_text.clone(),
+        ports: state_info
+            .ports
+            .iter()
+            .map(std::string::ToString::to_string)
+            .collect(),
+        endpoints: state_info.endpoints.clone(),
+        secret_files: state_info.secret_files.clone(),
+        placeholder_secrets: state_info.placeholder_secrets,
+        proxy_port: state_info.proxy_port,
+        secret_mappings: build_secret_mappings(state_info),
+        labels: state_info.labels.clone(),
+        description: state_info.description.clone(),
+        last_activity_at: state_info.last_activity_at.clone(),
+        workspace_revision: state_info.workspace_revision.clone(),
+        archived_at: state_info.archived_at.clone(),
+        archived_reason: state_info.archived_reason.clone(),
+        lifecycle: state_info.lifecycle_policy.clone(),
+    })
+}
+
+async fn handle_pause_sandbox(
+    req: Request<Incoming>,
+    name: &str,
+    state: Arc<AppState>,
+) -> Response<BoxBody> {
+    #[cfg(feature = "enterprise")]
+    let identity = extract_identity(&req, &state).await;
+    #[cfg(not(feature = "enterprise"))]
+    let _ = &req;
+
+    if let Err(error) = validation::validate_sandbox_name(name) {
+        return json_response(
+            StatusCode::BAD_REQUEST,
+            &ApiResponse::<()>::error(error.to_string()),
+        );
+    }
+
+    #[cfg(feature = "enterprise")]
+    if let Err(response) =
+        enforce_policy(&state, &identity, FULL_STATE_RUNTIME_POLICY_ACTION, name).await
+    {
+        return response;
+    }
+
+    let manager = match state.manager_handle() {
+        Ok(manager) => manager,
+        Err(error) => {
+            return json_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &ApiResponse::<()>::error(error.to_string()),
+            );
+        }
+    };
+    let name = name.to_string();
+    #[cfg(feature = "enterprise")]
+    let task_state = state.clone();
+    let task = tokio::spawn(async move {
+        // Pause changes running quota usage. Keep serialization in the task so
+        // it remains held even if the HTTP waiter disconnects.
+        #[cfg(feature = "enterprise")]
+        let _quota_guard = task_state.quota_controller.lock().await;
+        let mut manager = manager.write().await;
+        if let Err(response) = refresh_sandbox_state(&mut manager, &name) {
+            return response;
+        }
+        if let Err(response) = require_full_state_firecracker(&manager, &name) {
+            return response;
+        }
+        #[cfg(feature = "enterprise")]
+        if let Some(sandbox) = manager.get_state(&name)
+            && let Err(response) = require_sandbox_access(&task_state, &identity, sandbox)
+        {
+            return response;
+        }
+        match manager.pause_authorized(&name).await {
+            Ok(_) => json_response(StatusCode::OK, &ApiResponse::success("Sandbox paused")),
+            Err(error) => sandbox_lifecycle_error("pause", error),
+        }
+    });
+    await_server_owned_lifecycle("pause", task).await
+}
+
+async fn handle_resume_sandbox(
+    req: Request<Incoming>,
+    name: &str,
+    state: Arc<AppState>,
+) -> Response<BoxBody> {
+    #[cfg(feature = "enterprise")]
+    let identity = extract_identity(&req, &state).await;
+    #[cfg(not(feature = "enterprise"))]
+    let _ = &req;
+
+    if let Err(error) = validation::validate_sandbox_name(name) {
+        return json_response(
+            StatusCode::BAD_REQUEST,
+            &ApiResponse::<()>::error(error.to_string()),
+        );
+    }
+
+    #[cfg(feature = "enterprise")]
+    if let Err(response) =
+        enforce_policy(&state, &identity, FULL_STATE_RUNTIME_POLICY_ACTION, name).await
+    {
+        return response;
+    }
+
+    let manager = match state.manager_handle() {
+        Ok(manager) => manager,
+        Err(error) => {
+            return json_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &ApiResponse::<()>::error(error.to_string()),
+            );
+        }
+    };
+    let name = name.to_string();
+    #[cfg(feature = "enterprise")]
+    let task_state = state.clone();
+    let task = tokio::spawn(async move {
+        #[cfg(feature = "enterprise")]
+        let quota_guard = task_state.quota_controller.lock().await;
+        let mut manager = manager.write().await;
+        if let Err(response) = refresh_sandbox_state(&mut manager, &name) {
+            return response;
+        }
+        if let Err(response) = require_full_state_firecracker(&manager, &name) {
+            return response;
+        }
+        #[cfg(feature = "enterprise")]
+        if let Some(sandbox) = manager.get_state(&name)
+            && let Err(response) = require_sandbox_access(&task_state, &identity, sandbox)
+        {
+            return response;
+        }
+        #[cfg(feature = "enterprise")]
+        if let Err(error) = quota_guard.check_start(&manager, &name) {
+            let subject = manager
+                .get_state(&name)
+                .map(|sandbox| crate::quota::QuotaSubject {
+                    user_id: sandbox
+                        .owner_user_id
+                        .clone()
+                        .unwrap_or_else(|| "anonymous".to_string()),
+                    org_id: sandbox
+                        .owner_org_id
+                        .clone()
+                        .unwrap_or_else(|| "default".to_string()),
+                })
+                .unwrap_or(crate::quota::QuotaSubject {
+                    user_id: "anonymous".to_string(),
+                    org_id: "default".to_string(),
+                });
+            return quota_denial(&name, &subject, "resume", error);
+        }
+        match manager.resume_authorized(&name).await {
+            Ok(()) => json_response(StatusCode::OK, &ApiResponse::success("Sandbox resumed")),
+            Err(error) => sandbox_lifecycle_error("resume", error),
+        }
+    });
+    await_server_owned_lifecycle("resume", task).await
+}
+
+async fn handle_fork_sandbox(
+    req: Request<Incoming>,
+    source: &str,
+    state: Arc<AppState>,
+) -> Response<BoxBody> {
+    #[cfg(feature = "enterprise")]
+    let identity = extract_identity(&req, &state).await;
+    #[cfg(not(feature = "enterprise"))]
+    let trusted_owner = trusted_owner_identity(&req, &state);
+    #[cfg(feature = "enterprise")]
+    let trusted_tenant = trusted_tenant_for_sandbox(&identity, &state);
+
+    if let Err(error) = validation::validate_sandbox_name(source) {
+        return json_response(
+            StatusCode::BAD_REQUEST,
+            &ApiResponse::<()>::error(error.to_string()),
+        );
+    }
+
+    let body: ForkSandboxRequest = match read_json_body(req).await {
+        Ok(body) => body,
+        Err(response) => return response,
+    };
+    if let Err(error) = validation::validate_sandbox_name(&body.as_name) {
+        return json_response(
+            StatusCode::BAD_REQUEST,
+            &ApiResponse::<()>::error(format!("Invalid fork name: {error}")),
+        );
+    }
+
+    #[cfg(feature = "enterprise")]
+    {
+        if let Err(response) =
+            enforce_policy(&state, &identity, FORK_SOURCE_POLICY_ACTION, source).await
+        {
+            return response;
+        }
+        for action in FORK_CHILD_POLICY_ACTIONS {
+            if let Err(response) = enforce_policy(&state, &identity, action, &body.as_name).await {
+                return response;
+            }
+        }
+    }
+
+    #[cfg(feature = "enterprise")]
+    let quota_subject = quota_subject(&state, &identity);
+    let manager = match state.manager_handle() {
+        Ok(manager) => manager,
+        Err(error) => {
+            return json_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &ApiResponse::<()>::error(error.to_string()),
+            );
+        }
+    };
+    let source = source.to_string();
+    let child = body.as_name;
+    #[cfg(feature = "enterprise")]
+    let task_state = state.clone();
+    let task = tokio::spawn(async move {
+        #[cfg(feature = "enterprise")]
+        let quota_guard = task_state.quota_controller.lock().await;
+        let mut manager = manager.write().await;
+        if let Err(response) = refresh_sandbox_state(&mut manager, &source) {
+            return response;
+        }
+        if let Err(response) = refresh_sandbox_state(&mut manager, &child) {
+            return response;
+        }
+        if let Err(response) = require_full_state_firecracker(&manager, &source) {
+            return response;
+        }
+        if manager.exists(&child) {
+            return json_response(
+                StatusCode::CONFLICT,
+                &ApiResponse::<()>::error(format!("Sandbox '{child}' already exists")),
+            );
+        }
+        #[cfg(feature = "enterprise")]
+        if let Some(sandbox) = manager.get_state(&source)
+            && let Err(response) = require_sandbox_access(&task_state, &identity, sandbox)
+        {
+            return response;
+        }
+        #[cfg(feature = "enterprise")]
+        if let Some(source_state) = manager.get_state(&source)
+            && let Err(error) = quota_guard.check_create(
+                &manager,
+                &quota_subject,
+                source_state.vcpus,
+                source_state.memory_mb,
+            )
+        {
+            return quota_denial(&child, &quota_subject, "fork", error);
+        }
+
+        let source_state = match manager.get_state(&source) {
+            Some(source_state) => source_state,
+            None => {
+                return json_response(
+                    StatusCode::NOT_FOUND,
+                    &ApiResponse::<()>::error("Sandbox not found"),
+                );
+            }
+        };
+        #[cfg(feature = "enterprise")]
+        let requested_identity = (
+            trusted_tenant.as_deref(),
+            Some(quota_subject.user_id.as_str()),
+            Some(quota_subject.org_id.as_str()),
+        );
+        #[cfg(not(feature = "enterprise"))]
+        let requested_identity = (
+            source_state.tenant_id.as_deref(),
+            trusted_owner.as_ref().map(|(_, user)| user.as_str()),
+            trusted_owner.as_ref().map(|(tenant, _)| tenant.as_str()),
+        );
+        if !fork_identity_matches_source(
+            source_state,
+            requested_identity.0,
+            requested_identity.1,
+            requested_identity.2,
+        ) {
+            return json_response(
+                StatusCode::FORBIDDEN,
+                &ApiResponse::<()>::error(
+                    "Forking across sandbox owner or tenant boundaries is not supported",
+                ),
+            );
+        }
+
+        if let Err(error) = manager.fork_sandbox_authorized(&source, &child).await {
+            return sandbox_lifecycle_error("fork", error);
+        }
+        let sandbox = match sandbox_info_from_manager(&manager, &child) {
+            Ok(sandbox) => sandbox,
+            Err(response) => return response,
+        };
+        json_response(
+            StatusCode::CREATED,
+            &ApiResponse::success(ForkSandboxResult {
+                sandbox,
+                security_warning: crate::full_state::FORK_SECURITY_WARNING.to_string(),
+            }),
+        )
+    });
+    await_server_owned_lifecycle("fork", task).await
 }
 
 /// Request body for extending TTL
@@ -5664,6 +6877,15 @@ async fn handle_extend_ttl(
     name: &str,
     state: Arc<AppState>,
 ) -> Response<BoxBody> {
+    #[cfg(feature = "enterprise")]
+    let identity = extract_identity(&req, &state).await;
+    #[cfg(feature = "enterprise")]
+    if let Err(response) =
+        enforce_policy(&state, &identity, crate::policy::Action::Create, name).await
+    {
+        return response;
+    }
+
     // Validate sandbox name
     if let Err(e) = validation::validate_sandbox_name(name) {
         return json_response(
@@ -5701,12 +6923,23 @@ async fn handle_extend_ttl(
         }
     };
 
+    if let Err(response) = refresh_sandbox_state(&mut manager, name) {
+        return response;
+    }
+
     // Check if sandbox exists
     if !manager.exists(name) {
         return json_response(
             StatusCode::NOT_FOUND,
             &ApiResponse::<()>::error(format!("Sandbox '{}' not found", name)),
         );
+    }
+
+    #[cfg(feature = "enterprise")]
+    if let Some(sandbox) = manager.get_state(name)
+        && let Err(response) = require_sandbox_access(&state, &identity, sandbox)
+    {
+        return response;
     }
 
     // Extend the TTL
@@ -6205,6 +7438,18 @@ async fn handle_reconcile_lifecycle(
     req: Request<Incoming>,
     state: Arc<AppState>,
 ) -> Response<BoxBody> {
+    #[cfg(feature = "enterprise")]
+    {
+        let identity = extract_identity(&req, &state).await;
+        if !identity.has_role("admin") {
+            return json_response(
+                StatusCode::FORBIDDEN,
+                &ApiResponse::<()>::error(
+                    "Lifecycle reconciliation requires an administrator identity",
+                ),
+            );
+        }
+    }
     let body_bytes = match read_body_bytes(req).await {
         Ok(b) => b,
         Err(resp) => return resp,
@@ -7068,6 +8313,15 @@ fn sandbox_access_allowed(
     identity: &crate::identity::AgentIdentity,
     sandbox: &crate::vmm::SandboxState,
 ) -> bool {
+    if sandbox.owner_user_id.is_none() && sandbox.owner_org_id.is_none() {
+        // CLI-created --no-start state has not been claimed yet. A principal
+        // accepted by the server (or anonymous access when auth is disabled)
+        // may inspect/manage it, while partial or owned metadata remains
+        // tenant-scoped below. Start still requires its one-shot token before
+        // this state is assigned to an owner.
+        return trusted_owner_identity(identity, state).is_some()
+            || (!state.authentication_required() && !identity.is_authenticated());
+    }
     owner_access_allowed(
         state,
         identity,
@@ -7088,9 +8342,9 @@ fn owner_access_allowed(
     }
 
     let (Some(owner_user), Some(owner_org)) = (owner_user_id, owner_org_id) else {
-        // Legacy state without ownership metadata is deliberately not
-        // addressable through the authenticated HTTP surface. It remains
-        // available to local CLI/admin recovery paths.
+        // Partial ownership metadata is never trusted. The sandbox-specific
+        // caller handles the intentional fully-unowned CLI handoff case before
+        // reaching this generic owner comparison.
         return false;
     };
     let subject = quota_subject(state, identity);
@@ -8468,7 +9722,20 @@ async fn handle_audit_log(req: Request<Incoming>) -> Response<BoxBody> {
     }
 }
 
-async fn handle_gc(state: Arc<AppState>) -> Response<BoxBody> {
+async fn handle_gc(req: Request<Incoming>, state: Arc<AppState>) -> Response<BoxBody> {
+    #[cfg(feature = "enterprise")]
+    {
+        let identity = extract_identity(&req, &state).await;
+        if !identity.has_role("admin") {
+            return json_response(
+                StatusCode::FORBIDDEN,
+                &ApiResponse::<()>::error("Garbage collection requires an administrator identity"),
+            );
+        }
+    }
+    #[cfg(not(feature = "enterprise"))]
+    let _ = &req;
+
     let mut manager = match state.get_manager().await {
         Ok(m) => m,
         Err(e) => {
@@ -10723,6 +11990,22 @@ mod tests {
     use crate::durable_storage::DurableStorage;
     use std::sync::Arc;
 
+    fn start_test_sandbox(name: &str, uuid: &str) -> crate::vmm::SandboxState {
+        serde_json::from_value(serde_json::json!({
+            "name": name,
+            "uuid": uuid,
+            "image": "alpine:3.24",
+            "vcpus": 1,
+            "memory_mb": 512,
+            "vsock_cid": 3,
+            "created_at": "2026-01-01T00:00:00Z",
+            "backend": "Firecracker",
+            "owner_user_id": "persisted-owner",
+            "owner_org_id": "persisted-org"
+        }))
+        .unwrap()
+    }
+
     #[test]
     fn explicit_governance_config_parse_failure_is_not_silently_disabled() {
         let dir = tempfile::tempdir().unwrap();
@@ -10787,6 +12070,768 @@ mod tests {
         assert!(json.contains("\"success\":false"));
         assert!(!json.contains("\"data\"")); // data is skipped when None
         assert!(json.contains("\"error\":\"failed\""));
+    }
+
+    #[test]
+    fn persisted_start_configuration_preserves_permissions_and_binary_files() {
+        let temp = tempfile::tempdir().unwrap();
+        let sandbox = start_test_sandbox("configured", "019d0000-0000-7000-8000-000000000001");
+        let permissions = Permissions {
+            network: false,
+            mount_cwd: true,
+            mount_home: true,
+            pass_env: true,
+            allow_privileged: false,
+            read_only_root: true,
+            max_memory_mb: Some(2048),
+            max_cpu_percent: Some(75),
+            seccomp: Some("restrictive".to_string()),
+        };
+        let files = vec![FileInjection {
+            content: vec![0, 1, 2, 0xff],
+            dest: "/workspace/config.bin".to_string(),
+        }];
+
+        let request =
+            persist_start_configuration(temp.path(), &sandbox, &permissions, &files).unwrap();
+        let encoded = serde_json::to_vec(&request).unwrap();
+        let encoded_json: serde_json::Value = serde_json::from_slice(&encoded).unwrap();
+        assert_eq!(encoded_json["configuration"]["source"], "persisted");
+        assert_eq!(
+            encoded_json["configuration"]["token"]
+                .as_str()
+                .unwrap()
+                .len(),
+            64
+        );
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let token = encoded_json["configuration"]["token"].as_str().unwrap();
+            let mode =
+                std::fs::metadata(persisted_start_configuration_path(temp.path(), token).unwrap())
+                    .unwrap()
+                    .permissions()
+                    .mode()
+                    & 0o777;
+            assert_eq!(mode, 0o600);
+        }
+        assert!(!String::from_utf8_lossy(&encoded).contains("mount_home"));
+        assert!(!String::from_utf8_lossy(&encoded).contains("content_base64"));
+
+        let (decoded_permissions, decoded_files, state_sha256) =
+            parse_start_sandbox_request(&encoded)
+                .unwrap()
+                .into_runtime(
+                    temp.path(),
+                    &PersistedStartBinding::from_state(&sandbox),
+                    &local_start_request_owner_id(),
+                )
+                .unwrap();
+        assert!(decoded_permissions.mount_cwd);
+        assert!(decoded_permissions.mount_home);
+        assert!(!decoded_permissions.network);
+        assert_eq!(decoded_permissions.max_memory_mb, Some(2048));
+        assert_eq!(decoded_permissions.max_cpu_percent, Some(75));
+        assert_eq!(decoded_files.len(), 1);
+        assert_eq!(decoded_files[0].dest, "/workspace/config.bin");
+        assert_eq!(decoded_files[0].content, vec![0, 1, 2, 0xff]);
+        assert_eq!(state_sha256, Some(sandbox_state_sha256(&sandbox).unwrap()));
+
+        let replay = parse_start_sandbox_request(&encoded)
+            .unwrap()
+            .into_runtime(
+                temp.path(),
+                &PersistedStartBinding::from_state(&sandbox),
+                &local_start_request_owner_id(),
+            )
+            .unwrap_err();
+        assert!(format!("{replay:#}").contains("already consumed"));
+    }
+
+    #[test]
+    fn persisted_start_state_hash_is_stable_across_map_insertion_order() {
+        let mut first = start_test_sandbox("canonical-a", "canonical-uuid");
+        first.labels.clear();
+        first.labels.insert("alpha".to_string(), "1".to_string());
+        first.labels.insert("beta".to_string(), "2".to_string());
+
+        let mut second = first.clone();
+        second.labels.clear();
+        second.labels.insert("beta".to_string(), "2".to_string());
+        second.labels.insert("alpha".to_string(), "1".to_string());
+
+        assert_eq!(
+            sandbox_state_sha256(&first).unwrap(),
+            sandbox_state_sha256(&second).unwrap()
+        );
+    }
+
+    #[test]
+    fn empty_start_request_keeps_legacy_defaults() {
+        let temp = tempfile::tempdir().unwrap();
+        let sandbox = start_test_sandbox("legacy", "019d0000-0000-7000-8000-000000000002");
+        let (permissions, files, state_sha256) = parse_start_sandbox_request(&[])
+            .unwrap()
+            .into_runtime(
+                temp.path(),
+                &PersistedStartBinding::from_state(&sandbox),
+                "anonymous",
+            )
+            .unwrap();
+        let defaults = Permissions::default();
+
+        assert_eq!(permissions.network, defaults.network);
+        assert_eq!(permissions.mount_cwd, defaults.mount_cwd);
+        assert_eq!(permissions.mount_home, defaults.mount_home);
+        assert_eq!(permissions.read_only_root, defaults.read_only_root);
+        assert!(files.is_empty());
+        assert!(state_sha256.is_none());
+    }
+
+    #[test]
+    fn persisted_start_configuration_rejects_recreated_sandbox_and_is_consumed() {
+        let temp = tempfile::tempdir().unwrap();
+        let original = start_test_sandbox("reused", "019d0000-0000-7000-8000-000000000003");
+        let recreated = start_test_sandbox("reused", "019d0000-0000-7000-8000-000000000004");
+        let request =
+            persist_start_configuration(temp.path(), &original, &Permissions::default(), &[])
+                .unwrap();
+        let encoded = serde_json::to_vec(&request).unwrap();
+
+        let error = parse_start_sandbox_request(&encoded)
+            .unwrap()
+            .into_runtime(
+                temp.path(),
+                &PersistedStartBinding::from_state(&recreated),
+                &local_start_request_owner_id(),
+            )
+            .unwrap_err();
+        assert!(format!("{error:#}").contains("sandbox generation and owner"));
+
+        let replay = parse_start_sandbox_request(&encoded)
+            .unwrap()
+            .into_runtime(
+                temp.path(),
+                &PersistedStartBinding::from_state(&original),
+                &local_start_request_owner_id(),
+            )
+            .unwrap_err();
+        assert!(format!("{replay:#}").contains("already consumed"));
+    }
+
+    #[test]
+    fn persisted_start_configuration_is_bound_to_owner_and_request_identity() {
+        let temp = tempfile::tempdir().unwrap();
+        let sandbox = start_test_sandbox("owned", "019d0000-0000-7000-8000-000000000007");
+        let mut wrong_owner = sandbox.clone();
+        wrong_owner.owner_user_id = Some("other-owner".to_string());
+        let request =
+            persist_start_configuration(temp.path(), &sandbox, &Permissions::default(), &[])
+                .unwrap();
+
+        let error = request
+            .into_runtime(
+                temp.path(),
+                &PersistedStartBinding::from_state(&wrong_owner),
+                "different-request-owner",
+            )
+            .unwrap_err();
+        assert!(format!("{error:#}").contains("sandbox generation and owner"));
+    }
+
+    #[test]
+    fn newer_start_configuration_invalidates_stale_capabilities() {
+        let temp = tempfile::tempdir().unwrap();
+        let sandbox = start_test_sandbox("tightened", "019d0000-0000-7000-8000-000000000008");
+        let permissive = Permissions {
+            mount_home: true,
+            allow_privileged: true,
+            ..Permissions::default()
+        };
+        let stale = persist_start_configuration(temp.path(), &sandbox, &permissive, &[]).unwrap();
+
+        let restrictive = Permissions::default();
+        let current =
+            persist_start_configuration(temp.path(), &sandbox, &restrictive, &[]).unwrap();
+        let stale_error = stale
+            .into_runtime(
+                temp.path(),
+                &PersistedStartBinding::from_state(&sandbox),
+                &local_start_request_owner_id(),
+            )
+            .unwrap_err();
+        assert!(format!("{stale_error:#}").contains("already consumed"));
+
+        let (permissions, _, _) = current
+            .into_runtime(
+                temp.path(),
+                &PersistedStartBinding::from_state(&sandbox),
+                &local_start_request_owner_id(),
+            )
+            .unwrap();
+        assert!(!permissions.mount_home);
+        assert!(!permissions.allow_privileged);
+    }
+
+    #[test]
+    fn pending_start_configuration_is_scrubbed_on_remove() {
+        let temp = tempfile::tempdir().unwrap();
+        let sandbox = start_test_sandbox("remove-me", "019d0000-0000-7000-8000-000000000005");
+        let request =
+            persist_start_configuration(temp.path(), &sandbox, &Permissions::default(), &[])
+                .unwrap();
+        remove_persisted_start_configurations_for_sandbox(temp.path(), "remove-me").unwrap();
+
+        let error = request
+            .into_runtime(
+                temp.path(),
+                &PersistedStartBinding::from_state(&sandbox),
+                &local_start_request_owner_id(),
+            )
+            .unwrap_err();
+        assert!(format!("{error:#}").contains("already consumed"));
+    }
+
+    #[test]
+    fn public_start_request_rejects_caller_supplied_capabilities() {
+        let request = br#"{"permissions":{"allow_privileged":true,"mount_home":true}}"#;
+        let error = parse_start_sandbox_request(request).unwrap_err();
+        let message = format!("{error:#}");
+        assert!(message.contains("unknown field `permissions`"));
+    }
+
+    #[tokio::test]
+    async fn authenticated_start_caller_cannot_expand_host_capabilities() {
+        let state = Arc::new(AppState::with_api_keys(vec!["owner".to_string()]));
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server_state = state.clone();
+        let task = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let io = TokioIo::new(stream);
+            let service = service_fn(move |request| {
+                let state = server_state.clone();
+                handle_request(request, state)
+            });
+            http1::Builder::new()
+                .serve_connection(io, service)
+                .await
+                .unwrap();
+        });
+
+        let response = reqwest::Client::new()
+            .post(format!("http://{address}/sandboxes/demo/start"))
+            .bearer_auth("owner")
+            .json(&serde_json::json!({
+                "permissions": {
+                    "allow_privileged": true,
+                    "mount_home": true,
+                    "mount_cwd": true,
+                    "pass_env": true
+                }
+            }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = response.text().await.unwrap();
+        assert!(body.contains("unknown field `permissions`"), "{body}");
+        task.await.unwrap();
+    }
+
+    #[cfg(feature = "enterprise")]
+    #[tokio::test]
+    async fn router_allows_only_valid_token_to_claim_unowned_first_start() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut sandbox = start_test_sandbox("first-start", "first-start-uuid");
+        sandbox.tenant_id = None;
+        sandbox.owner_user_id = None;
+        sandbox.owner_org_id = None;
+        let token = "a".repeat(64);
+        let manifest = PersistedStartConfiguration::from_runtime(
+            &sandbox,
+            api_key_owner_id("owner"),
+            &Permissions::default(),
+            &[],
+        )
+        .unwrap();
+        crate::secure_fs::write_private_json(
+            &persisted_start_configuration_path(temp.path(), &token).unwrap(),
+            &manifest,
+        )
+        .unwrap();
+
+        let mut manager = VmManager::for_tests(temp.path()).unwrap();
+        manager.insert_state_for_tests(sandbox);
+        let manager = Arc::new(tokio::sync::RwLock::new(manager));
+        let state = AppState::with_api_keys(vec!["owner".to_string()]);
+        assert!(state.vm_manager.set(manager.clone()).is_ok());
+        *state.quota_controller.lock().await =
+            crate::quota::QuotaController::new(crate::config::ResourceQuotaConfig {
+                enabled: true,
+                default_limits: crate::config::ResourceQuotaLimits {
+                    max_running_sandboxes: Some(0),
+                    ..Default::default()
+                },
+                ..Default::default()
+            });
+        let state = Arc::new(state);
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server_state = state.clone();
+        let task = tokio::spawn(async move {
+            for _ in 0..2 {
+                let (stream, _) = listener.accept().await.unwrap();
+                let io = TokioIo::new(stream);
+                let state = server_state.clone();
+                let service = service_fn(move |request| {
+                    let state = state.clone();
+                    handle_request(request, state)
+                });
+                http1::Builder::new()
+                    .serve_connection(io, service)
+                    .await
+                    .unwrap();
+            }
+        });
+
+        let without_token = reqwest::Client::new()
+            .post(format!("http://{address}/sandboxes/first-start/start"))
+            .bearer_auth("owner")
+            .header("connection", "close")
+            .body("")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(without_token.status(), StatusCode::NOT_FOUND);
+
+        let with_token = reqwest::Client::new()
+            .post(format!("http://{address}/sandboxes/first-start/start"))
+            .bearer_auth("owner")
+            .header("connection", "close")
+            .json(&StartSandboxRequest {
+                configuration: Some(PersistedStartReference {
+                    source: StartConfigurationSource::Persisted,
+                    token,
+                }),
+            })
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(with_token.status(), StatusCode::TOO_MANY_REQUESTS);
+        task.await.unwrap();
+
+        let manager = manager.read().await;
+        let claimed = manager.get_state("first-start").unwrap();
+        let expected_owner = api_key_owner_id("owner");
+        assert_eq!(
+            claimed.owner_user_id.as_deref(),
+            Some(expected_owner.as_str())
+        );
+        assert_eq!(claimed.owner_org_id.as_deref(), Some("default"));
+    }
+
+    #[cfg(feature = "enterprise")]
+    #[tokio::test]
+    async fn delegated_start_refreshes_idle_state_and_enforces_manifest_hash() {
+        let temp = tempfile::tempdir().unwrap();
+        let owner_id = api_key_owner_id("owner");
+
+        let mut stale = start_test_sandbox("handoff-refresh", "handoff-refresh-uuid");
+        stale.owner_user_id = Some(owner_id.clone());
+        stale.owner_org_id = Some("default".to_string());
+        let mut final_state = stale.clone();
+        final_state.memory_mb = 2048;
+        final_state.work_dir = Some("/workspace/final".to_string());
+        let expected_hash = sandbox_state_sha256(&final_state).unwrap();
+        let valid_token = "b".repeat(64);
+        let valid_manifest = PersistedStartConfiguration::from_runtime(
+            &final_state,
+            owner_id.clone(),
+            &Permissions::default(),
+            &[],
+        )
+        .unwrap();
+        crate::secure_fs::write_private_json(
+            &persisted_start_configuration_path(temp.path(), &valid_token).unwrap(),
+            &valid_manifest,
+        )
+        .unwrap();
+
+        let mut stale_mismatch = start_test_sandbox("handoff-mismatch", "handoff-mismatch-uuid");
+        stale_mismatch.owner_user_id = Some(owner_id.clone());
+        stale_mismatch.owner_org_id = Some("default".to_string());
+        let expected_mismatch = stale_mismatch.clone();
+        let mismatch_token = "c".repeat(64);
+        let mismatch_manifest = PersistedStartConfiguration::from_runtime(
+            &expected_mismatch,
+            owner_id,
+            &Permissions::default(),
+            &[],
+        )
+        .unwrap();
+        crate::secure_fs::write_private_json(
+            &persisted_start_configuration_path(temp.path(), &mismatch_token).unwrap(),
+            &mismatch_manifest,
+        )
+        .unwrap();
+        let mut tampered_mismatch = expected_mismatch;
+        tampered_mismatch.memory_mb = 4096;
+
+        let mut manager = VmManager::for_tests(temp.path()).unwrap();
+        manager.insert_state_for_tests(stale);
+        manager.insert_state_for_tests(stale_mismatch);
+        std::fs::write(
+            temp.path().join("sandboxes/handoff-refresh.json"),
+            serde_json::to_vec_pretty(&final_state).unwrap(),
+        )
+        .unwrap();
+        std::fs::write(
+            temp.path().join("sandboxes/handoff-mismatch.json"),
+            serde_json::to_vec_pretty(&tampered_mismatch).unwrap(),
+        )
+        .unwrap();
+        let manager = Arc::new(tokio::sync::RwLock::new(manager));
+        let state = AppState::with_api_keys(vec!["owner".to_string()]);
+        assert!(state.vm_manager.set(manager.clone()).is_ok());
+        *state.quota_controller.lock().await =
+            crate::quota::QuotaController::new(crate::config::ResourceQuotaConfig {
+                enabled: true,
+                default_limits: crate::config::ResourceQuotaLimits {
+                    max_running_sandboxes: Some(0),
+                    ..Default::default()
+                },
+                ..Default::default()
+            });
+        let state = Arc::new(state);
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server_state = state.clone();
+        let task = tokio::spawn(async move {
+            for _ in 0..2 {
+                let (stream, _) = listener.accept().await.unwrap();
+                let io = TokioIo::new(stream);
+                let state = server_state.clone();
+                let service = service_fn(move |request| {
+                    let state = state.clone();
+                    handle_request(request, state)
+                });
+                http1::Builder::new()
+                    .serve_connection(io, service)
+                    .await
+                    .unwrap();
+            }
+        });
+
+        let valid = reqwest::Client::new()
+            .post(format!("http://{address}/sandboxes/handoff-refresh/start"))
+            .bearer_auth("owner")
+            .header("connection", "close")
+            .json(&StartSandboxRequest {
+                configuration: Some(PersistedStartReference {
+                    source: StartConfigurationSource::Persisted,
+                    token: valid_token,
+                }),
+            })
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(valid.status(), StatusCode::TOO_MANY_REQUESTS);
+
+        let mismatch = reqwest::Client::new()
+            .post(format!("http://{address}/sandboxes/handoff-mismatch/start"))
+            .bearer_auth("owner")
+            .header("connection", "close")
+            .json(&StartSandboxRequest {
+                configuration: Some(PersistedStartReference {
+                    source: StartConfigurationSource::Persisted,
+                    token: mismatch_token,
+                }),
+            })
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(mismatch.status(), StatusCode::CONFLICT);
+        assert!(
+            mismatch
+                .text()
+                .await
+                .unwrap()
+                .contains("changed after the start handoff")
+        );
+        task.await.unwrap();
+
+        let manager = manager.read().await;
+        let adopted = manager.get_state("handoff-refresh").unwrap();
+        assert_eq!(adopted.memory_mb, 2048);
+        assert_eq!(adopted.work_dir.as_deref(), Some("/workspace/final"));
+        assert_eq!(sandbox_state_sha256(adopted).unwrap(), expected_hash);
+    }
+
+    #[tokio::test]
+    async fn get_refreshes_cli_created_firecracker_state_for_authoritative_status() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut sandbox =
+            start_test_sandbox("cli-no-start", "019d0000-0000-7000-8000-000000000006");
+        sandbox.owner_user_id = Some("anonymous".to_string());
+        sandbox.owner_org_id = Some("default".to_string());
+        let manager = VmManager::for_tests(temp.path()).unwrap();
+        std::fs::write(
+            temp.path().join("sandboxes/cli-no-start.json"),
+            serde_json::to_vec_pretty(&sandbox).unwrap(),
+        )
+        .unwrap();
+        let state = AppState::with_api_keys(vec![]);
+        assert!(
+            state
+                .vm_manager
+                .set(Arc::new(tokio::sync::RwLock::new(manager)))
+                .is_ok()
+        );
+        let state = Arc::new(state);
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server_state = state.clone();
+        let task = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let io = TokioIo::new(stream);
+            let service = service_fn(move |request| {
+                let state = server_state.clone();
+                handle_request(request, state)
+            });
+            http1::Builder::new()
+                .serve_connection(io, service)
+                .await
+                .unwrap();
+        });
+
+        let response = reqwest::Client::new()
+            .get(format!("http://{address}/sandboxes/cli-no-start"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: serde_json::Value = response.json().await.unwrap();
+        assert_eq!(body["data"]["status"], "stopped");
+        assert_eq!(body["data"]["backend"], "firecracker");
+        task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn extend_ttl_route_updates_authoritative_manager_state() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut sandbox = start_test_sandbox("ttl-owner", "ttl-owner-uuid");
+        sandbox.owner_user_id = Some("anonymous".to_string());
+        sandbox.owner_org_id = Some("default".to_string());
+        let mut manager = VmManager::for_tests(temp.path()).unwrap();
+        manager.insert_state_for_tests(sandbox);
+        let manager = Arc::new(tokio::sync::RwLock::new(manager));
+        let state = AppState::with_api_keys(vec![]);
+        assert!(state.vm_manager.set(manager.clone()).is_ok());
+        let state = Arc::new(state);
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server_state = state.clone();
+        let task = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let io = TokioIo::new(stream);
+            let service = service_fn(move |request| {
+                let state = server_state.clone();
+                handle_request(request, state)
+            });
+            http1::Builder::new()
+                .serve_connection(io, service)
+                .await
+                .unwrap();
+        });
+
+        let response = reqwest::Client::new()
+            .post(format!("http://{address}/sandboxes/ttl-owner/extend"))
+            .json(&serde_json::json!({"by": "30m"}))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: serde_json::Value = response.json().await.unwrap();
+        let response_expiry = body["data"]["expires_at"].as_str().unwrap().to_string();
+        task.await.unwrap();
+
+        let manager = manager.read().await;
+        assert_eq!(
+            manager
+                .get_state("ttl-owner")
+                .and_then(|sandbox| sandbox.expires_at.as_deref()),
+            Some(response_expiry.as_str())
+        );
+    }
+
+    #[cfg(feature = "enterprise")]
+    #[tokio::test]
+    async fn disk_only_owned_delete_and_extend_deny_cross_tenant_mutation_after_refresh() {
+        let temp = tempfile::tempdir().unwrap();
+        let owner_id = api_key_owner_id("owner");
+        let mut delete_state = start_test_sandbox("disk-delete", "disk-delete-uuid");
+        delete_state.owner_user_id = Some(owner_id.clone());
+        delete_state.owner_org_id = Some("default".to_string());
+        let mut extend_state = start_test_sandbox("disk-extend", "disk-extend-uuid");
+        extend_state.owner_user_id = Some(owner_id);
+        extend_state.owner_org_id = Some("default".to_string());
+        extend_state.ttl_seconds = Some(600);
+        extend_state.expires_at = Some("2026-09-01T00:00:00Z".to_string());
+
+        let manager = VmManager::for_tests(temp.path()).unwrap();
+        let delete_path = temp.path().join("sandboxes/disk-delete.json");
+        let extend_path = temp.path().join("sandboxes/disk-extend.json");
+        std::fs::write(
+            &delete_path,
+            serde_json::to_vec_pretty(&delete_state).unwrap(),
+        )
+        .unwrap();
+        std::fs::write(
+            &extend_path,
+            serde_json::to_vec_pretty(&extend_state).unwrap(),
+        )
+        .unwrap();
+        let manager = Arc::new(tokio::sync::RwLock::new(manager));
+        let state = AppState::with_api_keys(vec!["owner".to_string(), "intruder".to_string()]);
+        assert!(state.vm_manager.set(manager.clone()).is_ok());
+        let state = Arc::new(state);
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server_state = state.clone();
+        let task = tokio::spawn(async move {
+            for _ in 0..2 {
+                let (stream, _) = listener.accept().await.unwrap();
+                let io = TokioIo::new(stream);
+                let state = server_state.clone();
+                let service = service_fn(move |request| {
+                    let state = state.clone();
+                    handle_request(request, state)
+                });
+                http1::Builder::new()
+                    .serve_connection(io, service)
+                    .await
+                    .unwrap();
+            }
+        });
+
+        let delete = reqwest::Client::new()
+            .delete(format!("http://{address}/sandboxes/disk-delete"))
+            .bearer_auth("intruder")
+            .header("connection", "close")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(delete.status(), StatusCode::NOT_FOUND);
+
+        let extend = reqwest::Client::new()
+            .post(format!("http://{address}/sandboxes/disk-extend/extend"))
+            .bearer_auth("intruder")
+            .header("connection", "close")
+            .json(&serde_json::json!({"by": "30m"}))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(extend.status(), StatusCode::NOT_FOUND);
+        task.await.unwrap();
+
+        assert!(delete_path.exists());
+        let persisted: crate::vmm::SandboxState =
+            serde_json::from_slice(&std::fs::read(extend_path).unwrap()).unwrap();
+        assert_eq!(persisted.expires_at, extend_state.expires_at);
+        let manager = manager.read().await;
+        assert!(manager.exists("disk-delete"));
+        assert_eq!(
+            manager
+                .get_state("disk-extend")
+                .and_then(|sandbox| sandbox.expires_at.as_deref()),
+            extend_state.expires_at.as_deref()
+        );
+    }
+
+    #[tokio::test]
+    async fn sandbox_lifecycle_error_preserves_context_and_recovery_path() {
+        let error = anyhow::anyhow!("Sandbox 'demo' is not paused").context(
+            "checkpoint restore failed; recovery artifacts retained at /tmp/agentkernel-recovery",
+        );
+        let response = sandbox_lifecycle_error("resume", error);
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let message = body["error"].as_str().unwrap();
+        assert!(message.contains("checkpoint restore failed"));
+        assert!(message.contains("/tmp/agentkernel-recovery"));
+        assert!(message.contains("Sandbox 'demo' is not paused"));
+    }
+
+    #[tokio::test]
+    async fn server_owned_lifecycle_task_survives_http_waiter_cancellation() {
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+        let (completed_tx, completed_rx) = tokio::sync::oneshot::channel::<()>();
+        let lifecycle_task = tokio::spawn(async move {
+            let _ = release_rx.await;
+            let _ = completed_tx.send(());
+            json_response(StatusCode::OK, &ApiResponse::success("completed"))
+        });
+        let waiter = tokio::spawn(await_server_owned_lifecycle("pause", lifecycle_task));
+        tokio::task::yield_now().await;
+        waiter.abort();
+
+        release_tx.send(()).unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(1), completed_rx)
+            .await
+            .expect("detached lifecycle task should keep running")
+            .unwrap();
+    }
+
+    #[cfg(feature = "enterprise")]
+    #[test]
+    fn full_state_http_policy_requires_run_for_runtime_transitions() {
+        assert_eq!(FULL_STATE_RUNTIME_POLICY_ACTION, crate::policy::Action::Run);
+        assert_eq!(FORK_SOURCE_POLICY_ACTION, crate::policy::Action::Run);
+        assert_eq!(
+            FORK_CHILD_POLICY_ACTIONS,
+            [crate::policy::Action::Create, crate::policy::Action::Run]
+        );
+    }
+
+    #[cfg(feature = "enterprise")]
+    #[tokio::test]
+    async fn non_admin_cannot_trigger_fleet_gc_or_lifecycle_reconcile() {
+        let state = Arc::new(AppState::with_api_keys(vec!["owner".to_string()]));
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server_state = state.clone();
+        let task = tokio::spawn(async move {
+            for _ in 0..2 {
+                let (stream, _) = listener.accept().await.unwrap();
+                let io = TokioIo::new(stream);
+                let state = server_state.clone();
+                let service = service_fn(move |request| {
+                    let state = state.clone();
+                    handle_request(request, state)
+                });
+                http1::Builder::new()
+                    .serve_connection(io, service)
+                    .await
+                    .unwrap();
+            }
+        });
+
+        for path in ["gc", "lifecycle/reconcile"] {
+            let response = reqwest::Client::new()
+                .post(format!("http://{address}/{path}"))
+                .bearer_auth("owner")
+                .header("connection", "close")
+                .json(&serde_json::json!({"dry_run": true}))
+                .send()
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::FORBIDDEN, "{path}");
+        }
+        task.await.unwrap();
     }
 
     #[test]
@@ -10912,6 +12957,17 @@ init_script = "echo ready"
         assert_eq!(req.name, "my-sandbox");
         assert!(req.image.is_none());
         assert!(req.volumes.is_empty());
+    }
+
+    #[test]
+    fn test_fork_sandbox_request_contract() {
+        let request: ForkSandboxRequest =
+            serde_json::from_str(r#"{"as_name":"experiment-b"}"#).unwrap();
+        assert_eq!(request.as_name, "experiment-b");
+
+        let unknown_field =
+            serde_json::from_str::<ForkSandboxRequest>(r#"{"as_name":"child","start":true}"#);
+        assert!(unknown_field.is_err());
     }
 
     #[test]
@@ -11116,6 +13172,99 @@ init_script = "echo ready"
         assert!(json.contains("\"status\":\"running\""));
     }
 
+    #[test]
+    fn test_fork_sandbox_result_includes_clone_security_warning() {
+        let result = ForkSandboxResult {
+            sandbox: SandboxInfo {
+                name: "experiment-b".to_string(),
+                uuid: uuid::Uuid::now_v7().to_string(),
+                status: "running".to_string(),
+                backend: "firecracker".to_string(),
+                ip: None,
+                image: Some("alpine:3.24".to_string()),
+                vcpus: Some(1),
+                memory_mb: Some(512),
+                created_at: None,
+                created_from_template: None,
+                template_help_text: None,
+                ports: vec![],
+                endpoints: vec![],
+                secret_files: vec![],
+                placeholder_secrets: false,
+                proxy_port: None,
+                secret_mappings: std::collections::HashMap::new(),
+                labels: std::collections::HashMap::new(),
+                description: None,
+                last_activity_at: None,
+                workspace_revision: None,
+                archived_at: None,
+                archived_reason: None,
+                lifecycle: None,
+            },
+            security_warning: crate::full_state::FORK_SECURITY_WARNING.to_string(),
+        };
+
+        let json = serde_json::to_value(result).unwrap();
+        assert_eq!(json["sandbox"]["status"], "running");
+        assert!(
+            json["security_warning"]
+                .as_str()
+                .unwrap()
+                .contains("cryptographic tokens")
+        );
+    }
+
+    #[tokio::test]
+    async fn pause_route_rejects_non_firecracker_backend() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut manager = VmManager::for_tests(temp.path()).unwrap();
+        let sandbox: crate::vmm::SandboxState = serde_json::from_value(serde_json::json!({
+            "name": "docker-source",
+            "uuid": uuid::Uuid::now_v7().to_string(),
+            "image": "alpine:3.24",
+            "vcpus": 1,
+            "memory_mb": 512,
+            "vsock_cid": 3,
+            "created_at": "2026-01-01T00:00:00Z",
+            "backend": "Docker",
+            "owner_user_id": "anonymous",
+            "owner_org_id": "default"
+        }))
+        .unwrap();
+        manager.insert_state_for_tests(sandbox);
+
+        let state = Arc::new(AppState::with_api_keys(vec![]));
+        let manager = Arc::new(tokio::sync::RwLock::new(manager));
+        assert!(state.vm_manager.set(manager.clone()).is_ok());
+        assert!(manager.read().await.exists("docker-source"));
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server_state = state.clone();
+        let task = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let io = TokioIo::new(stream);
+            let service = service_fn(move |request| {
+                let state = server_state.clone();
+                handle_request(request, state)
+            });
+            http1::Builder::new()
+                .serve_connection(io, service)
+                .await
+                .unwrap();
+        });
+
+        let response = reqwest::Client::new()
+            .post(format!("http://{address}/sandboxes/docker-source/pause"))
+            .send()
+            .await
+            .unwrap();
+        let status = response.status();
+        let body = response.text().await.unwrap();
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY, "{body}");
+        assert!(body.contains("Firecracker"));
+        task.await.unwrap();
+    }
+
     // === RunResponse tests ===
 
     #[test]
@@ -11139,6 +13288,41 @@ init_script = "echo ready"
     fn test_app_state_without_api_key() {
         let state = AppState::with_api_keys(vec![]);
         assert!(state.api_keys.is_empty());
+    }
+
+    #[cfg(feature = "enterprise")]
+    #[tokio::test]
+    async fn jwks_only_configuration_is_enforced_by_global_auth_gate() {
+        let mut state = AppState::with_api_keys(vec![]);
+        state.enterprise_config = Some(crate::config::EnterpriseConfig {
+            jwks_url: Some("http://127.0.0.1:9/.well-known/jwks.json".to_string()),
+            ..Default::default()
+        });
+        let state = Arc::new(state);
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server_state = state.clone();
+        let task = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let io = TokioIo::new(stream);
+            let service = service_fn(move |request| {
+                let state = server_state.clone();
+                handle_request(request, state)
+            });
+            http1::Builder::new()
+                .serve_connection(io, service)
+                .await
+                .unwrap();
+        });
+
+        let response = reqwest::Client::new()
+            .get(format!("http://{address}/sandboxes"))
+            .header("connection", "close")
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        task.await.unwrap();
     }
 
     #[cfg(feature = "enterprise")]
@@ -11352,6 +13536,192 @@ max_total_sandboxes = 0
             iat: None,
         });
         assert!(sandbox_access_allowed(&state, &admin, &sandbox));
+    }
+
+    #[cfg(feature = "enterprise")]
+    #[test]
+    fn trusted_local_principal_can_manage_unowned_no_start_state() {
+        let mut sandbox = start_test_sandbox("unowned", "unowned-uuid");
+        sandbox.owner_user_id = None;
+        sandbox.owner_org_id = None;
+
+        let open_state = AppState::with_api_keys(vec![]);
+        assert!(sandbox_access_allowed(
+            &open_state,
+            &crate::identity::AgentIdentity::anonymous(),
+            &sandbox
+        ));
+
+        let authenticated_state = AppState::with_api_keys(vec!["owner".to_string()]);
+        assert!(sandbox_access_allowed(
+            &authenticated_state,
+            &crate::identity::AgentIdentity::from_api_key("owner".to_string()),
+            &sandbox
+        ));
+        assert!(!sandbox_access_allowed(
+            &authenticated_state,
+            &crate::identity::AgentIdentity::anonymous(),
+            &sandbox
+        ));
+    }
+
+    #[cfg(feature = "enterprise")]
+    #[test]
+    fn valid_start_token_claims_unowned_sandbox_after_prior_refresh_without_overwrite() {
+        fn sandbox(name: &str) -> crate::vmm::SandboxState {
+            serde_json::from_value(serde_json::json!({
+                "name": name,
+                "uuid": format!("{name}-uuid"),
+                "image": "alpine:3.24",
+                "vcpus": 1,
+                "memory_mb": 512,
+                "vsock_cid": 3,
+                "created_at": "2026-01-01T00:00:00Z",
+                "backend": "Firecracker"
+            }))
+            .unwrap()
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let cli_state = sandbox("cli-created");
+        let request =
+            persist_start_configuration(dir.path(), &cli_state, &Permissions::default(), &[])
+                .unwrap();
+        let mut manager = VmManager::for_tests(dir.path()).unwrap();
+        manager.insert_state_for_tests(cli_state);
+        let state = AppState::with_api_keys(vec![]);
+        let anonymous = crate::identity::AgentIdentity::anonymous();
+
+        // A prior GET may already have refreshed this state, so claim cannot
+        // depend on the refresh result of the later start request.
+        assert!(!manager.refresh_sandbox_if_missing("cli-created").unwrap());
+        let binding = PersistedStartBinding::from_state(manager.get_state("cli-created").unwrap());
+        let token_authorizes_first_claim = request.configuration.is_some();
+        request
+            .into_runtime(dir.path(), &binding, &local_start_request_owner_id())
+            .unwrap();
+        claim_unowned_start_sandbox(
+            &mut manager,
+            "cli-created",
+            token_authorizes_first_claim,
+            &anonymous,
+            &state,
+        )
+        .unwrap();
+        let claimed = manager.get_state("cli-created").unwrap();
+        assert_eq!(claimed.owner_user_id.as_deref(), Some("anonymous"));
+        assert_eq!(claimed.owner_org_id.as_deref(), Some("default"));
+
+        manager
+            .set_owner_metadata("cli-created", Some("existing-user"), Some("existing-org"))
+            .unwrap();
+        claim_unowned_start_sandbox(&mut manager, "cli-created", true, &anonymous, &state).unwrap();
+        let preserved = manager.get_state("cli-created").unwrap();
+        assert_eq!(preserved.owner_user_id.as_deref(), Some("existing-user"));
+        assert_eq!(preserved.owner_org_id.as_deref(), Some("existing-org"));
+    }
+
+    #[cfg(feature = "enterprise")]
+    #[test]
+    fn unowned_sandbox_cannot_be_claimed_without_valid_start_token() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut sandbox = start_test_sandbox("unclaimed", "unclaimed-uuid");
+        sandbox.owner_user_id = None;
+        sandbox.owner_org_id = None;
+        let mut manager = VmManager::for_tests(dir.path()).unwrap();
+        manager.insert_state_for_tests(sandbox);
+        let state = AppState::with_api_keys(vec![]);
+        let anonymous = crate::identity::AgentIdentity::anonymous();
+
+        let response =
+            claim_unowned_start_sandbox(&mut manager, "unclaimed", false, &anonymous, &state)
+                .unwrap_err();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        let unclaimed = manager.get_state("unclaimed").unwrap();
+        assert_eq!(unclaimed.owner_user_id, None);
+        assert_eq!(unclaimed.owner_org_id, None);
+    }
+
+    #[test]
+    fn fork_identity_must_match_atomically_cloned_source_owner() {
+        let mut source = start_test_sandbox("source", "source-uuid");
+        source.tenant_id = Some("tenant-a".to_string());
+
+        assert!(fork_identity_matches_source(
+            &source,
+            Some("tenant-a"),
+            Some("persisted-owner"),
+            Some("persisted-org"),
+        ));
+        assert!(!fork_identity_matches_source(
+            &source,
+            Some("tenant-b"),
+            Some("persisted-owner"),
+            Some("persisted-org"),
+        ));
+        assert!(!fork_identity_matches_source(
+            &source,
+            Some("tenant-a"),
+            Some("other-owner"),
+            Some("persisted-org"),
+        ));
+    }
+
+    #[cfg(not(feature = "enterprise"))]
+    #[test]
+    fn configured_api_key_start_claim_allows_cli_origin_fork() {
+        let mut source = start_test_sandbox("api-key-source", "api-key-source-uuid");
+        source.tenant_id = None;
+        source.owner_user_id = None;
+        source.owner_org_id = None;
+        let dir = tempfile::tempdir().unwrap();
+        let mut manager = VmManager::for_tests(dir.path()).unwrap();
+        manager.insert_state_for_tests(source);
+        let trusted_owner = ("local".to_string(), api_key_owner_id("owner"));
+
+        claim_unowned_local_start_sandbox(
+            &mut manager,
+            "api-key-source",
+            true,
+            Some(&trusted_owner),
+        )
+        .unwrap();
+        let source = manager.get_state("api-key-source").unwrap();
+        assert!(fork_identity_matches_source(
+            source,
+            None,
+            Some(trusted_owner.1.as_str()),
+            Some(trusted_owner.0.as_str()),
+        ));
+    }
+
+    #[cfg(feature = "enterprise")]
+    #[test]
+    fn configured_org_start_claim_allows_cli_origin_fork() {
+        let mut source = start_test_sandbox("org-source", "org-source-uuid");
+        source.tenant_id = None;
+        source.owner_user_id = None;
+        source.owner_org_id = None;
+        let dir = tempfile::tempdir().unwrap();
+        let mut manager = VmManager::for_tests(dir.path()).unwrap();
+        manager.insert_state_for_tests(source);
+        let mut state = AppState::with_api_keys(vec!["owner".to_string()]);
+        state.enterprise_config = Some(crate::config::EnterpriseConfig {
+            enabled: true,
+            org_id: Some("acme".to_string()),
+            ..Default::default()
+        });
+        let identity = crate::identity::AgentIdentity::from_api_key("owner".to_string());
+
+        claim_unowned_start_sandbox(&mut manager, "org-source", true, &identity, &state).unwrap();
+        let subject = quota_subject(&state, &identity);
+        let source = manager.get_state("org-source").unwrap();
+        assert!(fork_identity_matches_source(
+            source,
+            Some("acme"),
+            Some(subject.user_id.as_str()),
+            Some(subject.org_id.as_str()),
+        ));
     }
 
     #[cfg(feature = "enterprise")]

--- a/src/identity/mod.rs
+++ b/src/identity/mod.rs
@@ -203,7 +203,10 @@ pub async fn validate_jwt(token: &str, jwks_url: &str) -> Result<JwtClaims> {
         .context("JWT header missing 'kid' field")?;
 
     // Fetch JWKS from the endpoint
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(5))
+        .build()
+        .context("Failed to build JWKS client")?;
     let jwks: JwksResponse = client
         .get(jwks_url)
         .send()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod cow;
 pub mod docker_backend;
 pub mod durable_storage;
 pub mod firecracker_client;
+pub mod full_state;
 pub mod hyperlight_backend;
 pub mod interactive_permissions;
 pub mod languages;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6474,9 +6474,10 @@ mod tests {
             let cli =
                 Cli::try_parse_from(["agentkernel", "sandbox", command, "paused-sandbox"]).unwrap();
             match cli.command {
-                Commands::Sandbox {
-                    action: SandboxAction::Pause { name },
-                } => assert_eq!(name, "paused-sandbox"),
+                Commands::Sandbox { action } => match *action {
+                    SandboxAction::Pause { name } => assert_eq!(name, "paused-sandbox"),
+                    _ => panic!("expected sandbox pause for {command}"),
+                },
                 _ => panic!("expected sandbox pause for {command}"),
             }
         }
@@ -6487,9 +6488,10 @@ mod tests {
         let resume =
             Cli::try_parse_from(["agentkernel", "sandbox", "resume", "paused-sandbox"]).unwrap();
         match resume.command {
-            Commands::Sandbox {
-                action: SandboxAction::Resume { name },
-            } => assert_eq!(name, "paused-sandbox"),
+            Commands::Sandbox { action } => match *action {
+                SandboxAction::Resume { name } => assert_eq!(name, "paused-sandbox"),
+                _ => panic!("expected sandbox resume"),
+            },
             _ => panic!("expected sandbox resume"),
         }
 
@@ -6503,16 +6505,16 @@ mod tests {
         ])
         .unwrap();
         match fork.command {
-            Commands::Sandbox {
-                action:
-                    SandboxAction::Fork {
-                        source,
-                        r#as: child,
-                    },
-            } => {
-                assert_eq!(source, "paused-sandbox");
-                assert_eq!(child, "candidate-a");
-            }
+            Commands::Sandbox { action } => match *action {
+                SandboxAction::Fork {
+                    source,
+                    r#as: child,
+                } => {
+                    assert_eq!(source, "paused-sandbox");
+                    assert_eq!(child, "candidate-a");
+                }
+                _ => panic!("expected sandbox fork"),
+            },
             _ => panic!("expected sandbox fork"),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ mod docker_backend;
 mod durable_storage;
 mod events;
 mod firecracker_client;
+mod full_state;
 mod git_utils;
 mod git_worktree;
 mod http_api;
@@ -573,6 +574,25 @@ enum SandboxAction {
         /// Name of the sandbox to stop
         name: String,
     },
+    /// Pause a running Firecracker sandbox while preserving guest memory and processes
+    #[command(visible_alias = "suspend")]
+    Pause {
+        /// Name of the sandbox to pause
+        name: String,
+    },
+    /// Resume a paused Firecracker sandbox
+    Resume {
+        /// Name of the sandbox to resume
+        name: String,
+    },
+    /// Fork a paused Firecracker sandbox into a new running sandbox
+    Fork {
+        /// Name of the paused source sandbox
+        source: String,
+        /// Name for the forked sandbox
+        #[arg(long, value_name = "NAME")]
+        r#as: String,
+    },
     /// Remove a sandbox
     Remove {
         /// Name of the sandbox to remove
@@ -1096,8 +1116,8 @@ memory_mb = 512
             println!("Created agentkernel.toml for sandbox '{}'", sandbox_name);
             println!("\nNext steps:");
             println!("  agentkernel create {} --dir .", sandbox_name);
-            println!("  agentkernel start {}", sandbox_name);
-            println!("  agentkernel attach {}", sandbox_name);
+            println!("  agentkernel sandbox start {}", sandbox_name);
+            println!("  agentkernel exec {} -- <command>", sandbox_name);
         }
         Commands::Sandbox { action } => match *action {
             SandboxAction::Create {
@@ -1316,6 +1336,12 @@ memory_mb = 512
                 };
 
                 let mut manager = VmManager::with_backend(backend_type)?;
+                if manager.backend() == crate::backend::BackendType::Firecracker {
+                    let api_port = local_api_port();
+                    if !try_server_health("127.0.0.1", api_port).await {
+                        return Err(firecracker_server_required("create", api_port));
+                    }
+                }
 
                 if managed_network.is_some()
                     && !matches!(
@@ -1575,24 +1601,51 @@ memory_mb = 512
                     println!("  TTL: {} (expires automatically)", format_ttl(secs));
                 }
 
+                let effective_backend = manager
+                    .get_state(&name)
+                    .and_then(|state| state.backend)
+                    .unwrap_or(manager.backend());
+                let firecracker = effective_backend == crate::backend::BackendType::Firecracker;
+
                 // Auto-start the sandbox unless --no-start was passed
                 if !no_start {
                     let has_secrets = !all_bindings.is_empty();
-                    let api_port = std::env::var("AGENTKERNEL_PORT")
-                        .ok()
-                        .and_then(|p| p.parse::<u16>().ok())
-                        .unwrap_or(18888);
+                    let api_port = local_api_port();
                     let server_running = try_server_health("127.0.0.1", api_port).await;
 
-                    if has_secrets && server_running {
+                    if firecracker {
+                        if !server_running {
+                            return Err(firecracker_server_required("start", api_port));
+                        }
+                        println!(
+                            "Starting Firecracker sandbox via API server (VM ownership will persist)..."
+                        );
+                        delegate_configured_start_to_server(
+                            "127.0.0.1",
+                            api_port,
+                            &name,
+                            &manager,
+                            &start_perms,
+                            &start_files,
+                        )
+                        .await?;
+                    } else if has_secrets && server_running {
                         // Delegate to HTTP server so the secrets proxy
                         // lives in the long-running server process
                         println!("Starting sandbox via API server (secrets proxy will persist)...");
-                        delegate_start_to_server("127.0.0.1", api_port, &name).await?;
+                        delegate_configured_start_to_server(
+                            "127.0.0.1",
+                            api_port,
+                            &name,
+                            &manager,
+                            &start_perms,
+                            &start_files,
+                        )
+                        .await?;
                     } else if has_secrets && !server_running {
                         eprintln!(
                             "Warning: Secrets proxy requires 'agentkernel serve' to be running.\n\
-                             Start the server first, then run: agentkernel start {}",
+                             Start the server first, then run: agentkernel sandbox start {}",
                             name
                         );
                     } else {
@@ -1621,7 +1674,18 @@ memory_mb = 512
                                 "-c".to_string(),
                                 "which git >/dev/null 2>&1 || apk add --no-cache git >/dev/null 2>&1 || apt-get update -qq && apt-get install -y -qq git >/dev/null 2>&1 || yum install -y git >/dev/null 2>&1 || true".to_string(),
                             ];
-                            let _ = manager.exec_cmd(&name, &install_cmd).await;
+                            if firecracker {
+                                let _ = delegate_sandbox_action_to_server(
+                                    "127.0.0.1",
+                                    api_port,
+                                    &name,
+                                    "exec",
+                                    Some(serde_json::json!({"command": install_cmd})),
+                                )
+                                .await;
+                            } else {
+                                let _ = manager.exec_cmd(&name, &install_cmd).await;
+                            }
 
                             let clone_cmd = vec![
                                 "git".to_string(),
@@ -1629,7 +1693,18 @@ memory_mb = 512
                                 url.to_string(),
                                 "/workspace".to_string(),
                             ];
-                            manager.exec_cmd(&name, &clone_cmd).await?;
+                            if firecracker {
+                                delegate_sandbox_action_to_server(
+                                    "127.0.0.1",
+                                    api_port,
+                                    &name,
+                                    "exec",
+                                    Some(serde_json::json!({"command": clone_cmd})),
+                                )
+                                .await?;
+                            } else {
+                                manager.exec_cmd(&name, &clone_cmd).await?;
+                            }
 
                             if let Some(ref git_ref_val) = git_ref {
                                 let checkout_cmd = vec![
@@ -1639,7 +1714,18 @@ memory_mb = 512
                                     "checkout".to_string(),
                                     git_ref_val.clone(),
                                 ];
-                                manager.exec_cmd(&name, &checkout_cmd).await?;
+                                if firecracker {
+                                    delegate_sandbox_action_to_server(
+                                        "127.0.0.1",
+                                        api_port,
+                                        &name,
+                                        "exec",
+                                        Some(serde_json::json!({"command": checkout_cmd})),
+                                    )
+                                    .await?;
+                                } else {
+                                    manager.exec_cmd(&name, &checkout_cmd).await?;
+                                }
                                 println!("Cloned {} (ref: {}) into /workspace", url, git_ref_val);
                             } else {
                                 println!("Cloned {} into /workspace", url);
@@ -1651,21 +1737,19 @@ memory_mb = 512
                     if !has_secrets || server_running {
                         println!("\nSandbox '{}' started.", name);
                         println!("To connect:");
-                        if enable_ssh {
-                            println!("  agentkernel ssh {}", name);
-                        } else {
-                            println!("  agentkernel attach {}", name);
-                        }
+                        println!(
+                            "  {}",
+                            sandbox_connection_command(&name, firecracker, enable_ssh)
+                        );
                     }
                 } else {
                     // --no-start: show manual next steps
                     println!("\nNext steps:");
-                    println!("  1. agentkernel start {}", name);
-                    if enable_ssh {
-                        println!("  2. agentkernel ssh {}", name);
-                    } else {
-                        println!("  2. agentkernel attach {}", name);
-                    }
+                    println!("  1. agentkernel sandbox start {}", name);
+                    println!(
+                        "  2. {}",
+                        sandbox_connection_command(&name, firecracker, enable_ssh)
+                    );
                 }
             }
             SandboxAction::Start { name, backend } => {
@@ -1701,39 +1785,6 @@ memory_mb = 512
                     );
                 }
 
-                // Check if sandbox has secret bindings that need a long-lived proxy
-                let has_secrets = manager
-                    .get_sandbox_state(&name)
-                    .is_some_and(|s| !s.secret_bindings.is_empty());
-
-                if has_secrets {
-                    let api_port = std::env::var("AGENTKERNEL_PORT")
-                        .ok()
-                        .and_then(|p| p.parse::<u16>().ok())
-                        .unwrap_or(18888);
-                    let server_running = try_server_health("127.0.0.1", api_port).await;
-                    if server_running {
-                        println!("Starting sandbox via API server (secrets proxy will persist)...");
-                        delegate_start_to_server("127.0.0.1", api_port, &name).await?;
-                        println!("Sandbox '{}' started.", name);
-                        if manager
-                            .get_sandbox_state(&name)
-                            .is_some_and(|s| s.ssh_enabled)
-                        {
-                            println!("\nTo connect: agentkernel ssh {}", name);
-                        } else {
-                            println!("\nTo attach: agentkernel attach {}", name);
-                        }
-                        return Ok(());
-                    } else {
-                        eprintln!(
-                            "Warning: Sandbox has secrets configured but 'agentkernel serve' is not running.\n\
-                             The secrets proxy will stop when this command exits.\n\
-                             For persistent proxy, start 'agentkernel serve' first."
-                        );
-                    }
-                }
-
                 let sandbox_config_path = manager
                     .get_state(&name)
                     .and_then(|state| state.config_path.clone())
@@ -1761,6 +1812,72 @@ memory_mb = 512
                     (crate::permissions::Permissions::default(), Vec::new())
                 };
 
+                if effective_backend == crate::backend::BackendType::Firecracker {
+                    let api_port = local_api_port();
+                    if !try_server_health("127.0.0.1", api_port).await {
+                        return Err(firecracker_server_required("start", api_port));
+                    }
+                    println!(
+                        "Starting Firecracker sandbox via API server (VM ownership will persist)..."
+                    );
+                    delegate_configured_start_to_server(
+                        "127.0.0.1",
+                        api_port,
+                        &name,
+                        &manager,
+                        &start_perms,
+                        &start_files,
+                    )
+                    .await?;
+                    println!("Sandbox '{}' started.", name);
+                    let ssh_enabled = manager
+                        .get_sandbox_state(&name)
+                        .is_some_and(|state| state.ssh_enabled);
+                    println!(
+                        "\nTo connect: {}",
+                        sandbox_connection_command(&name, true, ssh_enabled)
+                    );
+                    return Ok(());
+                }
+
+                // Check if sandbox has secret bindings that need a long-lived proxy
+                let has_secrets = manager
+                    .get_sandbox_state(&name)
+                    .is_some_and(|s| !s.secret_bindings.is_empty());
+
+                if has_secrets {
+                    let api_port = local_api_port();
+                    let server_running = try_server_health("127.0.0.1", api_port).await;
+                    if server_running {
+                        println!("Starting sandbox via API server (secrets proxy will persist)...");
+                        delegate_configured_start_to_server(
+                            "127.0.0.1",
+                            api_port,
+                            &name,
+                            &manager,
+                            &start_perms,
+                            &start_files,
+                        )
+                        .await?;
+                        println!("Sandbox '{}' started.", name);
+                        if manager
+                            .get_sandbox_state(&name)
+                            .is_some_and(|s| s.ssh_enabled)
+                        {
+                            println!("\nTo connect: agentkernel ssh {}", name);
+                        } else {
+                            println!("\nTo attach: agentkernel attach {}", name);
+                        }
+                        return Ok(());
+                    } else {
+                        eprintln!(
+                            "Warning: Sandbox has secrets configured but 'agentkernel serve' is not running.\n\
+                             The secrets proxy will stop when this command exits.\n\
+                             For persistent proxy, start 'agentkernel serve' first."
+                        );
+                    }
+                }
+
                 println!("Starting sandbox '{}'...", name);
                 manager
                     .start_with_permissions_and_files(&name, &start_perms, &start_files)
@@ -1785,15 +1902,130 @@ memory_mb = 512
                 }
 
                 println!("Stopping sandbox '{}'...", name);
-                manager.stop(&name).await?;
+                let backend = manager
+                    .get_state(&name)
+                    .and_then(|state| state.backend)
+                    .unwrap_or(manager.backend());
+                if backend == crate::backend::BackendType::Firecracker {
+                    let api_port = local_api_port();
+                    if !try_server_health("127.0.0.1", api_port).await {
+                        return Err(firecracker_server_required("stop", api_port));
+                    }
+                    delegate_sandbox_action_to_server("127.0.0.1", api_port, &name, "stop", None)
+                        .await?;
+                } else {
+                    manager.stop(&name).await?;
+                }
                 println!("Sandbox '{}' stopped.", name);
+            }
+            SandboxAction::Pause { name } => {
+                validation::validate_sandbox_name(&name)?;
+
+                let mut manager = VmManager::new()?;
+                if !manager.exists(&name) {
+                    bail!("Sandbox '{}' not found", name);
+                }
+
+                println!("Pausing sandbox '{}'...", name);
+                let backend = manager
+                    .get_state(&name)
+                    .and_then(|state| state.backend)
+                    .unwrap_or(manager.backend());
+                if backend == crate::backend::BackendType::Firecracker {
+                    let api_port = local_api_port();
+                    if !try_server_health("127.0.0.1", api_port).await {
+                        return Err(firecracker_server_required("pause", api_port));
+                    }
+                    delegate_sandbox_action_to_server("127.0.0.1", api_port, &name, "pause", None)
+                        .await?;
+                } else {
+                    manager.pause(&name).await?;
+                }
+                println!("Sandbox '{}' paused.", name);
+                println!("Resume it with: agentkernel sandbox resume {}", name);
+            }
+            SandboxAction::Resume { name } => {
+                validation::validate_sandbox_name(&name)?;
+
+                let mut manager = VmManager::new()?;
+                if !manager.exists(&name) {
+                    bail!("Sandbox '{}' not found", name);
+                }
+
+                println!("Resuming sandbox '{}'...", name);
+                let backend = manager
+                    .get_state(&name)
+                    .and_then(|state| state.backend)
+                    .unwrap_or(manager.backend());
+                if backend == crate::backend::BackendType::Firecracker {
+                    let api_port = local_api_port();
+                    if !try_server_health("127.0.0.1", api_port).await {
+                        return Err(firecracker_server_required("resume", api_port));
+                    }
+                    delegate_sandbox_action_to_server("127.0.0.1", api_port, &name, "resume", None)
+                        .await?;
+                } else {
+                    manager.resume(&name).await?;
+                }
+                println!("Sandbox '{}' resumed.", name);
+                let ssh_enabled = manager
+                    .get_sandbox_state(&name)
+                    .is_some_and(|state| state.ssh_enabled);
+                println!(
+                    "\nTo connect: {}",
+                    sandbox_connection_command(
+                        &name,
+                        backend == crate::backend::BackendType::Firecracker,
+                        ssh_enabled,
+                    )
+                );
+            }
+            SandboxAction::Fork {
+                source,
+                r#as: child,
+            } => {
+                validation::validate_sandbox_name(&source)?;
+                validation::validate_sandbox_name(&child)?;
+
+                let mut manager = VmManager::new()?;
+                if !manager.exists(&source) {
+                    bail!("Sandbox '{}' not found", source);
+                }
+                if manager.exists(&child) {
+                    bail!("Sandbox '{}' already exists", child);
+                }
+
+                println!("Forking paused sandbox '{}' as '{}'...", source, child);
+                let backend = manager
+                    .get_state(&source)
+                    .and_then(|state| state.backend)
+                    .unwrap_or(manager.backend());
+                if backend == crate::backend::BackendType::Firecracker {
+                    let api_port = local_api_port();
+                    if !try_server_health("127.0.0.1", api_port).await {
+                        return Err(firecracker_server_required("fork", api_port));
+                    }
+                    delegate_sandbox_action_to_server(
+                        "127.0.0.1",
+                        api_port,
+                        &source,
+                        "fork",
+                        Some(serde_json::json!({"as_name": child})),
+                    )
+                    .await?;
+                } else {
+                    manager.fork_sandbox(&source, &child).await?;
+                }
+                println!("Sandbox '{}' forked from '{}'.", child, source);
+                eprintln!("Security warning: {}", full_state::FORK_SECURITY_WARNING);
+                println!("The fork is running; the source remains paused and can be reused.");
             }
             SandboxAction::Remove { name } => {
                 validation::validate_sandbox_name(&name)?;
 
                 let mut manager = VmManager::new()?;
                 println!("Removing sandbox '{}'...", name);
-                manager.remove(&name).await?;
+                remove_sandbox_via_authoritative_manager(&mut manager, &name).await?;
                 println!("Sandbox '{}' removed.", name);
             }
             SandboxAction::ExtendTtl { name, by } => {
@@ -1804,8 +2036,8 @@ memory_mb = 512
                     bail!("Sandbox '{}' not found", name);
                 }
 
-                let additional_secs = crate::ssh::parse_ttl_to_secs(&by)?;
-                let new_expiry = manager.extend_ttl(&name, additional_secs)?;
+                let new_expiry =
+                    extend_ttl_via_authoritative_manager(&mut manager, &name, &by).await?;
 
                 match new_expiry {
                     Some(exp) => println!("Extended TTL for '{}'. New expiry: {}", name, exp),
@@ -1960,11 +2192,27 @@ memory_mb = 512
                         "NAME", "STATUS", "BACKEND", "IP", "LABELS"
                     );
                     for (name, running, backend) in filtered {
-                        let status = if running { "running" } else { "stopped" };
+                        let local_status = manager
+                            .get_state(name)
+                            .map(|state| state.status(running))
+                            .unwrap_or(if running { "running" } else { "stopped" })
+                            .to_string();
+                        let authoritative =
+                            if backend == Some(crate::backend::BackendType::Firecracker) {
+                                delegated_firecracker_status(name).await?
+                            } else {
+                                None
+                            };
+                        let status = authoritative
+                            .as_ref()
+                            .map(|status| status.status.as_str())
+                            .unwrap_or(&local_status);
                         let backend_str = backend
                             .map(|b| format!("{}", b))
                             .unwrap_or_else(|| "unknown".to_string());
-                        let ip_str = if running {
+                        let ip_str = if let Some(authoritative) = authoritative.as_ref() {
+                            authoritative.ip.clone().unwrap_or_else(|| "-".to_string())
+                        } else if running {
                             manager
                                 .get_container_ip(name)
                                 .unwrap_or_else(|| "-".to_string())
@@ -2030,7 +2278,7 @@ memory_mb = 512
                 } else {
                     let mut removed = Vec::new();
                     for name in candidates {
-                        manager.remove(&name).await?;
+                        remove_sandbox_via_authoritative_manager(&mut manager, &name).await?;
                         removed.push(name);
                     }
                     println!("Removed {} sandbox(es):", removed.len());
@@ -2041,7 +2289,7 @@ memory_mb = 512
             }
             SandboxAction::Info { name } => {
                 validation::validate_sandbox_name(&name)?;
-                run_info(&name)?;
+                run_info(&name).await?;
             }
             SandboxAction::Export { name, output } => {
                 validation::validate_sandbox_name(&name)?;
@@ -2133,7 +2381,7 @@ memory_mb = 512
 
                 println!("Sandbox '{}' created from config.", name);
                 println!("\nNext steps:");
-                println!("  agentkernel start {}", name);
+                println!("  agentkernel sandbox start {}", name);
             }
             SandboxAction::Clean { force, all } => {
                 run_clean(force, all).await?;
@@ -2147,10 +2395,21 @@ memory_mb = 512
             if !manager.exists(&name) {
                 bail!("Sandbox '{}' not found", name);
             }
+            let backend = manager
+                .get_state(&name)
+                .and_then(|state| state.backend)
+                .unwrap_or(manager.backend());
+            let firecracker = backend == crate::backend::BackendType::Firecracker;
+
+            if firecracker {
+                bail!(
+                    "Interactive attach is not yet supported for server-owned Firecracker sandboxes; use 'agentkernel exec' or SSH instead"
+                );
+            }
 
             if !manager.is_running(&name) {
                 bail!(
-                    "Sandbox '{}' is not running. Start it with: agentkernel start {}",
+                    "Sandbox '{}' is not running. Start it with: agentkernel sandbox start {}",
                     name,
                     name
                 );
@@ -2236,6 +2495,11 @@ memory_mb = 512
             if !manager.exists(&name) {
                 bail!("Sandbox '{}' not found", name);
             }
+            let backend = manager
+                .get_state(&name)
+                .and_then(|state| state.backend)
+                .unwrap_or(manager.backend());
+            let firecracker = backend == crate::backend::BackendType::Firecracker;
 
             let receipt_invocation = receipt_path.as_ref().map(|_| {
                 receipt::Invocation::Exec(receipt::ExecInvocation {
@@ -2264,10 +2528,32 @@ memory_mb = 512
                 if receipt_path.is_some() {
                     bail!("--receipt is not supported with --detach");
                 }
+                if firecracker {
+                    bail!(
+                        "Detached exec is not yet supported for server-owned Firecracker sandboxes; run a foreground command instead"
+                    );
+                }
                 let cmd = manager.exec_detached(&name, &command, &opts).await?;
                 println!("{}", serde_json::to_string_pretty(&cmd)?);
             } else {
-                let result = manager.exec_cmd_full(&name, &command, &opts).await;
+                let result = if firecracker {
+                    let api_port = local_api_port();
+                    if !try_server_health("127.0.0.1", api_port).await {
+                        return Err(firecracker_server_required("exec", api_port));
+                    }
+                    delegate_exec_to_server(
+                        "127.0.0.1",
+                        api_port,
+                        &name,
+                        &command,
+                        &env,
+                        workdir.as_deref(),
+                        sudo,
+                    )
+                    .await
+                } else {
+                    manager.exec_cmd_full(&name, &command, &opts).await
+                };
                 match result {
                     Ok(output) => {
                         print!("{}", output);
@@ -2630,15 +2916,7 @@ memory_mb = 512
             } else {
                 None
             };
-            let selected_backend = if let Some(bt) = backend_type {
-                bt
-            } else {
-                crate::backend::detect_best_backend().ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "No sandbox backend available. Need one of: KVM (Linux), Apple containers (macOS 26+), or Docker/Podman."
-                    )
-                })?
-            };
+            let selected_backend = resolve_requested_backend(backend_type)?;
 
             // Optimized path: use run_ephemeral for single-operation execution
             // This is faster than create→start→exec→stop→remove cycle:
@@ -2691,6 +2969,11 @@ memory_mb = 512
                 }
             }
 
+            let firecracker_run = selected_backend == crate::backend::BackendType::Firecracker;
+            let run_api_port = local_api_port();
+            if firecracker_run && !try_server_health("127.0.0.1", run_api_port).await {
+                return Err(firecracker_server_required("run a sandbox", run_api_port));
+            }
             let mut manager = VmManager::with_backend(Some(selected_backend))?;
 
             // Fallback: multi-step VM mode (for --keep or Firecracker backend)
@@ -2702,11 +2985,56 @@ memory_mb = 512
                 // Reuse existing sandbox if it already exists for this branch
                 if manager.exists(&name) {
                     eprintln!("Reusing existing sandbox for branch: {}", name);
-                    // Just exec in the existing sandbox
-                    if !manager.is_running(&name) {
-                        manager.start(&name).await?;
-                    }
-                    let result = manager.exec_cmd(&name, &command).await;
+                    let existing_backend = sandbox_backend(&manager, &name);
+                    let result = if existing_backend == crate::backend::BackendType::Firecracker {
+                        let api_port = local_api_port();
+                        if !try_server_health("127.0.0.1", api_port).await {
+                            return Err(firecracker_server_required(
+                                "reuse a branch sandbox",
+                                api_port,
+                            ));
+                        }
+                        let status = delegated_firecracker_status(&name).await?;
+                        match status.as_ref().map(|status| status.status.as_str()) {
+                            Some("running") => {}
+                            Some("paused") => {
+                                delegate_sandbox_action_to_server(
+                                    "127.0.0.1",
+                                    api_port,
+                                    &name,
+                                    "resume",
+                                    None,
+                                )
+                                .await?;
+                            }
+                            _ => {
+                                delegate_configured_start_to_server(
+                                    "127.0.0.1",
+                                    api_port,
+                                    &name,
+                                    &manager,
+                                    &perms,
+                                    &files,
+                                )
+                                .await?;
+                            }
+                        }
+                        delegate_exec_to_server(
+                            "127.0.0.1",
+                            api_port,
+                            &name,
+                            &command,
+                            &[],
+                            None,
+                            false,
+                        )
+                        .await
+                    } else {
+                        if !manager.is_running(&name) {
+                            manager.start(&name).await?;
+                        }
+                        manager.exec_cmd(&name, &command).await
+                    };
                     match result {
                         Ok(output) => {
                             print!("{}", output);
@@ -2809,18 +3137,49 @@ memory_mb = 512
                 }
             }
 
-            // Start with permissions and inject files
-            if let Err(e) = manager
-                .start_with_permissions_and_files(&sandbox_name, &perms, &files)
+            // A Firecracker runtime must be owned by the long-running daemon;
+            // the short-lived `run` process only publishes durable pre-start
+            // state and a UUID/generation-bound one-shot start capability.
+            let start_result = if firecracker_run {
+                delegate_configured_start_to_server(
+                    "127.0.0.1",
+                    run_api_port,
+                    &sandbox_name,
+                    &manager,
+                    &perms,
+                    &files,
+                )
                 .await
-            {
-                // Cleanup on failure
-                let _ = manager.remove(&sandbox_name).await;
+            } else {
+                manager
+                    .start_with_permissions_and_files(&sandbox_name, &perms, &files)
+                    .await
+            };
+            if let Err(e) = start_result {
+                if firecracker_run {
+                    let _ =
+                        delegate_remove_to_server("127.0.0.1", run_api_port, &sandbox_name).await;
+                } else {
+                    let _ = manager.remove(&sandbox_name).await;
+                }
                 bail!("Failed to start sandbox: {}", e);
             }
 
             // Execute command
-            let result = manager.exec_cmd(&sandbox_name, &command).await;
+            let result = if firecracker_run {
+                delegate_exec_to_server(
+                    "127.0.0.1",
+                    run_api_port,
+                    &sandbox_name,
+                    &command,
+                    &[],
+                    None,
+                    false,
+                )
+                .await
+            } else {
+                manager.exec_cmd(&sandbox_name, &command).await
+            };
 
             // Print output
             match &result {
@@ -2844,17 +3203,27 @@ memory_mb = 512
                 eprintln!("Execution receipt written to {}", path.display());
             }
 
-            // Stop
-            let _ = manager.stop(&sandbox_name).await;
-
-            // Remove (unless --keep)
-            if !keep {
-                let _ = manager.remove(&sandbox_name).await;
+            // Kept Firecracker sandboxes stay live in the daemon. Ephemeral
+            // Firecracker runs are removed directly by that same owner; never
+            // perform an ordinary stop that discards the writable overlay.
+            let cleanup_result = if firecracker_run && !keep {
+                delegate_remove_to_server("127.0.0.1", run_api_port, &sandbox_name).await
+            } else if !firecracker_run && !keep {
+                manager.remove(&sandbox_name).await
+            } else if !firecracker_run {
+                manager.stop(&sandbox_name).await
             } else {
+                Ok(())
+            };
+            if keep {
                 println!(
                     "\nSandbox '{}' kept. Remove with: agentkernel remove {}",
                     sandbox_name, sandbox_name
                 );
+            }
+            if let Err(cleanup_error) = cleanup_result {
+                return Err(cleanup_error)
+                    .context(format!("failed to finish run cleanup for '{sandbox_name}'"));
             }
 
             // Return error if command failed
@@ -3837,6 +4206,7 @@ memory_mb = 512
             } else {
                 None
             };
+            let backend_type = Some(resolve_batch_backend(backend_type, "parallel jobs")?);
 
             let total_start = std::time::Instant::now();
 
@@ -4196,7 +4566,8 @@ memory_mb = 512
             } else {
                 None
             };
-            let mut manager = VmManager::with_backend(backend_type)?;
+            let backend_type = resolve_batch_backend(backend_type, "pipelines")?;
+            let mut manager = VmManager::with_backend(Some(backend_type))?;
 
             let prefix = format!("pipe-{}", &uuid::Uuid::new_v4().to_string()[..8]);
             pipeline::run(&pipe, &mut manager, &prefix).await?;
@@ -4220,13 +4591,36 @@ memory_mb = 512
                     None
                 };
                 let mut manager = VmManager::with_backend(backend_type)?;
+                let firecracker = manager.backend() == crate::backend::BackendType::Firecracker;
+                if firecracker {
+                    let api_port = local_api_port();
+                    if !try_server_health("127.0.0.1", api_port).await {
+                        return Err(firecracker_server_required("start session", api_port));
+                    }
+                }
 
                 println!("Starting session '{}' (agent: {})...", name, agent);
                 manager.create(&sess.sandbox, &docker_image, 1, 512).await?;
-                manager.start(&sess.sandbox).await?;
+                if firecracker {
+                    let permissions = crate::permissions::Permissions::default();
+                    delegate_configured_start_to_server(
+                        "127.0.0.1",
+                        local_api_port(),
+                        &sess.sandbox,
+                        &manager,
+                        &permissions,
+                        &[],
+                    )
+                    .await?;
+                } else {
+                    manager.start(&sess.sandbox).await?;
+                }
                 println!("Session '{}' started.", name);
                 println!("  Sandbox: {}", sess.sandbox);
-                println!("\nAttach with: agentkernel attach {}", sess.sandbox);
+                println!(
+                    "\nUse: {}",
+                    sandbox_connection_command(&sess.sandbox, firecracker, false)
+                );
             }
             SessionAction::List => {
                 let sessions = session::list()?;
@@ -4252,8 +4646,29 @@ memory_mb = 512
                     .ok_or_else(|| anyhow::anyhow!("Session '{}' not found", name))?;
 
                 let mut manager = VmManager::new()?;
-                if manager.exists(&sess.sandbox) && manager.is_running(&sess.sandbox) {
-                    manager.stop(&sess.sandbox).await?;
+                if manager.exists(&sess.sandbox) {
+                    let backend = sandbox_backend(&manager, &sess.sandbox);
+                    if backend == crate::backend::BackendType::Firecracker {
+                        let api_port = local_api_port();
+                        if !try_server_health("127.0.0.1", api_port).await {
+                            return Err(firecracker_server_required("stop session", api_port));
+                        }
+                        if delegated_firecracker_status(&sess.sandbox)
+                            .await?
+                            .is_some_and(|status| status.status == "running")
+                        {
+                            delegate_sandbox_action_to_server(
+                                "127.0.0.1",
+                                api_port,
+                                &sess.sandbox,
+                                "stop",
+                                None,
+                            )
+                            .await?;
+                        }
+                    } else if manager.is_running(&sess.sandbox) {
+                        manager.stop(&sess.sandbox).await?;
+                    }
                 }
                 session::stop(&name)?;
                 println!("Session '{}' stopped.", name);
@@ -4346,12 +4761,52 @@ memory_mb = 512
                     }
                 }
 
-                if manager.exists(&sess.sandbox) && !manager.is_running(&sess.sandbox) {
-                    manager.start(&sess.sandbox).await?;
+                let firecracker = manager.exists(&sess.sandbox)
+                    && sandbox_backend(&manager, &sess.sandbox)
+                        == crate::backend::BackendType::Firecracker;
+                if manager.exists(&sess.sandbox) {
+                    let backend = sandbox_backend(&manager, &sess.sandbox);
+                    if backend == crate::backend::BackendType::Firecracker {
+                        let api_port = local_api_port();
+                        if !try_server_health("127.0.0.1", api_port).await {
+                            return Err(firecracker_server_required("resume session", api_port));
+                        }
+                        let status = delegated_firecracker_status(&sess.sandbox).await?;
+                        match status.as_ref().map(|status| status.status.as_str()) {
+                            Some("running") => {}
+                            Some("paused") => {
+                                delegate_sandbox_action_to_server(
+                                    "127.0.0.1",
+                                    api_port,
+                                    &sess.sandbox,
+                                    "resume",
+                                    None,
+                                )
+                                .await?;
+                            }
+                            _ => {
+                                let permissions = crate::permissions::Permissions::default();
+                                delegate_configured_start_to_server(
+                                    "127.0.0.1",
+                                    api_port,
+                                    &sess.sandbox,
+                                    &manager,
+                                    &permissions,
+                                    &[],
+                                )
+                                .await?;
+                            }
+                        }
+                    } else if !manager.is_running(&sess.sandbox) {
+                        manager.start(&sess.sandbox).await?;
+                    }
                 }
                 session::mark_running(&name)?;
                 println!("Session '{}' resumed.", name);
-                println!("\nAttach with: agentkernel attach {}", sess.sandbox);
+                println!(
+                    "\nUse: {}",
+                    sandbox_connection_command(&sess.sandbox, firecracker, false)
+                );
             }
             SessionAction::Delete { name } => {
                 let sess = session::get(&name)?
@@ -4359,10 +4814,7 @@ memory_mb = 512
 
                 let mut manager = VmManager::new()?;
                 if manager.exists(&sess.sandbox) {
-                    if manager.is_running(&sess.sandbox) {
-                        let _ = manager.stop(&sess.sandbox).await;
-                    }
-                    let _ = manager.remove(&sess.sandbox).await;
+                    remove_sandbox_via_authoritative_manager(&mut manager, &sess.sandbox).await?;
                 }
                 session::delete(&name)?;
                 println!("Session '{}' deleted.", name);
@@ -4495,8 +4947,8 @@ memory_mb = 512
 
                 println!("Sandbox '{}' restored from snapshot.", restore_name);
                 println!("\nNext steps:");
-                println!("  agentkernel start {}", restore_name);
-                println!("  agentkernel attach {}", restore_name);
+                println!("  agentkernel sandbox start {}", restore_name);
+                println!("  agentkernel exec {} -- <command>", restore_name);
             }
         },
         Commands::Llm { action } => match action {
@@ -5081,14 +5533,22 @@ fn parse_cp_path(path: &str) -> (Option<String>, String) {
     (None, path.to_string())
 }
 
-fn run_info(name: &str) -> Result<()> {
+async fn run_info(name: &str) -> Result<()> {
     let manager = VmManager::new()?;
     let state = manager
         .get_state(name)
         .ok_or_else(|| anyhow::anyhow!("Sandbox '{}' not found", name))?;
 
     let running = manager.is_running(name);
-    let status_str = if running { "running" } else { "stopped" };
+    let authoritative = if state.backend == Some(crate::backend::BackendType::Firecracker) {
+        delegated_firecracker_status(name).await?
+    } else {
+        None
+    };
+    let status_str = authoritative
+        .as_ref()
+        .map(|status| status.status.as_str())
+        .unwrap_or_else(|| state.status(running));
     let backend_str = state
         .backend
         .map(|b| format!("{}", b))
@@ -5098,7 +5558,11 @@ fn run_info(name: &str) -> Result<()> {
     println!("Status:         {}", status_str);
     println!("Backend:        {}", backend_str);
     println!("Image:          {}", state.image);
-    if running && let Some(ip) = manager.get_container_ip(name) {
+    let ip = authoritative
+        .as_ref()
+        .and_then(|status| status.ip.clone())
+        .or_else(|| running.then(|| manager.get_container_ip(name)).flatten());
+    if let Some(ip) = ip {
         println!("IP:             {}", ip);
     }
     println!(
@@ -5108,6 +5572,12 @@ fn run_info(name: &str) -> Result<()> {
         state.memory_mb
     );
     println!("Created:        {}", state.created_at);
+    if let Some(ref paused_at) = state.paused_at {
+        println!("Paused:         {}", paused_at);
+    }
+    if let Some(ref source) = state.forked_from {
+        println!("Forked from:    {}", source);
+    }
     if let Some(ttl) = state.ttl_seconds {
         println!("TTL:            {}", format_ttl(ttl));
     }
@@ -5238,22 +5708,29 @@ async fn run_clean(force: bool, all: bool) -> Result<()> {
     let sandboxes = manager
         .list()
         .iter()
-        .map(|(n, r, _)| (n.to_string(), *r))
+        .map(|(name, running, backend)| (name.to_string(), *running, *backend))
         .collect::<Vec<_>>();
 
     let mut removed = 0usize;
     let mut skipped = 0usize;
 
-    for (name, running) in &sandboxes {
-        if *running && !force {
+    for (name, locally_running, backend) in &sandboxes {
+        let running = if *backend == Some(crate::backend::BackendType::Firecracker) {
+            delegated_firecracker_status(name)
+                .await?
+                .is_some_and(|status| status.status == "running")
+        } else {
+            *locally_running
+        };
+        if running && !force {
             println!("  Skipping '{}' (running, use --force to remove)", name);
             skipped += 1;
             continue;
         }
-        if *running {
+        if running {
             println!("  Stopping '{}'...", name);
         }
-        manager.remove(name).await?;
+        remove_sandbox_via_authoritative_manager(&mut manager, name).await?;
         println!("  Removed sandbox '{}'", name);
         removed += 1;
     }
@@ -5486,65 +5963,470 @@ fn format_ttl(secs: u64) -> String {
     }
 }
 
-/// Check if the HTTP API server is running on the given address.
-/// Returns true if a TCP connection succeeds within a short timeout.
-async fn try_server_health(host: &str, port: u16) -> bool {
-    let addr = format!("{}:{}", host, port);
-    matches!(
-        tokio::time::timeout(
-            std::time::Duration::from_secs(1),
-            tokio::net::TcpStream::connect(&addr),
-        )
-        .await,
-        Ok(Ok(_))
-    )
+fn sandbox_connection_command(name: &str, firecracker: bool, ssh_enabled: bool) -> String {
+    if ssh_enabled {
+        format!("agentkernel ssh {name}")
+    } else if firecracker {
+        format!("agentkernel exec {name} -- <command>")
+    } else {
+        format!("agentkernel attach {name}")
+    }
 }
 
-/// Delegate sandbox start to the running HTTP server.
-/// Sends POST /sandboxes/{name}/start and checks for a 200 response.
-async fn delegate_start_to_server(host: &str, port: u16, name: &str) -> Result<()> {
-    use http_body_util::{BodyExt, Empty};
+/// Check that the plaintext loopback control endpoint is actually serving the
+/// AgentKernel health route. A raw TCP probe would incorrectly accept a TLS-
+/// only listener and make every delegated lifecycle request fail later.
+async fn try_server_health(host: &str, port: u16) -> bool {
+    use http_body_util::Full;
     use hyper::Request;
     use hyper_util::client::legacy::Client;
     use hyper_util::rt::TokioExecutor;
 
-    let uri: hyper::Uri = format!("http://{}:{}/sandboxes/{}/start", host, port, name)
-        .parse()
-        .map_err(|e| anyhow::anyhow!("invalid URI: {}", e))?;
-
-    let client = Client::builder(TokioExecutor::new()).build_http::<Empty<bytes::Bytes>>();
-
-    let req = Request::builder()
-        .method(hyper::Method::POST)
+    let Ok(uri) = format!("http://{host}:{port}/health").parse::<hyper::Uri>() else {
+        return false;
+    };
+    let Ok(request) = Request::builder()
+        .method(hyper::Method::GET)
         .uri(uri)
-        .header("content-type", "application/json")
-        .body(Empty::<bytes::Bytes>::new())
-        .map_err(|e| anyhow::anyhow!("failed to build request: {}", e))?;
-
-    let resp = tokio::time::timeout(std::time::Duration::from_secs(30), client.request(req))
+        .body(Full::new(bytes::Bytes::new()))
+    else {
+        return false;
+    };
+    let client = Client::builder(TokioExecutor::new()).build_http::<Full<bytes::Bytes>>();
+    tokio::time::timeout(std::time::Duration::from_secs(1), client.request(request))
         .await
-        .map_err(|_| anyhow::anyhow!("timeout waiting for server to start sandbox"))?
-        .map_err(|e| anyhow::anyhow!("HTTP request failed: {}", e))?;
+        .is_ok_and(|result| result.is_ok_and(|response| response.status().is_success()))
+}
 
-    if resp.status().is_success() {
-        Ok(())
-    } else {
-        let status = resp.status();
-        let body = resp
-            .into_body()
-            .collect()
-            .await
-            .map(|c| String::from_utf8_lossy(&c.to_bytes()).to_string())
-            .unwrap_or_default();
-        bail!("Server returned {} when starting sandbox: {}", status, body);
+fn local_api_port() -> u16 {
+    std::env::var("AGENTKERNEL_PORT")
+        .ok()
+        .and_then(|port| port.parse::<u16>().ok())
+        .unwrap_or(18888)
+}
+
+fn firecracker_server_required(operation: &str, port: u16) -> anyhow::Error {
+    anyhow::anyhow!(
+        "Firecracker sandbox {operation} requires a plaintext loopback control endpoint owned by the long-running API server. Start it with 'agentkernel serve --host 127.0.0.1 --port {port}' without --require-tls, then retry."
+    )
+}
+
+fn resolve_requested_backend(
+    requested: Option<crate::backend::BackendType>,
+) -> Result<crate::backend::BackendType> {
+    requested
+        .or_else(crate::backend::detect_best_backend)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "No sandbox backend available. Need one of: KVM (Linux), Apple containers (macOS 26+), or Docker/Podman."
+            )
+        })
+}
+
+fn resolve_batch_backend(
+    requested: Option<crate::backend::BackendType>,
+    operation: &str,
+) -> Result<crate::backend::BackendType> {
+    let backend = resolve_requested_backend(requested)?;
+    if backend == crate::backend::BackendType::Firecracker {
+        bail!(
+            "{operation} are not yet routed through the authoritative Firecracker daemon; select Docker, Podman, or Apple explicitly"
+        );
     }
+    Ok(backend)
+}
+
+/// Delegate a sandbox POST action to the running HTTP server.
+///
+/// Firecracker processes must be owned by a long-lived process. CLI and MCP
+/// commands therefore route their Firecracker lifecycle mutations through the
+/// local server rather than creating a short-lived `VmManager` owner.
+async fn delegate_sandbox_action_to_server(
+    host: &str,
+    port: u16,
+    name: &str,
+    action: &str,
+    body: Option<serde_json::Value>,
+) -> Result<String> {
+    delegate_sandbox_request_to_server(
+        host,
+        port,
+        hyper::Method::POST,
+        name,
+        Some(action),
+        body,
+        action,
+    )
+    .await
+}
+
+fn delegated_sandbox_uri(
+    host: &str,
+    port: u16,
+    name: &str,
+    suffix: Option<&str>,
+) -> Result<hyper::Uri> {
+    let path = suffix
+        .map(|suffix| format!("/sandboxes/{name}/{suffix}"))
+        .unwrap_or_else(|| format!("/sandboxes/{name}"));
+    format!("http://{host}:{port}{path}")
+        .parse()
+        .map_err(|error| anyhow::anyhow!("invalid URI: {error}"))
+}
+
+async fn delegate_sandbox_request_to_server(
+    host: &str,
+    port: u16,
+    method: hyper::Method,
+    name: &str,
+    suffix: Option<&str>,
+    body: Option<serde_json::Value>,
+    operation: &str,
+) -> Result<String> {
+    use http_body_util::{BodyExt, Full};
+    use hyper::Request;
+    use hyper_util::client::legacy::Client;
+    use hyper_util::rt::TokioExecutor;
+
+    let uri = delegated_sandbox_uri(host, port, name, suffix)?;
+
+    let body = body
+        .map(|value| serde_json::to_vec(&value))
+        .transpose()?
+        .unwrap_or_default();
+
+    let client = Client::builder(TokioExecutor::new()).build_http::<Full<bytes::Bytes>>();
+
+    let mut request = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("content-type", "application/json");
+    if let Ok(api_key) = std::env::var("AGENTKERNEL_API_KEY")
+        && !api_key.is_empty()
+    {
+        request = request.header(hyper::header::AUTHORIZATION, format!("Bearer {api_key}"));
+    }
+    let req = request
+        .body(Full::new(bytes::Bytes::from(body)))
+        .map_err(|e| anyhow::anyhow!("failed to build request: {e}"))?;
+
+    let resp = if let Some(timeout) = delegated_request_timeout(operation) {
+        tokio::time::timeout(timeout, client.request(req))
+            .await
+            .map_err(|_| anyhow::anyhow!("timeout waiting for server to {operation} sandbox"))?
+            .map_err(|e| anyhow::anyhow!("HTTP request failed: {e}"))?
+    } else {
+        client
+            .request(req)
+            .await
+            .map_err(|e| anyhow::anyhow!("HTTP request failed: {e}"))?
+    };
+
+    let status = resp.status();
+    let response_body = resp
+        .into_body()
+        .collect()
+        .await
+        .map(|collected| String::from_utf8_lossy(&collected.to_bytes()).to_string())
+        .unwrap_or_default();
+
+    if status.is_success() {
+        Ok(response_body)
+    } else {
+        Err(DelegatedHttpError {
+            status,
+            operation: operation.to_string(),
+            body: response_body,
+        }
+        .into())
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("Server returned {status} when attempting to {operation} sandbox: {body}")]
+struct DelegatedHttpError {
+    status: hyper::StatusCode,
+    operation: String,
+    body: String,
+}
+
+fn delegated_http_error(error: &anyhow::Error) -> Option<&DelegatedHttpError> {
+    error.downcast_ref::<DelegatedHttpError>()
+}
+
+fn delegated_exec_failure(error: &anyhow::Error) -> Option<crate::vmm::CommandFailed> {
+    let server_error = delegated_http_error(error)?;
+    if server_error.status != hyper::StatusCode::CONFLICT {
+        return None;
+    }
+    let body = serde_json::from_str::<serde_json::Value>(&server_error.body).ok()?;
+    let exit_code = body.get("exit_code")?.as_i64()?;
+    let exit_code = i32::try_from(exit_code).ok()?;
+    let output = body.get("output")?.as_str()?.to_string();
+    Some(crate::vmm::CommandFailed { exit_code, output })
+}
+
+fn delegated_request_timeout(operation: &str) -> Option<std::time::Duration> {
+    (!matches!(
+        operation,
+        "start" | "stop" | "pause" | "resume" | "fork" | "remove" | "exec"
+    ))
+    .then(|| std::time::Duration::from_secs(120))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DelegatedSandboxStatus {
+    status: String,
+    ip: Option<String>,
+}
+
+fn parse_delegated_sandbox_status(response: &str) -> Result<DelegatedSandboxStatus> {
+    let response: serde_json::Value = serde_json::from_str(response)
+        .context("local API server returned an invalid sandbox response")?;
+    let status = response
+        .pointer("/data/status")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| anyhow::anyhow!("local API server response did not include sandbox status"))?
+        .to_string();
+    let ip = response
+        .pointer("/data/ip")
+        .and_then(serde_json::Value::as_str)
+        .map(ToString::to_string);
+    Ok(DelegatedSandboxStatus { status, ip })
+}
+
+async fn delegated_firecracker_status(name: &str) -> Result<Option<DelegatedSandboxStatus>> {
+    let port = local_api_port();
+    if !try_server_health("127.0.0.1", port).await {
+        return Ok(None);
+    }
+    let response = match delegate_sandbox_request_to_server(
+        "127.0.0.1",
+        port,
+        hyper::Method::GET,
+        name,
+        None,
+        None,
+        "inspect",
+    )
+    .await
+    {
+        Ok(response) => response,
+        Err(error)
+            if delegated_http_error(&error)
+                .is_some_and(|error| error.status == hyper::StatusCode::NOT_FOUND) =>
+        {
+            return Ok(None);
+        }
+        Err(error) => return Err(error),
+    };
+    parse_delegated_sandbox_status(&response).map(Some)
+}
+
+fn sandbox_backend(manager: &VmManager, name: &str) -> crate::backend::BackendType {
+    manager
+        .get_state(name)
+        .and_then(|state| state.backend)
+        .unwrap_or(manager.backend())
+}
+
+fn sandbox_uses_authoritative_server(manager: &VmManager, name: &str) -> bool {
+    manager.exists(name)
+        && sandbox_backend(manager, name) == crate::backend::BackendType::Firecracker
+}
+
+pub(crate) async fn remove_sandbox_via_authoritative_manager(
+    manager: &mut VmManager,
+    name: &str,
+) -> Result<()> {
+    let local_exists = manager.exists(name);
+    let local_firecracker = sandbox_uses_authoritative_server(manager, name);
+    let port = local_api_port();
+    if (!local_exists || local_firecracker) && try_server_health("127.0.0.1", port).await {
+        match delegate_remove_to_server("127.0.0.1", port, name).await {
+            Ok(()) => return Ok(()),
+            Err(error)
+                if delegated_http_error(&error)
+                    .is_some_and(|error| error.status == hyper::StatusCode::NOT_FOUND) =>
+            {
+                let local_is_unowned = manager.get_state(name).is_some_and(|state| {
+                    state.owner_user_id.is_none() && state.owner_org_id.is_none()
+                });
+                if !local_exists || (local_firecracker && local_is_unowned) {
+                    return manager.remove(name).await.map(|_| ());
+                }
+                return Err(error);
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    if local_firecracker {
+        return Err(firecracker_server_required("remove", port));
+    }
+    manager.remove(name).await.map(|_| ())
+}
+
+async fn delegate_configured_start_to_server(
+    host: &str,
+    port: u16,
+    name: &str,
+    manager: &VmManager,
+    permissions: &crate::permissions::Permissions,
+    files: &[crate::backend::FileInjection],
+) -> Result<()> {
+    let sandbox = manager
+        .get_state(name)
+        .ok_or_else(|| anyhow::anyhow!("Sandbox '{name}' not found"))?;
+    let request = crate::http_api::persist_start_configuration(
+        manager.get_data_dir(),
+        sandbox,
+        permissions,
+        files,
+    )?;
+    let result = async {
+        let body = serde_json::to_value(&request)?;
+        delegate_sandbox_action_to_server(host, port, name, "start", Some(body))
+            .await
+            .map(|_| ())
+    }
+    .await;
+    let cleanup =
+        crate::http_api::discard_persisted_start_configuration(manager.get_data_dir(), &request);
+    match (result, cleanup) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Ok(()), Err(error)) => Err(error),
+        (Err(error), _) => Err(error),
+    }
+}
+
+async fn delegate_remove_to_server(host: &str, port: u16, name: &str) -> Result<()> {
+    delegate_sandbox_request_to_server(
+        host,
+        port,
+        hyper::Method::DELETE,
+        name,
+        None,
+        None,
+        "remove",
+    )
+    .await
+    .map(|_| ())
+}
+
+pub(crate) async fn delegate_extend_ttl_to_server(
+    host: &str,
+    port: u16,
+    name: &str,
+    by: &str,
+) -> Result<Option<String>> {
+    let response = delegate_sandbox_action_to_server(
+        host,
+        port,
+        name,
+        "extend",
+        Some(serde_json::json!({"by": by})),
+    )
+    .await?;
+    delegated_extend_ttl_expiry(&response)
+}
+
+pub(crate) async fn extend_ttl_via_authoritative_manager(
+    manager: &mut VmManager,
+    name: &str,
+    by: &str,
+) -> Result<Option<String>> {
+    if sandbox_backend(manager, name) != crate::backend::BackendType::Firecracker {
+        let additional_secs = crate::ssh::parse_ttl_to_secs(by)?;
+        return manager.extend_ttl(name, additional_secs);
+    }
+
+    let port = local_api_port();
+    if !try_server_health("127.0.0.1", port).await {
+        return Err(firecracker_server_required("extend TTL for", port));
+    }
+    match delegate_extend_ttl_to_server("127.0.0.1", port, name, by).await {
+        Ok(expiry) => Ok(expiry),
+        Err(error)
+            if delegated_http_error(&error)
+                .is_some_and(|error| error.status == hyper::StatusCode::NOT_FOUND)
+                && manager.get_state(name).is_some_and(|state| {
+                    state.owner_user_id.is_none() && state.owner_org_id.is_none()
+                }) =>
+        {
+            let additional_secs = crate::ssh::parse_ttl_to_secs(by)?;
+            manager.extend_ttl(name, additional_secs)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn delegated_extend_ttl_expiry(response: &str) -> Result<Option<String>> {
+    let response: serde_json::Value = serde_json::from_str(response)
+        .context("local API server returned an invalid extend-TTL response")?;
+    let expires_at = response.pointer("/data/expires_at").ok_or_else(|| {
+        anyhow::anyhow!("local API server response did not include the updated expiry")
+    })?;
+    match expires_at {
+        serde_json::Value::Null => Ok(None),
+        serde_json::Value::String(value) => Ok(Some(value.clone())),
+        _ => bail!("local API server returned an invalid updated expiry"),
+    }
+}
+
+async fn delegate_exec_to_server(
+    host: &str,
+    port: u16,
+    name: &str,
+    command: &[String],
+    env: &[String],
+    workdir: Option<&str>,
+    sudo: bool,
+) -> Result<String> {
+    let response = match delegate_sandbox_action_to_server(
+        host,
+        port,
+        name,
+        "exec",
+        Some(serde_json::json!({
+            "command": command,
+            "env": env,
+            "workdir": workdir,
+            "sudo": sudo,
+        })),
+    )
+    .await
+    {
+        Ok(response) => response,
+        Err(error) => {
+            if let Some(command_failure) = delegated_exec_failure(&error) {
+                return Err(command_failure.into());
+            }
+            return Err(error);
+        }
+    };
+    delegated_exec_output(&response)
+}
+
+fn delegated_exec_output(response: &str) -> Result<String> {
+    let response: serde_json::Value = serde_json::from_str(response)
+        .context("local API server returned an invalid exec response")?;
+    response
+        .pointer("/data/output")
+        .and_then(serde_json::Value::as_str)
+        .map(ToString::to_string)
+        .ok_or_else(|| anyhow::anyhow!("local API server exec response did not include output"))
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        Cli, Commands, SandboxAction, config_has_build_settings, resolve_devcontainer,
-        resolve_workspace_root, should_build_run_image,
+        Cli, Commands, DelegatedHttpError, SandboxAction, config_has_build_settings,
+        delegate_exec_to_server, delegated_exec_failure, delegated_exec_output,
+        delegated_extend_ttl_expiry, delegated_request_timeout, delegated_sandbox_uri,
+        firecracker_server_required, parse_delegated_sandbox_status, resolve_batch_backend,
+        resolve_devcontainer, resolve_requested_backend, resolve_workspace_root,
+        sandbox_connection_command, sandbox_uses_authoritative_server, should_build_run_image,
+        try_server_health,
     };
     use crate::config::Config;
     use clap::Parser;
@@ -5584,6 +6466,222 @@ mod tests {
             },
             _ => panic!("expected sandbox command"),
         }
+    }
+
+    #[test]
+    fn cli_accepts_pause_and_suspend_alias() {
+        for command in ["pause", "suspend"] {
+            let cli =
+                Cli::try_parse_from(["agentkernel", "sandbox", command, "paused-sandbox"]).unwrap();
+            match cli.command {
+                Commands::Sandbox {
+                    action: SandboxAction::Pause { name },
+                } => assert_eq!(name, "paused-sandbox"),
+                _ => panic!("expected sandbox pause for {command}"),
+            }
+        }
+    }
+
+    #[test]
+    fn cli_accepts_resume_and_fork_contract() {
+        let resume =
+            Cli::try_parse_from(["agentkernel", "sandbox", "resume", "paused-sandbox"]).unwrap();
+        match resume.command {
+            Commands::Sandbox {
+                action: SandboxAction::Resume { name },
+            } => assert_eq!(name, "paused-sandbox"),
+            _ => panic!("expected sandbox resume"),
+        }
+
+        let fork = Cli::try_parse_from([
+            "agentkernel",
+            "sandbox",
+            "fork",
+            "paused-sandbox",
+            "--as",
+            "candidate-a",
+        ])
+        .unwrap();
+        match fork.command {
+            Commands::Sandbox {
+                action:
+                    SandboxAction::Fork {
+                        source,
+                        r#as: child,
+                    },
+            } => {
+                assert_eq!(source, "paused-sandbox");
+                assert_eq!(child, "candidate-a");
+            }
+            _ => panic!("expected sandbox fork"),
+        }
+    }
+
+    #[test]
+    fn delegated_sandbox_uri_covers_lifecycle_and_remove() {
+        let stop = delegated_sandbox_uri("127.0.0.1", 18888, "demo", Some("stop")).unwrap();
+        assert_eq!(
+            stop.to_string(),
+            "http://127.0.0.1:18888/sandboxes/demo/stop"
+        );
+
+        let remove = delegated_sandbox_uri("127.0.0.1", 18888, "demo", None).unwrap();
+        assert_eq!(remove.to_string(), "http://127.0.0.1:18888/sandboxes/demo");
+
+        let extend = delegated_sandbox_uri("127.0.0.1", 18888, "demo", Some("extend")).unwrap();
+        assert_eq!(
+            extend.to_string(),
+            "http://127.0.0.1:18888/sandboxes/demo/extend"
+        );
+    }
+
+    #[test]
+    fn delegated_exec_response_contract_and_server_error_are_actionable() {
+        let output = delegated_exec_output(r#"{"success":true,"data":{"output":"ok\n"}}"#).unwrap();
+        assert_eq!(output, "ok\n");
+        assert!(delegated_exec_output(r#"{"success":true}"#).is_err());
+
+        let error = firecracker_server_required("pause", 18888).to_string();
+        assert!(error.contains("agentkernel serve --host 127.0.0.1 --port 18888"));
+        assert!(error.contains("without --require-tls"));
+
+        let error: anyhow::Error = DelegatedHttpError {
+            status: hyper::StatusCode::CONFLICT,
+            operation: "exec".to_string(),
+            body: r#"{"success":false,"exit_code":17,"output":"partial output\n"}"#.to_string(),
+        }
+        .into();
+        let failed = delegated_exec_failure(&error).unwrap();
+        assert_eq!(failed.exit_code, 17);
+        assert_eq!(failed.output, "partial output\n");
+    }
+
+    #[test]
+    fn delegated_full_state_lifecycle_has_no_client_timeout() {
+        for operation in ["start", "stop", "pause", "resume", "fork", "remove", "exec"] {
+            assert_eq!(delegated_request_timeout(operation), None);
+        }
+        assert_eq!(
+            delegated_request_timeout("inspect"),
+            Some(std::time::Duration::from_secs(120))
+        );
+    }
+
+    #[tokio::test]
+    async fn daemon_health_probe_requires_plain_http_health_response() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        async fn serve_once(listener: TcpListener, response: &'static [u8]) {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = [0_u8; 1024];
+            let _ = stream.read(&mut request).await.unwrap();
+            stream.write_all(response).await.unwrap();
+        }
+
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(serve_once(
+            listener,
+            b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
+        ));
+        assert!(try_server_health("127.0.0.1", port).await);
+        server.await.unwrap();
+
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(serve_once(
+            listener,
+            // A TLS record prefix must not be treated as a healthy plaintext
+            // AgentKernel control endpoint merely because TCP connected.
+            b"\x16\x03\x03\x00\x02\x02\x28",
+        ));
+        assert!(!try_server_health("127.0.0.1", port).await);
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn delegated_exec_preserves_guest_nonzero_exit_and_output() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        let body = r#"{"success":false,"error":"Command exited with code 23","exit_code":23,"output":"partial stdout\n"}"#;
+        let response = format!(
+            "HTTP/1.1 409 Conflict\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = [0_u8; 4096];
+            let _ = stream.read(&mut request).await.unwrap();
+            stream.write_all(response.as_bytes()).await.unwrap();
+        });
+
+        let error = delegate_exec_to_server(
+            "127.0.0.1",
+            port,
+            "demo",
+            &["sh".to_string(), "-c".to_string(), "exit 23".to_string()],
+            &[],
+            None,
+            false,
+        )
+        .await
+        .unwrap_err();
+        let failed = error.downcast_ref::<crate::vmm::CommandFailed>().unwrap();
+        assert_eq!(failed.exit_code, 23);
+        assert_eq!(failed.output, "partial stdout\n");
+        server.await.unwrap();
+    }
+
+    #[test]
+    fn delegated_sandbox_status_uses_server_response() {
+        let status = parse_delegated_sandbox_status(
+            r#"{"success":true,"data":{"name":"fork-a","status":"running","backend":"firecracker","ip":"172.16.0.2"}}"#,
+        )
+        .unwrap();
+        assert_eq!(status.status, "running");
+        assert_eq!(status.ip.as_deref(), Some("172.16.0.2"));
+        assert!(parse_delegated_sandbox_status(r#"{"success":true,"data":{}}"#).is_err());
+    }
+
+    #[test]
+    fn delegated_extend_ttl_uses_server_expiry() {
+        assert_eq!(
+            delegated_extend_ttl_expiry(
+                r#"{"success":true,"data":{"expires_at":"2026-08-24T12:00:00Z"}}"#,
+            )
+            .unwrap()
+            .as_deref(),
+            Some("2026-08-24T12:00:00Z")
+        );
+        assert_eq!(
+            delegated_extend_ttl_expiry(r#"{"success":true,"data":{"expires_at":null}}"#,).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn persisted_firecracker_removal_routes_to_authoritative_server() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut manager = crate::vmm::VmManager::for_tests(dir.path()).unwrap();
+        let sandbox = serde_json::from_value(serde_json::json!({
+            "name": "server-owned",
+            "uuid": "server-owned-uuid",
+            "image": "alpine:3.24",
+            "vcpus": 1,
+            "memory_mb": 512,
+            "vsock_cid": 3,
+            "created_at": "2026-01-01T00:00:00Z",
+            "backend": "Firecracker"
+        }))
+        .unwrap();
+        manager.insert_state_for_tests(sandbox);
+
+        assert!(sandbox_uses_authoritative_server(&manager, "server-owned"));
     }
 
     #[test]
@@ -5707,5 +6805,48 @@ mod tests {
             Some(&config),
             project.path()
         ));
+    }
+
+    #[test]
+    fn run_backend_resolution_preserves_explicit_firecracker() {
+        assert_eq!(
+            resolve_requested_backend(Some(crate::backend::BackendType::Firecracker)).unwrap(),
+            crate::backend::BackendType::Firecracker
+        );
+    }
+
+    #[test]
+    fn non_daemon_batch_commands_reject_firecracker_before_spawning_work() {
+        let error = resolve_batch_backend(
+            Some(crate::backend::BackendType::Firecracker),
+            "parallel jobs",
+        )
+        .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("authoritative Firecracker daemon")
+        );
+        assert_eq!(
+            resolve_batch_backend(Some(crate::backend::BackendType::Docker), "parallel jobs")
+                .unwrap(),
+            crate::backend::BackendType::Docker
+        );
+    }
+
+    #[test]
+    fn firecracker_connection_guidance_never_recommends_attach() {
+        assert_eq!(
+            sandbox_connection_command("demo", true, false),
+            "agentkernel exec demo -- <command>"
+        );
+        assert_eq!(
+            sandbox_connection_command("demo", true, true),
+            "agentkernel ssh demo"
+        );
+        assert_eq!(
+            sandbox_connection_command("demo", false, false),
+            "agentkernel attach demo"
+        );
     }
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -79,6 +79,23 @@ struct JsonRpcError {
     data: Option<Value>,
 }
 
+fn reject_fresh_manager_firecracker(
+    manager: &VmManager,
+    sandbox: Option<&str>,
+    operation: &str,
+) -> Result<()> {
+    let backend = sandbox
+        .and_then(|name| manager.get_state(name))
+        .and_then(|state| state.backend)
+        .unwrap_or(manager.backend());
+    if backend == crate::backend::BackendType::Firecracker {
+        anyhow::bail!(
+            "MCP operation '{operation}' is not yet routed through the authoritative Firecracker daemon; use the delegated sandbox lifecycle/exec tools or select another backend"
+        );
+    }
+    Ok(())
+}
+
 impl McpServer {
     pub fn new() -> Self {
         Self {
@@ -405,6 +422,52 @@ impl McpServer {
                             }
                         },
                         "required": ["name"]
+                    }
+                },
+                {
+                    "name": "sandbox_pause",
+                    "description": "Pause a running Firecracker sandbox into a durable full-VM checkpoint that preserves guest memory and processes.",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "description": "Name of the running Firecracker sandbox to pause"
+                            }
+                        },
+                        "required": ["name"]
+                    }
+                },
+                {
+                    "name": "sandbox_resume",
+                    "description": "Resume a paused Firecracker sandbox from its full-VM checkpoint.",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "description": "Name of the paused Firecracker sandbox to resume"
+                            }
+                        },
+                        "required": ["name"]
+                    }
+                },
+                {
+                    "name": "sandbox_fork",
+                    "description": "Fork a paused Firecracker sandbox into a new running sandbox. The paused source remains reusable. The fork copies guest memory and filesystem state, including any credentials captured in the checkpoint.",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "type": "string",
+                                "description": "Name of the paused source sandbox"
+                            },
+                            "as_name": {
+                                "type": "string",
+                                "description": "Name for the new running sandbox"
+                            }
+                        },
+                        "required": ["name", "as_name"]
                     }
                 },
                 {
@@ -924,6 +987,9 @@ impl McpServer {
                 .map(ToolOutput::Text),
             "sandbox_start" => self.tool_sandbox_start(&arguments).map(ToolOutput::Text),
             "sandbox_stop" => self.tool_sandbox_stop(&arguments).map(ToolOutput::Text),
+            "sandbox_pause" => self.tool_sandbox_pause(&arguments).map(ToolOutput::Text),
+            "sandbox_resume" => self.tool_sandbox_resume(&arguments).map(ToolOutput::Text),
+            "sandbox_fork" => self.tool_sandbox_fork(&arguments).map(ToolOutput::Text),
             "sandbox_exec_detach" => self
                 .tool_sandbox_exec_detach(&arguments)
                 .map(ToolOutput::Text),
@@ -1095,6 +1161,7 @@ impl McpServer {
         tokio::task::block_in_place(|| {
             Handle::current().block_on(async {
                 let mut manager = VmManager::new()?;
+                reject_fresh_manager_firecracker(&manager, None, "sandbox_run fast=false")?;
 
                 // Use optimized ephemeral run with permissions
                 manager
@@ -1159,10 +1226,38 @@ impl McpServer {
         tokio::task::block_in_place(|| {
             Handle::current().block_on(async {
                 let mut manager = VmManager::new()?;
+                if manager.backend() == crate::backend::BackendType::Firecracker {
+                    let port = crate::local_api_port();
+                    if !crate::try_server_health("127.0.0.1", port).await {
+                        return Err(crate::firecracker_server_required("create", port));
+                    }
+                }
                 manager
                     .create_with_options(name, image, 1, 512, None, ports)
                     .await?;
-                manager.start(name).await?;
+                let backend = manager
+                    .get_state(name)
+                    .and_then(|state| state.backend)
+                    .unwrap_or(manager.backend());
+                let firecracker = backend == crate::backend::BackendType::Firecracker;
+                let port = crate::local_api_port();
+                if firecracker {
+                    if !crate::try_server_health("127.0.0.1", port).await {
+                        return Err(crate::firecracker_server_required("start", port));
+                    }
+                    let permissions = crate::permissions::Permissions::default();
+                    crate::delegate_configured_start_to_server(
+                        "127.0.0.1",
+                        port,
+                        name,
+                        &manager,
+                        &permissions,
+                        &[],
+                    )
+                    .await?;
+                } else {
+                    manager.start(name).await?;
+                }
 
                 let mut result = format!(
                     "Sandbox '{}' created and started with image '{}'{}",
@@ -1176,7 +1271,18 @@ impl McpServer {
                         "-c".to_string(),
                         "which git >/dev/null 2>&1 || apk add --no-cache git >/dev/null 2>&1 || apt-get update -qq && apt-get install -y -qq git >/dev/null 2>&1 || true".to_string(),
                     ];
-                    let _ = manager.exec_cmd(name, &install).await;
+                    if firecracker {
+                        let _ = crate::delegate_sandbox_action_to_server(
+                            "127.0.0.1",
+                            port,
+                            name,
+                            "exec",
+                            Some(json!({"command": install})),
+                        )
+                        .await;
+                    } else {
+                        let _ = manager.exec_cmd(name, &install).await;
+                    }
 
                     let clone = vec![
                         "git".to_string(),
@@ -1184,7 +1290,18 @@ impl McpServer {
                         url.clone(),
                         "/workspace".to_string(),
                     ];
-                    manager.exec_cmd(name, &clone).await?;
+                    if firecracker {
+                        crate::delegate_sandbox_action_to_server(
+                            "127.0.0.1",
+                            port,
+                            name,
+                            "exec",
+                            Some(json!({"command": clone})),
+                        )
+                        .await?;
+                    } else {
+                        manager.exec_cmd(name, &clone).await?;
+                    }
 
                     if let Some(ref git_ref) = source_ref {
                         let checkout = vec![
@@ -1194,7 +1311,18 @@ impl McpServer {
                             "checkout".to_string(),
                             git_ref.clone(),
                         ];
-                        manager.exec_cmd(name, &checkout).await?;
+                        if firecracker {
+                            crate::delegate_sandbox_action_to_server(
+                                "127.0.0.1",
+                                port,
+                                name,
+                                "exec",
+                                Some(json!({"command": checkout})),
+                            )
+                            .await?;
+                        } else {
+                            manager.exec_cmd(name, &checkout).await?;
+                        }
                         result.push_str(&format!(". Cloned {} (ref: {}) into /workspace", url, git_ref));
                     } else {
                         result.push_str(&format!(". Cloned {} into /workspace", url));
@@ -1252,7 +1380,31 @@ impl McpServer {
         tokio::task::block_in_place(|| {
             Handle::current().block_on(async {
                 let mut manager = VmManager::new()?;
-                manager.exec_cmd_full(name, &command, &opts).await
+                if !manager.exists(name) {
+                    anyhow::bail!("Sandbox '{}' not found.", name);
+                }
+                let backend = manager
+                    .get_state(name)
+                    .and_then(|state| state.backend)
+                    .unwrap_or(manager.backend());
+                if backend == crate::backend::BackendType::Firecracker {
+                    let port = crate::local_api_port();
+                    if !crate::try_server_health("127.0.0.1", port).await {
+                        return Err(crate::firecracker_server_required("exec", port));
+                    }
+                    crate::delegate_exec_to_server(
+                        "127.0.0.1",
+                        port,
+                        name,
+                        &command,
+                        &opts.env,
+                        opts.workdir.as_deref(),
+                        sudo,
+                    )
+                    .await
+                } else {
+                    manager.exec_cmd_full(name, &command, &opts).await
+                }
             })
         })
     }
@@ -1269,11 +1421,27 @@ impl McpServer {
 
                 let mut output = String::from("NAME\tSTATUS\tBACKEND\tIP\tPORTS\n");
                 for (name, running, backend) in &sandboxes {
-                    let status = if *running { "running" } else { "stopped" };
+                    let local_status = manager
+                        .get_state(name)
+                        .map(|state| state.status(*running))
+                        .unwrap_or(if *running { "running" } else { "stopped" })
+                        .to_string();
+                    let authoritative =
+                        if *backend == Some(crate::backend::BackendType::Firecracker) {
+                            crate::delegated_firecracker_status(name).await?
+                        } else {
+                            None
+                        };
+                    let status = authoritative
+                        .as_ref()
+                        .map(|status| status.status.as_str())
+                        .unwrap_or(&local_status);
                     let backend_str = backend
                         .map(|b| format!("{}", b))
                         .unwrap_or_else(|| "unknown".to_string());
-                    let ip_str = if *running {
+                    let ip_str = if let Some(authoritative) = authoritative.as_ref() {
+                        authoritative.ip.clone().unwrap_or_else(|| "-".to_string())
+                    } else if *running {
                         manager
                             .get_container_ip(name)
                             .unwrap_or_else(|| "-".to_string())
@@ -1315,7 +1483,7 @@ impl McpServer {
         tokio::task::block_in_place(|| {
             Handle::current().block_on(async {
                 let mut manager = VmManager::new()?;
-                manager.remove(name).await?;
+                crate::remove_sandbox_via_authoritative_manager(&mut manager, name).await?;
                 Ok(format!("Sandbox '{}' removed.", name))
             })
         })
@@ -1340,6 +1508,7 @@ impl McpServer {
         tokio::task::block_in_place(|| {
             Handle::current().block_on(async {
                 let mut manager = VmManager::new()?;
+                reject_fresh_manager_firecracker(&manager, Some(name), "sandbox_file_write")?;
 
                 if !manager.is_running(name) {
                     anyhow::bail!(
@@ -1373,6 +1542,7 @@ impl McpServer {
         tokio::task::block_in_place(|| {
             Handle::current().block_on(async {
                 let mut manager = VmManager::new()?;
+                reject_fresh_manager_firecracker(&manager, Some(name), "sandbox_file_read")?;
 
                 if !manager.is_running(name) {
                     anyhow::bail!(
@@ -1417,6 +1587,7 @@ impl McpServer {
         tokio::task::block_in_place(|| {
             Handle::current().block_on(async {
                 let mut manager = VmManager::new()?;
+                reject_fresh_manager_firecracker(&manager, Some(name), "sandbox_write_files")?;
 
                 if !manager.is_running(name) {
                     anyhow::bail!(
@@ -1458,7 +1629,28 @@ impl McpServer {
                     return Ok(format!("Sandbox '{}' is already running.", name));
                 }
 
-                manager.start(name).await?;
+                let backend = manager
+                    .get_state(name)
+                    .and_then(|state| state.backend)
+                    .unwrap_or(manager.backend());
+                if backend == crate::backend::BackendType::Firecracker {
+                    let port = crate::local_api_port();
+                    if !crate::try_server_health("127.0.0.1", port).await {
+                        return Err(crate::firecracker_server_required("start", port));
+                    }
+                    let permissions = crate::permissions::Permissions::default();
+                    crate::delegate_configured_start_to_server(
+                        "127.0.0.1",
+                        port,
+                        name,
+                        &manager,
+                        &permissions,
+                        &[],
+                    )
+                    .await?;
+                } else {
+                    manager.start(name).await?;
+                }
                 Ok(format!("Sandbox '{}' started.", name))
             })
         })
@@ -1478,12 +1670,159 @@ impl McpServer {
                     anyhow::bail!("Sandbox '{}' not found.", name);
                 }
 
-                if !manager.is_running(name) {
+                let backend = manager
+                    .get_state(name)
+                    .and_then(|state| state.backend)
+                    .unwrap_or(manager.backend());
+                if backend == crate::backend::BackendType::Firecracker {
+                    let port = crate::local_api_port();
+                    if !crate::try_server_health("127.0.0.1", port).await {
+                        return Err(crate::firecracker_server_required("stop", port));
+                    }
+                    crate::delegate_sandbox_action_to_server("127.0.0.1", port, name, "stop", None)
+                        .await?;
+                } else if !manager.is_running(name) {
                     return Ok(format!("Sandbox '{}' is already stopped.", name));
+                } else {
+                    manager.stop(name).await?;
+                }
+                Ok(format!("Sandbox '{}' stopped.", name))
+            })
+        })
+    }
+
+    fn tool_sandbox_pause(&self, args: &Value) -> Result<String> {
+        let name = args
+            .get("name")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow::anyhow!("name is required"))?;
+        crate::validation::validate_sandbox_name(name)?;
+
+        tokio::task::block_in_place(|| {
+            Handle::current().block_on(async {
+                let mut manager = VmManager::new()?;
+                if !manager.exists(name) {
+                    anyhow::bail!("Sandbox '{}' not found.", name);
                 }
 
-                manager.stop(name).await?;
-                Ok(format!("Sandbox '{}' stopped.", name))
+                let backend = manager
+                    .get_state(name)
+                    .and_then(|state| state.backend)
+                    .unwrap_or(manager.backend());
+                if backend == crate::backend::BackendType::Firecracker {
+                    let port = crate::local_api_port();
+                    if !crate::try_server_health("127.0.0.1", port).await {
+                        return Err(crate::firecracker_server_required("pause", port));
+                    }
+                    crate::delegate_sandbox_action_to_server(
+                        "127.0.0.1",
+                        port,
+                        name,
+                        "pause",
+                        None,
+                    )
+                    .await?;
+                } else {
+                    manager.pause(name).await?;
+                }
+                Ok(format!(
+                    "Sandbox '{}' paused. Resume it with sandbox_resume.",
+                    name
+                ))
+            })
+        })
+    }
+
+    fn tool_sandbox_resume(&self, args: &Value) -> Result<String> {
+        let name = args
+            .get("name")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow::anyhow!("name is required"))?;
+        crate::validation::validate_sandbox_name(name)?;
+
+        tokio::task::block_in_place(|| {
+            Handle::current().block_on(async {
+                let mut manager = VmManager::new()?;
+                if !manager.exists(name) {
+                    anyhow::bail!("Sandbox '{}' not found.", name);
+                }
+
+                let backend = manager
+                    .get_state(name)
+                    .and_then(|state| state.backend)
+                    .unwrap_or(manager.backend());
+                if backend == crate::backend::BackendType::Firecracker {
+                    let port = crate::local_api_port();
+                    if !crate::try_server_health("127.0.0.1", port).await {
+                        return Err(crate::firecracker_server_required("resume", port));
+                    }
+                    crate::delegate_sandbox_action_to_server(
+                        "127.0.0.1",
+                        port,
+                        name,
+                        "resume",
+                        None,
+                    )
+                    .await?;
+                } else {
+                    manager.resume(name).await?;
+                }
+                Ok(format!("Sandbox '{}' resumed.", name))
+            })
+        })
+    }
+
+    fn tool_sandbox_fork(&self, args: &Value) -> Result<String> {
+        let source = args
+            .get("name")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow::anyhow!("name is required"))?;
+        let child = args
+            .get("as_name")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow::anyhow!("as_name is required"))?;
+        crate::validation::validate_sandbox_name(source)?;
+        crate::validation::validate_sandbox_name(child)?;
+
+        self.require_permission(
+            crate::interactive_permissions::PermissionKind::SandboxCreate,
+            Some(child),
+        )?;
+
+        tokio::task::block_in_place(|| {
+            Handle::current().block_on(async {
+                let mut manager = VmManager::new()?;
+                if !manager.exists(source) {
+                    anyhow::bail!("Sandbox '{}' not found.", source);
+                }
+                if manager.exists(child) {
+                    anyhow::bail!("Sandbox '{}' already exists.", child);
+                }
+
+                let backend = manager
+                    .get_state(source)
+                    .and_then(|state| state.backend)
+                    .unwrap_or(manager.backend());
+                if backend == crate::backend::BackendType::Firecracker {
+                    let port = crate::local_api_port();
+                    if !crate::try_server_health("127.0.0.1", port).await {
+                        return Err(crate::firecracker_server_required("fork", port));
+                    }
+                    crate::delegate_sandbox_action_to_server(
+                        "127.0.0.1",
+                        port,
+                        source,
+                        "fork",
+                        Some(json!({"as_name": child})),
+                    )
+                    .await?;
+                } else {
+                    manager.fork_sandbox(source, child).await?;
+                }
+                Ok(format!(
+                    "Sandbox '{}' forked from '{}' and is running. The source remains paused and reusable.\n\nSecurity warning: {}",
+                    child, source, crate::full_state::FORK_SECURITY_WARNING
+                ))
             })
         })
     }
@@ -1518,6 +1857,7 @@ impl McpServer {
         tokio::task::block_in_place(|| {
             Handle::current().block_on(async {
                 let mut manager = VmManager::new()?;
+                reject_fresh_manager_firecracker(&manager, Some(name), "sandbox_exec_detach")?;
                 let opts = crate::backend::ExecOptions {
                     env,
                     workdir,
@@ -1590,15 +1930,16 @@ impl McpServer {
 
         let by = args.get("by").and_then(|v| v.as_str()).unwrap_or("1h");
 
-        // Parse the time string into seconds
-        let additional_secs = crate::ssh::parse_ttl_to_secs(by)?;
-
         let mut manager = VmManager::new()?;
         if !manager.exists(name) {
             anyhow::bail!("Sandbox '{}' not found", name);
         }
 
-        let new_expiry = manager.extend_ttl(name, additional_secs)?;
+        let new_expiry = tokio::task::block_in_place(|| {
+            Handle::current().block_on(async {
+                crate::extend_ttl_via_authoritative_manager(&mut manager, name, by).await
+            })
+        })?;
 
         match new_expiry {
             Some(exp) => Ok(format!(
@@ -1744,6 +2085,7 @@ impl McpServer {
         tokio::task::block_in_place(|| {
             Handle::current().block_on(async {
                 let mut manager = VmManager::new()?;
+                reject_fresh_manager_firecracker(&manager, None, "browser_create")?;
                 manager
                     .create_with_options(
                         name,
@@ -1785,6 +2127,7 @@ impl McpServer {
         tokio::task::block_in_place(|| {
             Handle::current().block_on(async {
                 let mut manager = VmManager::new()?;
+                reject_fresh_manager_firecracker(&manager, Some(name), "browser_goto")?;
                 let cmd = vec![
                     "python3".to_string(),
                     "-c".to_string(),
@@ -1810,6 +2153,7 @@ impl McpServer {
         tokio::task::block_in_place(|| {
             Handle::current().block_on(async {
                 let mut manager = VmManager::new()?;
+                reject_fresh_manager_firecracker(&manager, Some(name), "browser_screenshot")?;
                 let cmd = vec![
                     "python3".to_string(),
                     "-c".to_string(),
@@ -1844,6 +2188,7 @@ impl McpServer {
         tokio::task::block_in_place(|| {
             Handle::current().block_on(async {
                 let mut manager = VmManager::new()?;
+                reject_fresh_manager_firecracker(&manager, Some(name), "browser_evaluate")?;
                 let cmd = vec![
                     "python3".to_string(),
                     "-c".to_string(),
@@ -1868,6 +2213,7 @@ impl McpServer {
         tokio::task::block_in_place(|| {
             Handle::current().block_on(async {
                 let mut manager = VmManager::new()?;
+                reject_fresh_manager_firecracker(&manager, Some(name), "browser server")?;
 
                 // Check if server is already running
                 let health_cmd = vec![
@@ -1917,6 +2263,7 @@ impl McpServer {
         tokio::task::block_in_place(|| {
             Handle::current().block_on(async {
                 let mut manager = VmManager::new()?;
+                reject_fresh_manager_firecracker(&manager, Some(name), "browser request")?;
                 let mut cmd = vec![
                     "python3".to_string(),
                     "-c".to_string(),
@@ -2317,6 +2664,30 @@ mod tests {
         assert!(tool_names.contains(&"sandbox_file_read"));
         assert!(tool_names.contains(&"sandbox_start"));
         assert!(tool_names.contains(&"sandbox_stop"));
+        assert!(tool_names.contains(&"sandbox_pause"));
+        assert!(tool_names.contains(&"sandbox_resume"));
+        assert!(tool_names.contains(&"sandbox_fork"));
+    }
+
+    #[test]
+    fn test_full_state_tool_schemas() {
+        let server = McpServer::new();
+        let response = server.handle_tools_list(Value::Number(1.into()));
+        let result = response.result.unwrap();
+        let tools = result.get("tools").and_then(Value::as_array).unwrap();
+
+        let fork = tools
+            .iter()
+            .find(|tool| tool["name"] == "sandbox_fork")
+            .unwrap();
+        assert_eq!(fork["inputSchema"]["required"], json!(["name", "as_name"]));
+        assert!(
+            fork["description"]
+                .as_str()
+                .unwrap()
+                .contains("credentials")
+        );
+        assert!(crate::full_state::FORK_SECURITY_WARNING.contains("cryptographic tokens"));
     }
 
     // === handle_request tests ===
@@ -2496,6 +2867,44 @@ mod tests {
         let result = server.tool_sandbox_stop(&json!({}));
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("name is required"));
+    }
+
+    #[test]
+    fn test_tool_sandbox_pause_missing_name() {
+        let server = McpServer::new();
+        let result = server.tool_sandbox_pause(&json!({}));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("name is required"));
+    }
+
+    #[test]
+    fn test_tool_sandbox_resume_missing_name() {
+        let server = McpServer::new();
+        let result = server.tool_sandbox_resume(&json!({}));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("name is required"));
+    }
+
+    #[test]
+    fn test_tool_sandbox_fork_missing_parameters() {
+        let server = McpServer::new();
+        let missing_source = server.tool_sandbox_fork(&json!({"as_name": "child"}));
+        assert!(missing_source.is_err());
+        assert!(
+            missing_source
+                .unwrap_err()
+                .to_string()
+                .contains("name is required")
+        );
+
+        let missing_child = server.tool_sandbox_fork(&json!({"name": "source"}));
+        assert!(missing_child.is_err());
+        assert!(
+            missing_child
+                .unwrap_err()
+                .to_string()
+                .contains("as_name is required")
+        );
     }
 
     // === Browser tool tests ===

--- a/src/quota.rs
+++ b/src/quota.rs
@@ -293,12 +293,25 @@ impl QuotaController {
             org_id: owner_org.to_string(),
         };
         let (user_usage, org_usage) = self.usage_for(manager, &subject);
-        Self::check_scope("user", &self.user_limits(&subject), &user_usage, 1, 0, 0, 0)?;
+        // Recovery may already own a confirmed-live runtime while its
+        // persisted state still says paused. Rechecking start must preserve
+        // that existing slot rather than charging a second one and making
+        // metadata reconciliation impossible at the quota limit.
+        let additional_running = u32::from(!manager.is_running(name));
+        Self::check_scope(
+            "user",
+            &self.user_limits(&subject),
+            &user_usage,
+            additional_running,
+            0,
+            0,
+            0,
+        )?;
         Self::check_scope(
             "organization",
             &self.organization_limits(&subject),
             &org_usage,
-            1,
+            additional_running,
             0,
             0,
             0,
@@ -420,6 +433,11 @@ mod tests {
             dormant_at: None,
             dormant_reason: None,
             lifecycle_policy: None,
+            full_state_checkpoint: None,
+            full_state_cleanup_pending: Vec::new(),
+            full_state_lineage: false,
+            paused_at: None,
+            forked_from: None,
             owner_user_id: Some(user.to_string()),
             owner_org_id: Some(org.to_string()),
         }

--- a/src/vmm.rs
+++ b/src/vmm.rs
@@ -6994,7 +6994,7 @@ mod tests {
     #[tokio::test]
     async fn test_reconcile_lifecycle_deletes_archived_sandbox() {
         let temp_dir = TempDir::new().unwrap();
-        let mut manager = new_test_manager(&temp_dir);
+        let mut manager = VmManager::for_tests(temp_dir.path()).unwrap();
         let mut state = lifecycle_state("delete-now");
         state.archived_at = Some((chrono::Utc::now() - chrono::Duration::hours(2)).to_rfc3339());
         state.archived_reason = Some("stale".to_string());

--- a/src/vmm.rs
+++ b/src/vmm.rs
@@ -5,12 +5,14 @@
 
 use crate::audit::{AuditEvent, log_event};
 use crate::backend::{
-    BackendType, FileInjection, PortMapping, RemoteSandboxContext, ResolvedEndpoint, Sandbox,
-    SandboxConfig, SandboxRuntimeMetadata, backend_capabilities, create_sandbox,
-    create_sandbox_with_state, detect_best_backend,
+    BackendType, FileInjection, FullStatePauseError, FullStateSnapshot, FullStateTerminationError,
+    PortMapping, RemoteSandboxContext, ResolvedEndpoint, Sandbox, SandboxConfig,
+    SandboxRuntimeMetadata, backend_capabilities, create_sandbox, create_sandbox_with_state,
+    detect_best_backend,
 };
 use crate::config::Config;
 use crate::docker_backend::detect_container_runtime;
+use crate::full_state::{FullStateCheckpoint, FullStateCheckpointStore};
 use crate::languages::docker_image_to_firecracker_runtime;
 use crate::permissions::Permissions;
 use crate::pool::ContainerPool;
@@ -297,6 +299,22 @@ pub struct SandboxState {
     /// Optional lifecycle automation policy.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub lifecycle_policy: Option<SandboxLifecyclePolicy>,
+    /// Durable Firecracker full-state checkpoint used while this sandbox is paused.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub full_state_checkpoint: Option<String>,
+    /// Published checkpoints awaiting best-effort deletion after consumption.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub full_state_cleanup_pending: Vec<String>,
+    /// True after this sandbox has restored mutable disk state from a full-state checkpoint.
+    /// This is dedicated metadata because user-editable labels cannot enforce safety.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub full_state_lineage: bool,
+    /// Timestamp at which the running Firecracker VM was paused to zero compute.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub paused_at: Option<String>,
+    /// Source sandbox name when this sandbox was created by a full-state fork.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub forked_from: Option<String>,
 }
 
 impl SandboxState {
@@ -306,6 +324,8 @@ impl SandboxState {
             "archived"
         } else if self.dormant_at.is_some() {
             "dormant"
+        } else if self.paused_at.is_some() {
+            "paused"
         } else if running {
             "running"
         } else {
@@ -411,6 +431,15 @@ pub struct VmManager {
     backend: BackendType,
     /// Running sandboxes (unified interface)
     running: HashMap<String, Box<dyn Sandbox>>,
+    /// Interrupted pause transitions retained after automatic recovery fails.
+    /// Entries own either a possibly-live source runtime, safe completed
+    /// staging metadata, or both. Only resume or explicit removal may consume
+    /// them; normal exec paths must never expose these transitional states.
+    pause_recovery: HashMap<String, PendingFullStateRecovery>,
+    /// Running runtimes whose post-resume metadata write failed. A repeated
+    /// resume retries only the atomic state publication; it never starts a
+    /// second VM or destroys the retained runtime.
+    resume_state_recovery: HashMap<String, SandboxState>,
     /// Persisted sandbox configurations
     sandboxes: HashMap<String, SandboxState>,
     /// Data directory for persistence
@@ -431,6 +460,31 @@ pub struct VmManager {
     /// Enterprise policy engine (when enterprise feature is enabled)
     #[cfg(feature = "enterprise")]
     policy_engine: Option<Arc<crate::policy::PolicyEngine>>,
+}
+
+struct PendingFullStateRecovery {
+    sandbox: Option<Box<dyn Sandbox>>,
+    staging_path: PathBuf,
+    completed_snapshot: Option<FullStateSnapshot>,
+}
+
+fn runtime_may_survive_failed_stop(error: &anyhow::Error, probe_running: bool) -> bool {
+    error
+        .downcast_ref::<FullStateTerminationError>()
+        .map_or(probe_running, |failure| failure.process_may_be_running)
+}
+
+fn with_full_state_cleanup_intent(mut state: SandboxState, checkpoint_id: &str) -> SandboxState {
+    if !state
+        .full_state_cleanup_pending
+        .iter()
+        .any(|id| id == checkpoint_id)
+    {
+        state
+            .full_state_cleanup_pending
+            .push(checkpoint_id.to_string());
+    }
+    state
 }
 
 /// Escape a string for use inside a single-quoted shell command.
@@ -460,6 +514,8 @@ impl VmManager {
         Ok(Self {
             backend: BackendType::Docker,
             running: HashMap::new(),
+            pause_recovery: HashMap::new(),
+            resume_state_recovery: HashMap::new(),
             sandboxes: HashMap::new(),
             data_dir: data_dir.to_path_buf(),
             volume_base_dir: None,
@@ -535,6 +591,8 @@ impl VmManager {
         let mut manager = Self {
             backend,
             running: HashMap::new(),
+            pause_recovery: HashMap::new(),
+            resume_state_recovery: HashMap::new(),
             sandboxes,
             data_dir,
             volume_base_dir: None,
@@ -549,6 +607,8 @@ impl VmManager {
 
         // Detect already-running sandboxes
         manager.detect_running_sandboxes();
+        manager.reconcile_full_state_cleanup();
+        manager.report_full_state_recovery_state();
 
         crate::metrics::set_active_sandboxes(manager.sandboxes.len() as i64);
 
@@ -672,6 +732,107 @@ impl VmManager {
         }
     }
 
+    /// Report interrupted pause transitions without deleting artifacts that
+    /// could still belong to another live manager. Deterministic staging names
+    /// let operators correlate a paused sandbox with its recovery directory.
+    fn report_full_state_recovery_state(&self) {
+        let Ok(store) = FullStateCheckpointStore::new(&self.data_dir) else {
+            return;
+        };
+        let referenced: std::collections::HashSet<String> = self
+            .sandboxes
+            .values()
+            .filter(|state| state.paused_at.is_some())
+            .filter_map(|state| state.full_state_checkpoint.clone())
+            .collect();
+
+        if let Ok(entries) = store.staging_entries() {
+            for (id, path) in entries {
+                if id.as_ref().is_some_and(|id| referenced.contains(id)) {
+                    let recovery_ready = id
+                        .as_deref()
+                        .is_some_and(|id| store.recovery_is_ready(id).unwrap_or(false));
+                    if recovery_ready {
+                        eprintln!(
+                            "Warning: interrupted full-state pause retained recovery-ready staging at {}; the next resume or fork will publish it",
+                            path.display()
+                        );
+                    } else {
+                        eprintln!(
+                            "Warning: interrupted full-state pause retained diagnostic staging at {}; automatic restore is unavailable until the transition is reconciled",
+                            path.display()
+                        );
+                    }
+                } else {
+                    eprintln!(
+                        "Warning: orphaned full-state checkpoint staging retained at {}; it was not deleted because another manager may still own the transition",
+                        path.display()
+                    );
+                }
+            }
+        }
+
+        for id in referenced {
+            let published = store.contains(&id).unwrap_or(false);
+            let staged = store.staging_path(&id).is_ok_and(|path| path.is_dir());
+            if !published && !staged {
+                eprintln!(
+                    "Warning: paused sandbox references missing full-state checkpoint '{id}'"
+                );
+            }
+        }
+    }
+
+    fn delete_full_state_artifacts(
+        store: &FullStateCheckpointStore,
+        checkpoint_id: &str,
+    ) -> Result<()> {
+        store.delete(checkpoint_id)?;
+        let staging_path = store.staging_path(checkpoint_id)?;
+        store.discard_staging(&staging_path)
+    }
+
+    /// Retry durable deletion intents left after a checkpoint was consumed.
+    /// The intent is cleared only after both published and staging locations
+    /// are absent and the updated sandbox state is atomically persisted.
+    fn reconcile_full_state_cleanup(&mut self) {
+        let Ok(store) = FullStateCheckpointStore::new(&self.data_dir) else {
+            return;
+        };
+        let names: Vec<String> = self.sandboxes.keys().cloned().collect();
+        for name in names {
+            let Some(current) = self.sandboxes.get(&name).cloned() else {
+                continue;
+            };
+            if current.full_state_cleanup_pending.is_empty() {
+                continue;
+            }
+            let mut remaining = Vec::new();
+            for checkpoint_id in &current.full_state_cleanup_pending {
+                if let Err(error) = Self::delete_full_state_artifacts(&store, checkpoint_id) {
+                    eprintln!(
+                        "Warning: failed to finish checkpoint cleanup '{}' for sandbox '{}': {error:#}",
+                        checkpoint_id, name
+                    );
+                    remaining.push(checkpoint_id.clone());
+                }
+            }
+            if remaining == current.full_state_cleanup_pending {
+                continue;
+            }
+            let mut updated = current;
+            updated.full_state_cleanup_pending = remaining;
+            if let Err(error) = self.save_sandbox(&updated) {
+                eprintln!(
+                    "Warning: checkpoint artifacts were deleted for sandbox '{}', but its cleanup intent could not be cleared: {error:#}",
+                    name
+                );
+                continue;
+            }
+            self.sandboxes.insert(name, updated);
+        }
+    }
+
     /// Get the data directory
     fn data_dir() -> PathBuf {
         if let Some(home) = std::env::var_os("HOME") {
@@ -721,23 +882,36 @@ impl VmManager {
 
     /// Save a sandbox state to disk
     fn save_sandbox(&self, state: &SandboxState) -> Result<()> {
-        let path = self
-            .data_dir
-            .join("sandboxes")
-            .join(format!("{}.json", state.name));
-        let content = serde_json::to_string_pretty(state)?;
-        std::fs::write(path, content)?;
+        let directory = self.data_dir.join("sandboxes");
+        std::fs::create_dir_all(&directory)?;
+        let path = directory.join(format!("{}.json", state.name));
+        let content = serde_json::to_vec_pretty(state)?;
+        let mut staging =
+            tempfile::NamedTempFile::new_in(&directory).context("failed to stage sandbox state")?;
+        std::io::Write::write_all(staging.as_file_mut(), &content)?;
+        staging.as_file().sync_all()?;
+        staging
+            .persist(&path)
+            .map_err(|error| error.error)
+            .with_context(|| format!("failed to publish sandbox state {}", path.display()))?;
+        // The state is atomically visible after rename. A directory fsync
+        // failure is advisory: reporting it as a failed write would cause
+        // callers to roll back after the new state is already published.
+        if let Err(error) = std::fs::File::open(&directory).and_then(|dir| dir.sync_all()) {
+            eprintln!("Warning: failed to sync sandbox state directory: {error}");
+        }
         Ok(())
     }
 
     /// Delete a sandbox state from disk
     fn delete_sandbox(&self, name: &str) -> Result<()> {
-        let path = self
-            .data_dir
-            .join("sandboxes")
-            .join(format!("{}.json", name));
+        let directory = self.data_dir.join("sandboxes");
+        let path = directory.join(format!("{}.json", name));
         if path.exists() {
             std::fs::remove_file(path)?;
+            if let Err(error) = std::fs::File::open(&directory).and_then(|dir| dir.sync_all()) {
+                eprintln!("Warning: failed to sync sandbox state deletion: {error}");
+            }
         }
         Ok(())
     }
@@ -1096,6 +1270,11 @@ impl VmManager {
             dormant_at: None,
             dormant_reason: None,
             lifecycle_policy: None,
+            full_state_checkpoint: None,
+            full_state_cleanup_pending: Vec::new(),
+            full_state_lineage: false,
+            paused_at: None,
+            forked_from: None,
         };
 
         self.save_sandbox(&state)?;
@@ -1360,18 +1539,14 @@ impl VmManager {
         let tenant_id = tenant_id
             .map(|value| value.trim().to_string())
             .filter(|value| !value.is_empty());
-        {
-            let state = self
-                .sandboxes
-                .get_mut(name)
-                .ok_or_else(|| anyhow::anyhow!("Sandbox '{}' not found", name))?;
-            state.tenant_id = tenant_id;
-        }
-        let state = self
+        let mut state = self
             .sandboxes
             .get(name)
+            .cloned()
             .ok_or_else(|| anyhow::anyhow!("Sandbox '{}' not found", name))?;
-        self.save_sandbox(state)?;
+        state.tenant_id = tenant_id;
+        self.save_sandbox(&state)?;
+        self.sandboxes.insert(name.to_string(), state);
         Ok(())
     }
 
@@ -1411,14 +1586,39 @@ impl VmManager {
 
     /// Persist trusted ownership metadata supplied by the authenticated API.
     pub fn set_owner_identity(&mut self, name: &str, tenant: &str, user: &str) -> Result<()> {
-        let state = self
+        let mut state = self
             .sandboxes
-            .get_mut(name)
+            .get(name)
+            .cloned()
             .ok_or_else(|| anyhow::anyhow!("Sandbox '{}' not found", name))?;
         state.owner_org_id = Some(tenant.to_string());
         state.owner_user_id = Some(user.to_string());
-        let snapshot = state.clone();
-        self.save_sandbox(&snapshot)?;
+        self.save_sandbox(&state)?;
+        self.sandboxes.insert(name.to_string(), state);
+        Ok(())
+    }
+
+    /// Atomically persist the trusted tenant and owner established by an
+    /// authenticated first-start claim, then publish it in memory.
+    pub fn set_trusted_ownership(
+        &mut self,
+        name: &str,
+        tenant_id: Option<String>,
+        user_id: Option<&str>,
+        org_id: Option<&str>,
+    ) -> Result<()> {
+        let mut state = self
+            .sandboxes
+            .get(name)
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("Sandbox '{}' not found", name))?;
+        state.tenant_id = tenant_id
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+        state.owner_user_id = user_id.map(ToString::to_string);
+        state.owner_org_id = org_id.map(ToString::to_string);
+        self.save_sandbox(&state)?;
+        self.sandboxes.insert(name.to_string(), state);
         Ok(())
     }
 
@@ -1465,14 +1665,15 @@ impl VmManager {
         user_id: Option<&str>,
         org_id: Option<&str>,
     ) -> Result<()> {
-        let state = self
+        let mut state = self
             .sandboxes
-            .get_mut(name)
+            .get(name)
+            .cloned()
             .ok_or_else(|| anyhow::anyhow!("Sandbox '{}' not found", name))?;
         state.owner_user_id = user_id.map(ToString::to_string);
         state.owner_org_id = org_id.map(ToString::to_string);
-        let snapshot = state.clone();
-        self.save_sandbox(&snapshot)?;
+        self.save_sandbox(&state)?;
+        self.sandboxes.insert(name.to_string(), state);
         Ok(())
     }
 
@@ -1494,13 +1695,14 @@ impl VmManager {
         name: &str,
         policy: Option<SandboxLifecyclePolicy>,
     ) -> Result<()> {
-        let state = self
+        let mut state = self
             .sandboxes
-            .get_mut(name)
+            .get(name)
+            .cloned()
             .ok_or_else(|| anyhow::anyhow!("Sandbox '{}' not found", name))?;
         state.lifecycle_policy = policy;
-        let snapshot = state.clone();
-        self.save_sandbox(&snapshot)?;
+        self.save_sandbox(&state)?;
+        self.sandboxes.insert(name.to_string(), state);
         Ok(())
     }
 
@@ -1518,15 +1720,16 @@ impl VmManager {
 
     /// Mark a stopped sandbox dormant after a configured period of disuse.
     pub fn mark_dormant(&mut self, name: &str, at: &str, reason: &str) -> Result<()> {
-        let state = self
+        let mut state = self
             .sandboxes
-            .get_mut(name)
+            .get(name)
+            .cloned()
             .ok_or_else(|| anyhow::anyhow!("Sandbox '{}' not found", name))?;
         if state.dormant_at.is_none() {
             state.dormant_at = Some(at.to_string());
             state.dormant_reason = Some(reason.to_string());
-            let snapshot = state.clone();
-            self.save_sandbox(&snapshot)?;
+            self.save_sandbox(&state)?;
+            self.sandboxes.insert(name.to_string(), state);
         }
         Ok(())
     }
@@ -1775,57 +1978,49 @@ impl VmManager {
     pub fn extend_ttl(&mut self, name: &str, additional_secs: u64) -> Result<Option<String>> {
         use chrono::{DateTime, Duration, Utc};
 
-        let new_expiry = {
-            let state = self
-                .sandboxes
-                .get_mut(name)
-                .ok_or_else(|| anyhow::anyhow!("Sandbox '{}' not found", name))?;
-
-            // Calculate new expiry based on current state
-            let now = Utc::now();
-            let base_time = if let Some(ref expires_at) = state.expires_at {
-                // Extend from current expiry (if not already expired)
-                expires_at
-                    .parse::<DateTime<Utc>>()
-                    .ok()
-                    .filter(|exp| *exp > now)
-                    .unwrap_or(now)
-            } else {
-                // No current expiry, extend from now
-                now
-            };
-
-            let new_exp = base_time + Duration::seconds(additional_secs as i64);
-            let new_expiry_str = new_exp.to_rfc3339();
-
-            // Update state
-            state.expires_at = Some(new_expiry_str.clone());
-            // Also update ttl_seconds to reflect total TTL from creation
-            if let Ok(created) = state.created_at.parse::<DateTime<Utc>>() {
-                let total_secs = (new_exp - created).num_seconds();
-                if total_secs > 0 {
-                    state.ttl_seconds = Some(total_secs as u64);
-                }
-            }
-
-            Some(new_expiry_str)
-        };
-
-        // Save the updated state
-        let state = self
+        let mut state = self
             .sandboxes
             .get(name)
+            .cloned()
             .ok_or_else(|| anyhow::anyhow!("Sandbox '{}' not found", name))?;
-        self.save_sandbox(state)?;
 
-        Ok(new_expiry)
+        // Calculate new expiry based on current state
+        let now = Utc::now();
+        let base_time = if let Some(ref expires_at) = state.expires_at {
+            // Extend from current expiry (if not already expired)
+            expires_at
+                .parse::<DateTime<Utc>>()
+                .ok()
+                .filter(|exp| *exp > now)
+                .unwrap_or(now)
+        } else {
+            // No current expiry, extend from now
+            now
+        };
+
+        let new_exp = base_time + Duration::seconds(additional_secs as i64);
+        let new_expiry_str = new_exp.to_rfc3339();
+
+        state.expires_at = Some(new_expiry_str.clone());
+        if let Ok(created) = state.created_at.parse::<DateTime<Utc>>() {
+            let total_secs = (new_exp - created).num_seconds();
+            if total_secs > 0 {
+                state.ttl_seconds = Some(total_secs as u64);
+            }
+        }
+
+        self.save_sandbox(&state)?;
+        self.sandboxes.insert(name.to_string(), state);
+
+        Ok(Some(new_expiry_str))
     }
 
     /// Recover an archived sandbox back to a normal lifecycle state.
     pub fn recover(&mut self, name: &str) -> Result<()> {
-        let state = self
+        let mut state = self
             .sandboxes
-            .get_mut(name)
+            .get(name)
+            .cloned()
             .ok_or_else(|| anyhow::anyhow!("Sandbox '{}' not found", name))?;
 
         state.archived_at = None;
@@ -1834,8 +2029,8 @@ impl VmManager {
         state.dormant_reason = None;
         state.last_activity_at = Some(chrono::Utc::now().to_rfc3339());
 
-        let snapshot = state.clone();
-        self.save_sandbox(&snapshot)?;
+        self.save_sandbox(&state)?;
+        self.sandboxes.insert(name.to_string(), state);
         Ok(())
     }
 
@@ -1919,12 +2114,42 @@ impl VmManager {
         perms: &Permissions,
         files: &[FileInjection],
     ) -> Result<()> {
+        self.start_with_permissions_and_files_impl(name, perms, files, false)
+            .await
+    }
+
+    /// Start after the HTTP layer has authorized the authenticated principal.
+    /// This avoids re-evaluating Cedar against the daemon process identity.
+    pub(crate) async fn start_with_permissions_and_files_authorized(
+        &mut self,
+        name: &str,
+        perms: &Permissions,
+        files: &[FileInjection],
+    ) -> Result<()> {
+        self.start_with_permissions_and_files_impl(name, perms, files, true)
+            .await
+    }
+
+    async fn start_with_permissions_and_files_impl(
+        &mut self,
+        name: &str,
+        perms: &Permissions,
+        files: &[FileInjection],
+        _policy_prechecked: bool,
+    ) -> Result<()> {
         let start_time = std::time::Instant::now();
         let state = self
             .sandboxes
             .get(name)
             .ok_or_else(|| anyhow::anyhow!("Sandbox '{}' not found", name))?
             .clone();
+        let backend = state.backend.unwrap_or(self.backend);
+        if self.pause_recovery.contains_key(name) || self.resume_state_recovery.contains_key(name) {
+            bail!(
+                "Sandbox '{}' has a pending full-state recovery; retry the recovery operation or remove it before starting another runtime",
+                name
+            );
+        }
 
         crate::llm_intercept::register_sandbox_metadata(
             name,
@@ -1958,17 +2183,32 @@ impl VmManager {
             );
         }
 
+        if state.paused_at.is_some() {
+            bail!(
+                "Sandbox '{}' is paused with full VM state. Resume it instead of cold-starting it.",
+                name
+            );
+        }
+
+        if backend == BackendType::Firecracker && state.full_state_lineage {
+            bail!(
+                "Sandbox '{}' belongs to a full-state Firecracker lineage whose writable runtime is not attached; cold start would lose that state. Resume a checkpoint when available or remove the sandbox explicitly.",
+                name
+            );
+        }
+
         if self.running.contains_key(name) {
             bail!("Sandbox '{}' is already running", name);
         }
 
         // Enterprise policy check for start
         #[cfg(feature = "enterprise")]
-        self.check_enterprise_policy(crate::policy::Action::Run, name, "unknown", &state.image)
-            .await?;
+        if !_policy_prechecked {
+            self.check_enterprise_policy(crate::policy::Action::Run, name, "unknown", &state.image)
+                .await?;
+        }
 
         // Use the backend from stored state, or fall back to current backend
-        let backend = state.backend.unwrap_or(self.backend);
         let capabilities = backend_capabilities(backend);
 
         if effective_perms.mount_home && !capabilities.mount_home {
@@ -2403,7 +2643,16 @@ impl VmManager {
             volumes: volume_args,
         };
 
-        sandbox.start(&config).await?;
+        if let Err(error) = sandbox.start(&config).await {
+            if runtime_may_survive_failed_stop(&error, sandbox.is_running()) {
+                self.running.insert(name.to_string(), sandbox);
+                return Err(error).context(format!(
+                    "sandbox '{name}' failed to start cleanly, but its runtime may still exist and remains under manager ownership; remove it before retrying"
+                ));
+            }
+            return Err(error);
+        }
+        let setup_result = async {
         if let Some(persisted) = self.sandboxes.get_mut(name) {
             persisted.work_dir = config.work_dir.clone();
             if let Some(metadata) = sandbox.runtime_metadata() {
@@ -2705,6 +2954,24 @@ impl VmManager {
                 return Err(error)
                     .context("failed to persist devcontainer postCreateCommand completion");
             }
+        }
+
+            Ok::<(), anyhow::Error>(())
+        }
+        .await;
+        if let Err(setup_error) = setup_result {
+            if let Err(stop_error) = sandbox.stop().await {
+                if runtime_may_survive_failed_stop(&stop_error, sandbox.is_running()) {
+                    self.running.insert(name.to_string(), sandbox);
+                    return Err(setup_error).context(format!(
+                        "post-start setup failed and cleanup could not prove sandbox '{name}' exited ({stop_error:#}); the runtime remains under manager ownership and must be removed before retrying"
+                    ));
+                }
+                return Err(setup_error).context(format!(
+                    "post-start setup failed; sandbox '{name}' exited, but cleanup also failed ({stop_error:#})"
+                ));
+            }
+            return Err(setup_error);
         }
 
         self.running.insert(name.to_string(), sandbox);
@@ -3125,6 +3392,905 @@ impl VmManager {
         result
     }
 
+    /// Pause a running Firecracker sandbox into a durable, full-VM checkpoint.
+    ///
+    /// The backend keeps the source VM running if snapshot creation fails. A
+    /// successful call terminates the paused Firecracker process only after
+    /// memory, device state, and an immutable disk have been captured.
+    pub async fn pause(&mut self, name: &str) -> Result<FullStateCheckpoint> {
+        self.pause_impl(name, false).await
+    }
+
+    pub(crate) async fn pause_authorized(&mut self, name: &str) -> Result<FullStateCheckpoint> {
+        self.pause_impl(name, true).await
+    }
+
+    async fn pause_impl(
+        &mut self,
+        name: &str,
+        _policy_prechecked: bool,
+    ) -> Result<FullStateCheckpoint> {
+        let pause_start = std::time::Instant::now();
+        validation::validate_sandbox_name(name)?;
+        let state = self
+            .sandboxes
+            .get(name)
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("Sandbox '{}' not found", name))?;
+        let backend = state.backend.unwrap_or(self.backend);
+        if backend != BackendType::Firecracker {
+            bail!(
+                "Backend '{}' does not support full-state pause/resume; Firecracker on Linux/KVM is required",
+                backend
+            );
+        }
+        if state.paused_at.is_some() {
+            bail!("Sandbox '{}' is already paused", name);
+        }
+        if state.proxy_port.is_some() || !state.secret_bindings.is_empty() {
+            bail!(
+                "Sandbox '{}' uses a host-side secret or governance proxy whose live state cannot yet be checkpointed",
+                name
+            );
+        }
+
+        #[cfg(feature = "enterprise")]
+        if !_policy_prechecked {
+            self.check_enterprise_policy(crate::policy::Action::Run, name, "unknown", &state.image)
+                .await?;
+        }
+
+        if !self.running.contains_key(name) {
+            bail!("Sandbox '{}' is not running", name);
+        }
+        let store = FullStateCheckpointStore::new(&self.data_dir)?;
+        let reservation_bytes = self
+            .running
+            .get(name)
+            .expect("running presence was validated before capacity reservation")
+            .full_state_reservation_bytes(state.memory_mb)?;
+        store
+            .ensure_capacity(reservation_bytes)
+            .with_context(|| format!("cannot pause sandbox '{name}'"))?;
+        let staging = store.begin()?;
+        // Persist the checkpoint identity before changing the VM. If the
+        // service exits after Firecracker stops but before publication, the
+        // sandbox remains conservatively paused instead of silently becoming
+        // a cold-startable state with an orphaned memory image.
+        let mut paused_state = state.clone();
+        paused_state.full_state_checkpoint = Some(staging.id().to_string());
+        paused_state.full_state_lineage = true;
+        paused_state.paused_at = Some(chrono::Utc::now().to_rfc3339());
+        paused_state.last_activity_at = Some(chrono::Utc::now().to_rfc3339());
+        if let Err(error) = self.save_sandbox(&paused_state) {
+            if let Err(cleanup_error) = store.discard_staging(staging.path()) {
+                return Err(error).context(format!(
+                    "failed to persist pause transition and failed to discard staging: {cleanup_error:#}"
+                ));
+            }
+            return Err(error).context("failed to persist pause transition");
+        }
+        self.sandboxes
+            .insert(name.to_string(), paused_state.clone());
+
+        let mut sandbox = self
+            .running
+            .remove(name)
+            .expect("running presence was validated before pause transition");
+        let backend_snapshot = match sandbox.pause_to(staging.path()).await {
+            Ok(snapshot) => snapshot,
+            Err(error) => {
+                if let Some(recovery) = error.downcast_ref::<FullStatePauseError>().cloned() {
+                    debug_assert!(recovery.source_resume_failed);
+
+                    if recovery.artifacts_complete {
+                        let snapshot = recovery.snapshot.clone();
+                        // Never publish a cloneable checkpoint until process
+                        // death is confirmed. Otherwise a failed kill could
+                        // leave the original VM alive beside a resumed copy.
+                        if let Err(stop_error) = sandbox.stop().await {
+                            let termination_confirmed = stop_error
+                                .downcast_ref::<FullStateTerminationError>()
+                                .is_some_and(|failure| !failure.process_may_be_running);
+                            if !termination_confirmed {
+                                let recovery_path = staging.preserve();
+                                self.pause_recovery.insert(
+                                    name.to_string(),
+                                    PendingFullStateRecovery {
+                                        sandbox: Some(sandbox),
+                                        staging_path: recovery_path.clone(),
+                                        completed_snapshot: Some(snapshot),
+                                    },
+                                );
+                                return Err(error).context(format!(
+                                    "complete checkpoint artifacts were produced, but source termination could not be confirmed ({stop_error:#}); checkpoint remains unpublished at {} and the source stays under recovery ownership; call resume to retry termination and publication or remove to abandon it",
+                                    recovery_path.display()
+                                ));
+                            }
+                            eprintln!(
+                                "Warning: source termination was confirmed, but runtime cleanup failed before checkpoint publication: {stop_error:#}"
+                            );
+                        }
+
+                        if let Err(marker_error) = store.mark_recovery_ready(
+                            &staging,
+                            name,
+                            state.vcpus,
+                            state.memory_mb,
+                            snapshot.clone(),
+                        ) {
+                            match store.commit(
+                                &staging,
+                                name,
+                                state.vcpus,
+                                state.memory_mb,
+                                snapshot.clone(),
+                            ) {
+                                Ok(checkpoint) => {
+                                    crate::metrics::record_sandbox_lifecycle(
+                                        "paused",
+                                        "firecracker",
+                                        pause_start.elapsed().as_secs_f64(),
+                                    );
+                                    return Ok(checkpoint);
+                                }
+                                Err(commit_error) => {
+                                    let recovery_path = staging.preserve();
+                                    self.pause_recovery.insert(
+                                        name.to_string(),
+                                        PendingFullStateRecovery {
+                                            sandbox: None,
+                                            staging_path: recovery_path.clone(),
+                                            completed_snapshot: Some(snapshot),
+                                        },
+                                    );
+                                    return Err(commit_error).context(format!(
+                                        "source was terminated, but complete checkpoint staging could neither be marked recovery-ready ({marker_error:#}) nor published after pause recovery ({error:#}); safe completed artifacts retained under recovery ownership at {}",
+                                        recovery_path.display()
+                                    ));
+                                }
+                            }
+                        }
+
+                        match store.commit(&staging, name, state.vcpus, state.memory_mb, snapshot) {
+                            Ok(checkpoint) => {
+                                crate::metrics::record_sandbox_lifecycle(
+                                    "paused",
+                                    "firecracker",
+                                    pause_start.elapsed().as_secs_f64(),
+                                );
+                                return Ok(checkpoint);
+                            }
+                            Err(commit_error) => {
+                                let recovery_path = staging.preserve();
+                                return Err(commit_error).context(format!(
+                                    "source was terminated after pause recovery, but checkpoint publication failed ({error:#}); recovery-ready artifacts retained at {}",
+                                    recovery_path.display()
+                                ));
+                            }
+                        }
+                    }
+
+                    // Partial artifacts cannot restore independently. Retry
+                    // the live source once now and retain exact ownership if
+                    // the retry is still ambiguous or unsuccessful.
+                    match sandbox.retry_full_state_resume().await {
+                        Ok(()) => {
+                            let running_state =
+                                with_full_state_cleanup_intent(state.clone(), staging.id());
+                            if let Err(rollback_error) = self.save_sandbox(&running_state) {
+                                let recovery_path = staging.preserve();
+                                self.running.insert(name.to_string(), sandbox);
+                                self.resume_state_recovery
+                                    .insert(name.to_string(), running_state);
+                                return Err(error).context(format!(
+                                    "failed to pause Firecracker sandbox; source resumed on retry, but failed to roll back persisted pause transition ({rollback_error:#}); the live runtime and desired metadata remain under recovery ownership and staging remains at {}; call resume to retry metadata publication",
+                                    recovery_path.display()
+                                ));
+                            }
+                            self.running.insert(name.to_string(), sandbox);
+                            self.sandboxes.insert(name.to_string(), running_state);
+                            self.reconcile_full_state_cleanup();
+                            return Err(error).context(
+                                "failed to create a complete checkpoint; source resumed on retry",
+                            );
+                        }
+                        Err(retry_error) => {
+                            let recovery_path = staging.preserve();
+                            self.pause_recovery.insert(
+                                name.to_string(),
+                                PendingFullStateRecovery {
+                                    sandbox: Some(sandbox),
+                                    staging_path: recovery_path.clone(),
+                                    completed_snapshot: None,
+                                },
+                            );
+                            return Err(error).context(format!(
+                                "checkpoint is incomplete and source resume retry failed ({retry_error:#}); source remains paused under manager ownership and diagnostic artifacts are retained at {}; call resume to retry in place",
+                                recovery_path.display()
+                            ));
+                        }
+                    }
+                }
+
+                // Ordinary backend errors guarantee a confirmed running
+                // source. Restore both in-memory and persisted state.
+                let running_state = with_full_state_cleanup_intent(state.clone(), staging.id());
+                if let Err(rollback_error) = self.save_sandbox(&running_state) {
+                    let recovery_path = staging.preserve();
+                    self.running.insert(name.to_string(), sandbox);
+                    self.resume_state_recovery
+                        .insert(name.to_string(), running_state);
+                    return Err(error).context(format!(
+                        "failed to pause Firecracker sandbox; failed to roll back persisted pause transition ({rollback_error:#}); the live runtime and desired metadata remain under recovery ownership and staging remains at {}; call resume to retry metadata publication",
+                        recovery_path.display()
+                    ));
+                }
+                self.running.insert(name.to_string(), sandbox);
+                self.sandboxes.insert(name.to_string(), running_state);
+                self.reconcile_full_state_cleanup();
+                return Err(error).context("failed to pause Firecracker sandbox");
+            }
+        };
+
+        // The backend has completed all artifacts and terminated the source.
+        // Publish a durable ready marker before the manifest rename so a
+        // crash in the narrow commit window can be recovered without risking
+        // a duplicate of a still-live VM.
+        let marker_failure = store
+            .mark_recovery_ready(
+                &staging,
+                name,
+                state.vcpus,
+                state.memory_mb,
+                backend_snapshot.clone(),
+            )
+            .err()
+            .map(|error| format!("{error:#}"));
+
+        let checkpoint = match store.commit(
+            &staging,
+            name,
+            state.vcpus,
+            state.memory_mb,
+            backend_snapshot.clone(),
+        ) {
+            Ok(checkpoint) => checkpoint,
+            Err(error) => {
+                let marker_context = marker_failure.as_deref().map_or(String::new(), |failure| {
+                    format!("; recovery-ready marker also failed: {failure}")
+                });
+                let retained_kind = if marker_failure.is_some() {
+                    "diagnostic"
+                } else {
+                    "recovery-ready"
+                };
+                // Snapshot artifacts still live in staging. Restore from them
+                // so a publication failure does not destroy a running session.
+                match sandbox
+                    .restore_from(staging.path(), &backend_snapshot)
+                    .await
+                {
+                    Ok(()) => {
+                        let running_state =
+                            with_full_state_cleanup_intent(state.clone(), staging.id());
+                        if let Err(rollback_error) = self.save_sandbox(&running_state) {
+                            let recovery_path = staging.preserve();
+                            self.running.insert(name.to_string(), sandbox);
+                            self.resume_state_recovery
+                                .insert(name.to_string(), running_state);
+                            return Err(error).context(format!(
+                                "failed to publish checkpoint{marker_context}; source resumed but persisted pause transition rollback failed ({rollback_error:#}); the live runtime and desired metadata remain under recovery ownership and {retained_kind} staging is retained at {}; call resume to retry metadata publication",
+                                recovery_path.display()
+                            ));
+                        }
+                        self.running.insert(name.to_string(), sandbox);
+                        self.sandboxes.insert(name.to_string(), running_state);
+                        self.reconcile_full_state_cleanup();
+                        return Err(error).context(format!(
+                            "failed to publish checkpoint{marker_context}; the source sandbox was resumed"
+                        ));
+                    }
+                    Err(restore_error) => {
+                        let recovery_path = staging.preserve();
+                        let sandbox =
+                            runtime_may_survive_failed_stop(&restore_error, sandbox.is_running())
+                                .then_some(sandbox);
+                        self.pause_recovery.insert(
+                            name.to_string(),
+                            PendingFullStateRecovery {
+                                sandbox,
+                                staging_path: recovery_path.clone(),
+                                completed_snapshot: Some(backend_snapshot),
+                            },
+                        );
+                        return Err(error).context(format!(
+                            "failed to publish checkpoint{marker_context} and failed to resume source ({restore_error:#}); safe completed {retained_kind} artifacts retained under recovery ownership at {}",
+                            recovery_path.display()
+                        ));
+                    }
+                }
+            }
+        };
+        debug_assert_eq!(
+            paused_state.full_state_checkpoint.as_deref(),
+            Some(checkpoint.id.as_str())
+        );
+        crate::metrics::record_sandbox_lifecycle(
+            "paused",
+            "firecracker",
+            pause_start.elapsed().as_secs_f64(),
+        );
+        Ok(checkpoint)
+    }
+
+    /// Resume a paused Firecracker sandbox from its durable checkpoint.
+    pub async fn resume(&mut self, name: &str) -> Result<()> {
+        self.resume_impl(name, false).await
+    }
+
+    pub(crate) async fn resume_authorized(&mut self, name: &str) -> Result<()> {
+        self.resume_impl(name, true).await
+    }
+
+    async fn resume_impl(&mut self, name: &str, _policy_prechecked: bool) -> Result<()> {
+        let resume_start = std::time::Instant::now();
+        validation::validate_sandbox_name(name)?;
+        let state = self
+            .sandboxes
+            .get(name)
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("Sandbox '{}' not found", name))?;
+        let backend = state.backend.unwrap_or(self.backend);
+        if backend != BackendType::Firecracker {
+            bail!(
+                "Backend '{}' does not support full-state pause/resume; Firecracker on Linux/KVM is required",
+                backend
+            );
+        }
+        if state.paused_at.is_none() {
+            bail!("Sandbox '{}' is not paused", name);
+        }
+        if state.archived_at.is_some() || state.dormant_at.is_some() {
+            bail!(
+                "Sandbox '{}' is archived or dormant; recover it before resuming",
+                name
+            );
+        }
+        let checkpoint_id = state
+            .full_state_checkpoint
+            .as_deref()
+            .ok_or_else(|| anyhow::anyhow!("Sandbox '{}' has no full-state checkpoint", name))?;
+        if state.proxy_port.is_some() || !state.secret_bindings.is_empty() {
+            bail!(
+                "Sandbox '{}' requires host-side proxy rehydration, which full-state resume does not yet support",
+                name
+            );
+        }
+
+        #[cfg(feature = "enterprise")]
+        if !_policy_prechecked {
+            self.check_enterprise_policy(crate::policy::Action::Run, name, "unknown", &state.image)
+                .await?;
+        }
+
+        if let Some(running_state) = self.resume_state_recovery.get(name).cloned() {
+            if !self
+                .running
+                .get(name)
+                .is_some_and(|sandbox| sandbox.is_running())
+            {
+                bail!(
+                    "Sandbox '{}' no longer has a confirmed-live runtime for its pending resume-state recovery; remove it before retrying",
+                    name
+                );
+            }
+            self.save_sandbox(&running_state).with_context(|| {
+                format!("failed to retry running-state publication for sandbox '{name}'")
+            })?;
+            self.sandboxes.insert(name.to_string(), running_state);
+            self.resume_state_recovery.remove(name);
+            self.reconcile_full_state_cleanup();
+            log_event(AuditEvent::SandboxStarted {
+                name: name.to_string(),
+                profile: Some("full-state-resume-metadata-recovery".to_string()),
+            });
+            crate::metrics::record_sandbox_lifecycle(
+                "resumed",
+                "firecracker",
+                resume_start.elapsed().as_secs_f64(),
+            );
+            return Ok(());
+        }
+        if self.running.contains_key(name) {
+            bail!("Sandbox '{}' is already running", name);
+        }
+
+        let store = FullStateCheckpointStore::new(&self.data_dir)?;
+        if let Some(mut recovery) = self.pause_recovery.remove(name) {
+            if let Some(snapshot) = recovery.completed_snapshot.clone() {
+                if let Some(mut sandbox) = recovery.sandbox.take()
+                    && let Err(error) = sandbox.stop().await
+                {
+                    let termination_confirmed = error
+                        .downcast_ref::<FullStateTerminationError>()
+                        .is_some_and(|failure| !failure.process_may_be_running);
+                    if !termination_confirmed {
+                        recovery.sandbox = Some(sandbox);
+                        self.pause_recovery.insert(name.to_string(), recovery);
+                        return Err(error).with_context(|| {
+                            format!(
+                                "failed to confirm termination of recovery-pending sandbox '{name}'; retry resume or remove"
+                            )
+                        });
+                    }
+                    eprintln!(
+                        "Warning: source termination was confirmed during recovery, but runtime cleanup failed: {error:#}"
+                    );
+                }
+
+                let staging = match store.open_staging(checkpoint_id) {
+                    Ok(staging) => staging,
+                    Err(error) => {
+                        self.pause_recovery.insert(name.to_string(), recovery);
+                        return Err(error).with_context(|| {
+                            format!(
+                                "failed to reopen completed checkpoint staging for sandbox '{name}'"
+                            )
+                        });
+                    }
+                };
+                let marker_error = store
+                    .mark_recovery_ready(
+                        &staging,
+                        name,
+                        state.vcpus,
+                        state.memory_mb,
+                        snapshot.clone(),
+                    )
+                    .err();
+                if let Err(error) =
+                    store.commit(&staging, name, state.vcpus, state.memory_mb, snapshot)
+                {
+                    let marker_context = marker_error.as_ref().map_or(String::new(), |marker| {
+                        format!("; recovery-ready marker also failed: {marker:#}")
+                    });
+                    self.pause_recovery.insert(name.to_string(), recovery);
+                    return Err(error).context(format!(
+                        "failed to publish completed checkpoint for sandbox '{name}'{marker_context}; safe staging remains at {}",
+                        staging.path().display()
+                    ));
+                }
+            } else {
+                let Some(mut sandbox) = recovery.sandbox.take() else {
+                    self.pause_recovery.insert(name.to_string(), recovery);
+                    bail!(
+                        "Sandbox '{}' has invalid partial recovery ownership without a source runtime",
+                        name
+                    );
+                };
+                if let Err(error) = sandbox.retry_full_state_resume().await {
+                    recovery.sandbox = Some(sandbox);
+                    self.pause_recovery.insert(name.to_string(), recovery);
+                    return Err(error).with_context(|| {
+                        format!("failed to resume recovery-pending sandbox '{name}' in place")
+                    });
+                }
+
+                let mut running_state = state.clone();
+                running_state.full_state_checkpoint = None;
+                if !running_state
+                    .full_state_cleanup_pending
+                    .iter()
+                    .any(|id| id == checkpoint_id)
+                {
+                    running_state
+                        .full_state_cleanup_pending
+                        .push(checkpoint_id.to_string());
+                }
+                running_state.paused_at = None;
+                running_state.last_activity_at = Some(chrono::Utc::now().to_rfc3339());
+                if let Err(error) = self.save_sandbox(&running_state) {
+                    self.running.insert(name.to_string(), sandbox);
+                    self.resume_state_recovery
+                        .insert(name.to_string(), running_state);
+                    return Err(error).context(format!(
+                        "sandbox '{name}' resumed in place, but its running state could not be persisted; the runtime and desired metadata remain under recovery ownership, and diagnostic artifacts remain at {}; call resume to retry metadata publication",
+                        recovery.staging_path.display()
+                    ));
+                }
+                self.running.insert(name.to_string(), sandbox);
+                self.sandboxes.insert(name.to_string(), running_state);
+                self.reconcile_full_state_cleanup();
+                log_event(AuditEvent::SandboxStarted {
+                    name: name.to_string(),
+                    profile: Some("full-state-in-place-recovery".to_string()),
+                });
+                crate::metrics::record_sandbox_lifecycle(
+                    "resumed",
+                    "firecracker",
+                    resume_start.elapsed().as_secs_f64(),
+                );
+                return Ok(());
+            }
+        }
+
+        let (checkpoint, checkpoint_path) = if store.contains(checkpoint_id)? {
+            store.load(checkpoint_id)?
+        } else {
+            let staging_path = store.staging_path(checkpoint_id)?;
+            if staging_path.is_dir() {
+                if store.recovery_is_ready(checkpoint_id)? {
+                    store
+                        .recover_ready(checkpoint_id, name, state.vcpus, state.memory_mb)
+                        .with_context(|| {
+                            format!(
+                                "failed to publish recovery-ready checkpoint for sandbox '{name}'"
+                            )
+                        })?
+                } else {
+                    bail!(
+                        "Sandbox '{}' has an interrupted pause transition at {} that cannot be restored automatically; keep these artifacts for operator recovery",
+                        name,
+                        staging_path.display()
+                    );
+                }
+            } else {
+                bail!(
+                    "Sandbox '{}' references missing full-state checkpoint '{}'",
+                    name,
+                    checkpoint_id
+                );
+            }
+        };
+        if checkpoint.source_sandbox != name {
+            bail!(
+                "Sandbox '{}' references checkpoint '{}' owned by sandbox '{}'",
+                name,
+                checkpoint.id,
+                checkpoint.source_sandbox
+            );
+        }
+        if checkpoint.vcpus != state.vcpus || checkpoint.memory_mb != state.memory_mb {
+            bail!(
+                "Sandbox '{}' resources no longer match its checkpoint",
+                name
+            );
+        }
+        let mut sandbox = create_sandbox(BackendType::Firecracker, name)?;
+        if let Err(error) = sandbox
+            .restore_from(&checkpoint_path, &checkpoint.backend_snapshot)
+            .await
+        {
+            if runtime_may_survive_failed_stop(&error, sandbox.is_running()) {
+                self.pause_recovery.insert(
+                    name.to_string(),
+                    PendingFullStateRecovery {
+                        sandbox: Some(sandbox),
+                        staging_path: checkpoint_path.clone(),
+                        completed_snapshot: None,
+                    },
+                );
+                return Err(error).context(format!(
+                    "failed to resume sandbox '{name}', and restore cleanup could not prove the new VMM exited; it remains under recovery ownership while the durable checkpoint stays paused; call resume to retry in place or remove to abandon it"
+                ));
+            }
+            return Err(error).with_context(|| format!("failed to resume sandbox '{name}'"));
+        }
+
+        let mut running_state = state.clone();
+        running_state.full_state_checkpoint = None;
+        if !running_state
+            .full_state_cleanup_pending
+            .iter()
+            .any(|id| id == checkpoint_id)
+        {
+            running_state
+                .full_state_cleanup_pending
+                .push(checkpoint_id.to_string());
+        }
+        running_state.paused_at = None;
+        running_state.last_activity_at = Some(chrono::Utc::now().to_rfc3339());
+        running_state.labels.insert(
+            "agentkernel.full-state-lineage".to_string(),
+            "true".to_string(),
+        );
+        running_state.full_state_lineage = true;
+        if let Err(error) = self.save_sandbox(&running_state) {
+            if let Err(stop_error) = sandbox.stop().await {
+                if runtime_may_survive_failed_stop(&stop_error, sandbox.is_running()) {
+                    // Fail closed: retain ownership of an ambiguously live
+                    // runtime, but keep the persisted paused state and its
+                    // checkpoint visible for operator recovery.
+                    self.running.insert(name.to_string(), sandbox);
+                    self.resume_state_recovery
+                        .insert(name.to_string(), running_state);
+                    return Err(error).context(format!(
+                        "failed to persist resumed state and failed to stop the restored runtime ({stop_error:#}); an ambiguously live runtime and its desired metadata remain under recovery ownership while the sandbox stays conservatively paused; call resume to retry metadata publication"
+                    ));
+                }
+                return Err(error).context(format!(
+                    "failed to persist resumed state; the restored runtime exited, but cleanup also failed ({stop_error:#}); the checkpoint remains available"
+                ));
+            }
+            return Err(error).context(
+                "failed to persist resumed state; restored runtime was stopped and the checkpoint remains available",
+            );
+        }
+
+        self.sandboxes.insert(name.to_string(), running_state);
+        self.running.insert(name.to_string(), sandbox);
+        self.reconcile_full_state_cleanup();
+        log_event(AuditEvent::SandboxStarted {
+            name: name.to_string(),
+            profile: Some("full-state-resume".to_string()),
+        });
+        crate::metrics::record_sandbox_lifecycle(
+            "resumed",
+            "firecracker",
+            resume_start.elapsed().as_secs_f64(),
+        );
+        Ok(())
+    }
+
+    /// Fork a paused Firecracker sandbox into a running child.
+    pub async fn fork_sandbox(&mut self, source: &str, child: &str) -> Result<()> {
+        self.fork_sandbox_impl(source, child, false).await
+    }
+
+    pub(crate) async fn fork_sandbox_authorized(
+        &mut self,
+        source: &str,
+        child: &str,
+    ) -> Result<()> {
+        self.fork_sandbox_impl(source, child, true).await
+    }
+
+    async fn fork_sandbox_impl(
+        &mut self,
+        source: &str,
+        child: &str,
+        _policy_prechecked: bool,
+    ) -> Result<()> {
+        let fork_start = std::time::Instant::now();
+        validation::validate_sandbox_name(source)?;
+        validation::validate_sandbox_name(child)?;
+        if source == child {
+            bail!("Fork child name must differ from the source sandbox");
+        }
+        if self.sandboxes.contains_key(child) {
+            bail!("Sandbox '{}' already exists", child);
+        }
+        if self.pause_recovery.contains_key(source)
+            || self.resume_state_recovery.contains_key(source)
+        {
+            bail!(
+                "Sandbox '{}' has pending full-state recovery; resume or remove it before forking",
+                source
+            );
+        }
+        let source_state = self
+            .sandboxes
+            .get(source)
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("Sandbox '{}' not found", source))?;
+        let backend = source_state.backend.unwrap_or(self.backend);
+        if backend != BackendType::Firecracker {
+            bail!(
+                "Backend '{}' does not support full-state fork; Firecracker on Linux/KVM is required",
+                backend
+            );
+        }
+        if source_state.paused_at.is_none() {
+            bail!(
+                "Sandbox '{}' must be paused before it can be forked",
+                source
+            );
+        }
+        if source_state.archived_at.is_some() || source_state.dormant_at.is_some() {
+            bail!(
+                "Sandbox '{}' is archived or dormant; recover it before forking",
+                source
+            );
+        }
+        if source_state.proxy_port.is_some() || !source_state.secret_bindings.is_empty() {
+            bail!(
+                "Sandbox '{}' uses a host-side proxy whose live state cannot yet be forked",
+                source
+            );
+        }
+        let checkpoint_id = source_state
+            .full_state_checkpoint
+            .as_deref()
+            .ok_or_else(|| anyhow::anyhow!("Sandbox '{}' has no full-state checkpoint", source))?;
+
+        #[cfg(feature = "enterprise")]
+        if !_policy_prechecked {
+            self.check_enterprise_policy(
+                crate::policy::Action::Run,
+                source,
+                "unknown",
+                &source_state.image,
+            )
+            .await?;
+            self.check_enterprise_policy(
+                crate::policy::Action::Create,
+                child,
+                "unknown",
+                &source_state.image,
+            )
+            .await?;
+            self.check_enterprise_policy(
+                crate::policy::Action::Run,
+                child,
+                "unknown",
+                &source_state.image,
+            )
+            .await?;
+        }
+
+        let store = FullStateCheckpointStore::new(&self.data_dir)?;
+        let (checkpoint, checkpoint_path) = if store.contains(checkpoint_id)? {
+            store.load(checkpoint_id)?
+        } else {
+            let staging_path = store.staging_path(checkpoint_id)?;
+            if staging_path.is_dir() && store.recovery_is_ready(checkpoint_id)? {
+                store
+                    .recover_ready(
+                        checkpoint_id,
+                        source,
+                        source_state.vcpus,
+                        source_state.memory_mb,
+                    )
+                    .with_context(|| {
+                        format!(
+                            "failed to publish recovery-ready checkpoint for sandbox '{source}'"
+                        )
+                    })?
+            } else {
+                bail!(
+                    "Sandbox '{}' has no published, recovery-ready full-state checkpoint",
+                    source
+                );
+            }
+        };
+        if checkpoint.source_sandbox != source {
+            bail!(
+                "Sandbox '{}' references checkpoint '{}' owned by sandbox '{}'",
+                source,
+                checkpoint.id,
+                checkpoint.source_sandbox
+            );
+        }
+        if checkpoint.vcpus != source_state.vcpus || checkpoint.memory_mb != source_state.memory_mb
+        {
+            bail!(
+                "Sandbox '{}' resources no longer match its checkpoint",
+                source
+            );
+        }
+        let now = chrono::Utc::now();
+        let mut child_state = source_state.clone();
+        child_state.name = child.to_string();
+        child_state.uuid = uuid::Uuid::now_v7().to_string();
+        child_state.vsock_cid = self.next_cid;
+        self.next_cid += 1;
+        child_state.created_at = now.to_rfc3339();
+        child_state.expires_at = child_state
+            .ttl_seconds
+            .map(|ttl| (now + chrono::Duration::seconds(ttl as i64)).to_rfc3339());
+        child_state.remote_id = None;
+        child_state.remote_namespace = None;
+        child_state.remote_metadata.clear();
+        child_state.workspace_revision = None;
+        child_state.endpoints.clear();
+        child_state.work_dir = None;
+        child_state.container_work_dir = None;
+        child_state.git_worktree = None;
+        child_state.ports.clear();
+        child_state.ssh_enabled = false;
+        child_state.ssh_host_port = None;
+        child_state.volumes.clear();
+        child_state.proxy_port = None;
+        child_state.full_state_checkpoint = None;
+        child_state.paused_at = None;
+        child_state.forked_from = Some(source.to_string());
+        child_state.archived_at = None;
+        child_state.archived_reason = None;
+        child_state.dormant_at = None;
+        child_state.dormant_reason = None;
+        child_state.last_activity_at = Some(now.to_rfc3339());
+        child_state
+            .labels
+            .insert("agentkernel.forked-from".to_string(), source.to_string());
+        child_state.labels.insert(
+            "agentkernel.full-state-lineage".to_string(),
+            "true".to_string(),
+        );
+        child_state.full_state_lineage = true;
+
+        let mut sandbox = create_sandbox(BackendType::Firecracker, child)?;
+        if let Err(error) = sandbox
+            .restore_from(&checkpoint_path, &checkpoint.backend_snapshot)
+            .await
+        {
+            if runtime_may_survive_failed_stop(&error, sandbox.is_running()) {
+                let persistence_error = self.save_sandbox(&child_state).err();
+                self.sandboxes
+                    .insert(child.to_string(), child_state.clone());
+                self.pause_recovery.insert(
+                    child.to_string(),
+                    PendingFullStateRecovery {
+                        sandbox: Some(sandbox),
+                        // This is diagnostic ownership only. The published
+                        // source checkpoint is never consumed by child removal.
+                        staging_path: checkpoint_path.clone(),
+                        completed_snapshot: None,
+                    },
+                );
+                crate::metrics::inc_active_sandboxes();
+                let persistence_context =
+                    persistence_error.as_ref().map_or(String::new(), |persist| {
+                        format!("; transitional child state also failed to persist: {persist:#}")
+                    });
+                return Err(error).context(format!(
+                    "failed to restore fork '{child}' from sandbox '{source}', and cleanup could not prove the child VMM exited{persistence_context}; the child remains under recovery ownership and must be removed before retrying"
+                ));
+            }
+            return Err(error).with_context(|| {
+                format!(
+                    "failed to restore fork '{}' from sandbox '{}'",
+                    child, source
+                )
+            });
+        }
+
+        // Publish a normal child only after its runtime has restored. If the
+        // atomic state write fails, stop the unadvertised runtime so callers
+        // never observe a persisted fork that did not actually start.
+        if let Err(error) = self.save_sandbox(&child_state) {
+            if let Err(stop_error) = sandbox.stop().await {
+                if runtime_may_survive_failed_stop(&stop_error, sandbox.is_running()) {
+                    self.sandboxes
+                        .insert(child.to_string(), child_state.clone());
+                    self.running.insert(child.to_string(), sandbox);
+                    crate::metrics::inc_active_sandboxes();
+                    return Err(error).context(format!(
+                        "failed to persist restored fork '{}'; failed to stop an ambiguously live runtime ({stop_error:#}), so it remains under manager ownership and must be explicitly removed",
+                        child
+                    ));
+                }
+                return Err(error).context(format!(
+                    "failed to persist restored fork '{}'; its runtime exited, but cleanup also failed ({stop_error:#})",
+                    child
+                ));
+            }
+            return Err(error)
+                .with_context(|| format!("failed to persist restored fork '{child}'"));
+        }
+        self.sandboxes
+            .insert(child.to_string(), child_state.clone());
+        self.running.insert(child.to_string(), sandbox);
+
+        log_event(AuditEvent::SandboxCreated {
+            name: child.to_string(),
+            image: child_state.image.clone(),
+            backend: "firecracker".to_string(),
+            labels: child_state.labels.clone(),
+        });
+        log_event(AuditEvent::SandboxStarted {
+            name: child.to_string(),
+            profile: Some(format!("fork-of:{source}")),
+        });
+        crate::metrics::inc_active_sandboxes();
+        crate::metrics::record_sandbox_lifecycle(
+            "forked",
+            "firecracker",
+            fork_start.elapsed().as_secs_f64(),
+        );
+        Ok(())
+    }
+
     /// Stop a sandbox
     pub async fn stop(&mut self, name: &str) -> Result<()> {
         let stop_start = std::time::Instant::now();
@@ -3133,6 +4299,18 @@ impl VmManager {
             .get(name)
             .and_then(|state| state.backend)
             .unwrap_or(self.backend);
+        if backend == BackendType::Firecracker
+            && self.running.contains_key(name)
+            && self
+                .sandboxes
+                .get(name)
+                .is_some_and(|state| state.full_state_lineage)
+        {
+            bail!(
+                "Refusing to stop full-state Firecracker sandbox '{}': ordinary stop would discard its writable disk; use full-state pause to preserve it or remove to discard it",
+                name
+            );
+        }
         if let Err(e) = self.hydrate_remote_runtime(name) {
             eprintln!(
                 "Warning: failed to hydrate remote runtime for '{}': {}",
@@ -3143,8 +4321,19 @@ impl VmManager {
         if let Some(handle) = PROXY_HANDLES.write().await.remove(name) {
             let _ = handle.shutdown_tx.send(());
         }
+        // A recovery-pending source is already paused. Keep its exact backend
+        // handle alive so `resume` can retry in place; `remove` is the explicit
+        // operation that abandons it.
+        if self.pause_recovery.contains_key(name) || self.resume_state_recovery.contains_key(name) {
+            return Ok(());
+        }
         if let Some(mut sandbox) = self.running.remove(name) {
-            sandbox.stop().await?;
+            if let Err(error) = sandbox.stop().await {
+                if runtime_may_survive_failed_stop(&error, sandbox.is_running()) {
+                    self.running.insert(name.to_string(), sandbox);
+                }
+                return Err(error).with_context(|| format!("failed to stop sandbox '{name}'"));
+            }
             if let Some(metadata) = sandbox.runtime_metadata()
                 && let Some(state) = self.sandboxes.get_mut(name)
             {
@@ -3189,7 +4378,17 @@ impl VmManager {
         #[cfg(not(test))]
         let bypass_backend_runtime = false;
 
-        if let Some(mut sandbox) = self.running.remove(name) {
+        if let Some(mut recovery) = self.pause_recovery.remove(name) {
+            if let Some(mut sandbox) = recovery.sandbox.take()
+                && let Err(error) = sandbox.remove().await
+            {
+                recovery.sandbox = Some(sandbox);
+                self.pause_recovery.insert(name.to_string(), recovery);
+                return Err(error).with_context(|| {
+                    format!("failed to abandon recovery-pending sandbox '{name}'")
+                });
+            }
+        } else if let Some(mut sandbox) = self.running.remove(name) {
             if let Err(error) = sandbox.remove().await {
                 self.running.insert(name.to_string(), sandbox);
                 return Err(error).with_context(|| format!("failed to remove sandbox '{name}'"));
@@ -3217,14 +4416,34 @@ impl VmManager {
                 .with_context(|| format!("failed to clean up Git worktree for sandbox '{name}'"));
         }
 
-        if let Some(state) = self.sandboxes.get(name)
-            && let Some(network) = state.managed_network.as_ref()
-        {
-            crate::backend::NetworkAllocator::new(self.data_dir.clone()).release(name, network)?;
+        if let Some(state) = self.sandboxes.get(name).cloned() {
+            if let Some(network) = state.managed_network.as_ref() {
+                crate::backend::NetworkAllocator::new(self.data_dir.clone())
+                    .release(name, network)?;
+            }
+
+            let mut checkpoint_ids = state.full_state_cleanup_pending;
+            if let Some(checkpoint_id) = state.full_state_checkpoint {
+                checkpoint_ids.push(checkpoint_id);
+            }
+            checkpoint_ids.sort();
+            checkpoint_ids.dedup();
+            if !checkpoint_ids.is_empty() {
+                let store = FullStateCheckpointStore::new(&self.data_dir)?;
+                for checkpoint_id in checkpoint_ids {
+                    Self::delete_full_state_artifacts(&store, &checkpoint_id).with_context(|| {
+                        format!(
+                            "failed to delete full-state artifacts '{}' for sandbox '{}' after its runtime was removed; retry removal to finish cleanup",
+                            checkpoint_id, name
+                        )
+                    })?;
+                }
+            }
         }
 
         self.delete_sandbox(name)?;
         self.sandboxes.remove(name);
+        self.resume_state_recovery.remove(name);
 
         log_event(AuditEvent::SandboxRemoved {
             name: name.to_string(),
@@ -3360,11 +4579,11 @@ impl VmManager {
                         if self.is_running(&decision.sandbox) {
                             self.stop(&decision.sandbox).await?;
                         }
-                        if let Some(state) = self.sandboxes.get_mut(&decision.sandbox) {
+                        if let Some(mut state) = self.sandboxes.get(&decision.sandbox).cloned() {
                             state.archived_at = Some(now.to_rfc3339());
                             state.archived_reason = Some(decision.reason.clone());
-                            let snapshot = state.clone();
-                            self.save_sandbox(&snapshot)?;
+                            self.save_sandbox(&state)?;
+                            self.sandboxes.insert(decision.sandbox.clone(), state);
                         }
                     }
                     result.archived.push(decision.sandbox);
@@ -3427,17 +4646,13 @@ impl VmManager {
         self.sandboxes
             .iter()
             .map(|(name, state)| {
-                let running = self
-                    .running
-                    .get(name)
-                    .map(|s| s.is_running())
-                    .unwrap_or_else(|| {
-                        state.backend.is_some_and(|backend| backend.is_remote())
-                            && state
-                                .remote_metadata
-                                .get("last_known_status")
-                                .is_some_and(|value| value == "running")
-                    });
+                let running = self.is_running(name) || {
+                    state.backend.is_some_and(|backend| backend.is_remote())
+                        && state
+                            .remote_metadata
+                            .get("last_known_status")
+                            .is_some_and(|value| value == "running")
+                };
                 (name.as_str(), running, state.backend)
             })
             .collect()
@@ -3448,13 +4663,103 @@ impl VmManager {
         self.sandboxes.contains_key(name)
     }
 
+    /// Import a sandbox that another AgentKernel process persisted after this
+    /// manager started.
+    ///
+    /// The long-lived HTTP service uses this narrow refresh path when a CLI
+    /// creates a Firecracker sandbox and then delegates runtime ownership to
+    /// the service. Existing entries are never overwritten, so live runtime
+    /// state cannot be replaced by a stale file.
+    pub fn refresh_sandbox_if_missing(&mut self, name: &str) -> Result<bool> {
+        validation::validate_sandbox_name(name)?;
+        if self.sandboxes.contains_key(name) {
+            return Ok(false);
+        }
+
+        let Some(mut state) = self.read_persisted_sandbox(name)? else {
+            return Ok(false);
+        };
+        if state.uuid.is_empty() {
+            state.uuid = uuid::Uuid::now_v7().to_string();
+            self.save_sandbox(&state)?;
+        }
+        self.sandboxes.insert(name.to_string(), state);
+        Ok(true)
+    }
+
+    /// Reload a persisted sandbox only when no runtime or recovery transition
+    /// is owned by this manager. This is the second half of the CLI-to-daemon
+    /// start handoff: a one-shot manifest binds the exact disk state, then the
+    /// daemon atomically adopts that final configuration before starting it.
+    pub fn refresh_stopped_sandbox_from_disk(&mut self, name: &str) -> Result<bool> {
+        validation::validate_sandbox_name(name)?;
+        if self.running.contains_key(name)
+            || self.pause_recovery.contains_key(name)
+            || self.resume_state_recovery.contains_key(name)
+        {
+            bail!(
+                "Sandbox '{}' owns a runtime or full-state recovery and cannot be refreshed from disk",
+                name
+            );
+        }
+        let Some(state) = self.read_persisted_sandbox(name)? else {
+            return Ok(false);
+        };
+        if state.uuid.is_empty() {
+            bail!("persisted sandbox '{}' has no generation UUID", name);
+        }
+        if let Some(current) = self.sandboxes.get(name)
+            && current.uuid != state.uuid
+        {
+            bail!(
+                "sandbox generation changed while refreshing '{}': daemon={}, disk={}",
+                name,
+                current.uuid,
+                state.uuid
+            );
+        }
+        self.sandboxes.insert(name.to_string(), state);
+        Ok(true)
+    }
+
+    fn read_persisted_sandbox(&self, name: &str) -> Result<Option<SandboxState>> {
+        let path = self.data_dir.join("sandboxes").join(format!("{name}.json"));
+        let contents = match std::fs::read_to_string(&path) {
+            Ok(contents) => contents,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => {
+                return Err(error)
+                    .with_context(|| format!("failed to read sandbox state {}", path.display()));
+            }
+        };
+        let state: SandboxState = serde_json::from_str(&contents)
+            .with_context(|| format!("failed to parse sandbox state {}", path.display()))?;
+        if state.name != name {
+            bail!(
+                "sandbox state identity mismatch: requested '{}' but {} contains '{}'",
+                name,
+                path.display(),
+                state.name
+            );
+        }
+        Ok(Some(state))
+    }
+
     /// Get the backend type for a sandbox (from stored state or current default)
     /// Check if a sandbox is currently running
     pub fn is_running(&self, name: &str) -> bool {
         self.running
             .get(name)
             .map(|s| s.is_running())
-            .unwrap_or_else(|| {
+            .unwrap_or(false)
+            || self
+                .pause_recovery
+                .get(name)
+                .and_then(|recovery| recovery.sandbox.as_ref())
+                // A recovery-owned handle is charged conservatively: its
+                // typed cleanup failure means termination is not yet proved.
+                .is_some()
+            || {
                 self.sandboxes.get(name).is_some_and(|state| {
                     state.backend.is_some_and(|backend| backend.is_remote())
                         && state
@@ -3462,19 +4767,32 @@ impl VmManager {
                             .get("last_known_status")
                             .is_some_and(|value| value == "running")
                 })
-            })
+            }
     }
 
     /// Update persisted sandbox resource values without recreating.
     pub fn update_resources(&mut self, name: &str, vcpus: u32, memory_mb: u64) -> Result<()> {
-        let state = self
+        if self.pause_recovery.contains_key(name) || self.resume_state_recovery.contains_key(name) {
+            bail!(
+                "Sandbox '{}' has a pending full-state recovery; resume or remove it before changing resources",
+                name
+            );
+        }
+        let mut state = self
             .sandboxes
-            .get_mut(name)
+            .get(name)
+            .cloned()
             .ok_or_else(|| anyhow::anyhow!("Sandbox '{}' not found", name))?;
+        if state.paused_at.is_some() || state.full_state_checkpoint.is_some() {
+            bail!(
+                "Sandbox '{}' is paused with a full-state checkpoint; resume or remove it before changing resources",
+                name
+            );
+        }
         state.vcpus = vcpus;
         state.memory_mb = memory_mb;
-        let snapshot = state.clone();
-        self.save_sandbox(&snapshot)?;
+        self.save_sandbox(&state)?;
+        self.sandboxes.insert(name.to_string(), state);
         Ok(())
     }
 
@@ -3809,6 +5127,7 @@ mod tests {
     use super::*;
     use crate::backend::ExecResult;
     use async_trait::async_trait;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use tempfile::TempDir;
 
     #[test]
@@ -3861,6 +5180,11 @@ mod tests {
             dormant_at: None,
             dormant_reason: None,
             lifecycle_policy: None,
+            full_state_checkpoint: None,
+            full_state_cleanup_pending: Vec::new(),
+            full_state_lineage: false,
+            paused_at: None,
+            forked_from: None,
         };
 
         let json = serde_json::to_string(&state).unwrap();
@@ -3880,13 +5204,24 @@ mod tests {
             "created_at": "2024-01-01T00:00:00Z"
         }"#;
 
-        let state: SandboxState = serde_json::from_str(json).unwrap();
+        let mut state: SandboxState = serde_json::from_str(json).unwrap();
         assert_eq!(state.name, "my-sandbox");
         assert_eq!(state.image, "python:3.12-alpine");
         assert_eq!(state.vcpus, 4);
         assert_eq!(state.memory_mb, 2048);
         assert_eq!(state.vsock_cid, 10);
         assert!(!state.post_create_completed);
+        assert!(state.full_state_checkpoint.is_none());
+        assert!(state.full_state_cleanup_pending.is_empty());
+        assert!(!state.full_state_lineage);
+        assert!(state.paused_at.is_none());
+        assert!(state.forked_from.is_none());
+        assert_eq!(state.status(false), "stopped");
+
+        state.full_state_checkpoint = Some("checkpoint-id".to_string());
+        state.paused_at = Some("2026-08-23T00:00:00Z".to_string());
+        assert_eq!(state.status(false), "paused");
+        assert_eq!(state.status(true), "paused");
     }
 
     #[test]
@@ -3987,6 +5322,11 @@ mod tests {
             dormant_at: None,
             dormant_reason: None,
             lifecycle_policy: None,
+            full_state_checkpoint: None,
+            full_state_cleanup_pending: Vec::new(),
+            full_state_lineage: false,
+            paused_at: None,
+            forked_from: None,
         };
 
         let json = serde_json::to_string(&original).unwrap();
@@ -4074,6 +5414,11 @@ mod tests {
             dormant_at: None,
             dormant_reason: None,
             lifecycle_policy: None,
+            full_state_checkpoint: None,
+            full_state_cleanup_pending: Vec::new(),
+            full_state_lineage: false,
+            paused_at: None,
+            forked_from: None,
         };
         let json = serde_json::to_string(&state).unwrap();
         std::fs::write(temp_dir.path().join("loaded-sandbox.json"), &json).unwrap();
@@ -4177,6 +5522,11 @@ mod tests {
                 dormant_at: None,
                 dormant_reason: None,
                 lifecycle_policy: None,
+                full_state_checkpoint: None,
+                full_state_cleanup_pending: Vec::new(),
+                full_state_lineage: false,
+                paused_at: None,
+                forked_from: None,
             };
             let json = serde_json::to_string(&state).unwrap();
             std::fs::write(temp_dir.path().join(format!("{}.json", name)), &json).unwrap();
@@ -4207,6 +5557,8 @@ mod tests {
             bypass_backend_runtime: false,
             backend: BackendType::Docker,
             running: HashMap::new(),
+            pause_recovery: HashMap::new(),
+            resume_state_recovery: HashMap::new(),
             rootfs_dir: None,
             next_cid: 3,
             detached: HashMap::new(),
@@ -4263,6 +5615,11 @@ mod tests {
             dormant_at: None,
             dormant_reason: None,
             lifecycle_policy: None,
+            full_state_checkpoint: None,
+            full_state_cleanup_pending: Vec::new(),
+            full_state_lineage: false,
+            paused_at: None,
+            forked_from: None,
         };
         std::fs::create_dir_all(temp_dir.path().join("sandboxes")).unwrap();
         manager.sandboxes.insert("label-test".to_string(), state);
@@ -4289,6 +5646,8 @@ mod tests {
             bypass_backend_runtime: false,
             backend: BackendType::Docker,
             running: HashMap::new(),
+            pause_recovery: HashMap::new(),
+            resume_state_recovery: HashMap::new(),
             rootfs_dir: None,
             next_cid: 3,
             detached: HashMap::new(),
@@ -4349,6 +5708,11 @@ mod tests {
                 dormant_at: None,
                 dormant_reason: None,
                 lifecycle_policy: None,
+                full_state_checkpoint: None,
+                full_state_cleanup_pending: Vec::new(),
+                full_state_lineage: false,
+                paused_at: None,
+                forked_from: None,
             };
             manager.sandboxes.insert(name.to_string(), state);
         }
@@ -4380,6 +5744,8 @@ mod tests {
             bypass_backend_runtime: false,
             backend: BackendType::Docker,
             running: HashMap::new(),
+            pause_recovery: HashMap::new(),
+            resume_state_recovery: HashMap::new(),
             rootfs_dir: None,
             next_cid: 3,
             detached: HashMap::new(),
@@ -4436,6 +5802,11 @@ mod tests {
             dormant_at: None,
             dormant_reason: None,
             lifecycle_policy: None,
+            full_state_checkpoint: None,
+            full_state_cleanup_pending: Vec::new(),
+            full_state_lineage: false,
+            paused_at: None,
+            forked_from: None,
         };
         manager.sandboxes.insert("desc-test".to_string(), state);
 
@@ -4517,6 +5888,11 @@ mod tests {
             dormant_at: None,
             dormant_reason: None,
             lifecycle_policy: None,
+            full_state_checkpoint: None,
+            full_state_cleanup_pending: Vec::new(),
+            full_state_lineage: false,
+            paused_at: None,
+            forked_from: None,
         };
 
         // Save to disk
@@ -4583,13 +5959,101 @@ mod tests {
             dormant_at: None,
             dormant_reason: None,
             lifecycle_policy: None,
+            full_state_checkpoint: None,
+            full_state_cleanup_pending: Vec::new(),
+            full_state_lineage: false,
+            paused_at: None,
+            forked_from: None,
         }
+    }
+
+    #[test]
+    fn refresh_sandbox_imports_only_missing_persisted_state() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut manager = new_test_manager(&temp_dir);
+        let state = lifecycle_state("created-by-cli");
+        let state_path = temp_dir
+            .path()
+            .join("sandboxes")
+            .join("created-by-cli.json");
+        std::fs::write(&state_path, serde_json::to_vec_pretty(&state).unwrap()).unwrap();
+
+        assert!(
+            manager
+                .refresh_sandbox_if_missing("created-by-cli")
+                .unwrap()
+        );
+        assert_eq!(
+            manager.get_state("created-by-cli").unwrap().uuid,
+            state.uuid
+        );
+
+        let mut stale = state.clone();
+        stale.image = "should-not-overwrite-live-state".to_string();
+        std::fs::write(&state_path, serde_json::to_vec_pretty(&stale).unwrap()).unwrap();
+        assert!(
+            !manager
+                .refresh_sandbox_if_missing("created-by-cli")
+                .unwrap()
+        );
+        assert_eq!(
+            manager.get_state("created-by-cli").unwrap().image,
+            "alpine:3.24"
+        );
     }
 
     #[allow(dead_code)]
     struct TestSandbox {
         name: String,
         running: bool,
+    }
+
+    struct RecoverySandbox {
+        name: String,
+        running: bool,
+        stop_attempts: Option<Arc<AtomicUsize>>,
+        stop_failures_before_success: usize,
+    }
+
+    #[cfg(unix)]
+    #[derive(Clone, Copy)]
+    enum PauseRollbackMode {
+        Ordinary,
+        Partial,
+        Commit,
+        CommitAmbiguousRestore,
+    }
+
+    #[cfg(unix)]
+    struct PauseRollbackSandbox {
+        name: String,
+        running: bool,
+        state_directory: PathBuf,
+        mode: PauseRollbackMode,
+        stop_attempts: Option<Arc<AtomicUsize>>,
+    }
+
+    #[cfg(unix)]
+    impl PauseRollbackSandbox {
+        fn snapshot() -> FullStateSnapshot {
+            FullStateSnapshot {
+                firecracker_version: "1.16.1".to_string(),
+                architecture: std::env::consts::ARCH.to_string(),
+                host_kernel_release: "test-host-kernel".to_string(),
+                host_identity_sha256: "test-host".to_string(),
+                cpu_fingerprint_sha256: "test-cpu".to_string(),
+                guest_kernel_release: "6.18.45-agentkernel".to_string(),
+            }
+        }
+
+        fn block_state_writes(&self) -> Result<()> {
+            use std::os::unix::fs::PermissionsExt;
+
+            let mut permissions = std::fs::metadata(&self.state_directory)?.permissions();
+            permissions.set_mode(0o500);
+            std::fs::set_permissions(&self.state_directory, permissions)?;
+            Ok(())
+        }
     }
 
     #[async_trait]
@@ -4635,6 +6099,736 @@ mod tests {
         async fn mkdir_unchecked(&mut self, _path: &str, _recursive: bool) -> Result<()> {
             Ok(())
         }
+    }
+
+    #[async_trait]
+    impl Sandbox for RecoverySandbox {
+        async fn start(&mut self, _config: &SandboxConfig) -> Result<()> {
+            self.running = true;
+            Ok(())
+        }
+
+        async fn exec(&mut self, _cmd: &[&str]) -> Result<ExecResult> {
+            Ok(ExecResult::success(String::new()))
+        }
+
+        async fn stop(&mut self) -> Result<()> {
+            if let Some(attempts) = &self.stop_attempts
+                && attempts.fetch_add(1, Ordering::SeqCst) < self.stop_failures_before_success
+            {
+                return Err(FullStateTerminationError {
+                    process_may_be_running: true,
+                    detail: "simulated ambiguous wait after kill".to_string(),
+                }
+                .into());
+            }
+            self.running = false;
+            Ok(())
+        }
+
+        async fn retry_full_state_resume(&mut self) -> Result<()> {
+            self.running = true;
+            Ok(())
+        }
+
+        fn name(&self) -> &str {
+            &self.name
+        }
+
+        fn backend_type(&self) -> BackendType {
+            BackendType::Firecracker
+        }
+
+        fn is_running(&self) -> bool {
+            self.running
+        }
+
+        async fn write_file_unchecked(&mut self, _path: &str, _content: &[u8]) -> Result<()> {
+            Ok(())
+        }
+
+        async fn read_file_unchecked(&mut self, _path: &str) -> Result<Vec<u8>> {
+            Ok(Vec::new())
+        }
+
+        async fn remove_file_unchecked(&mut self, _path: &str) -> Result<()> {
+            Ok(())
+        }
+
+        async fn mkdir_unchecked(&mut self, _path: &str, _recursive: bool) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    #[cfg(unix)]
+    #[async_trait]
+    impl Sandbox for PauseRollbackSandbox {
+        async fn start(&mut self, _config: &SandboxConfig) -> Result<()> {
+            self.running = true;
+            Ok(())
+        }
+
+        async fn exec(&mut self, _cmd: &[&str]) -> Result<ExecResult> {
+            Ok(ExecResult::success(String::new()))
+        }
+
+        async fn stop(&mut self) -> Result<()> {
+            if let Some(attempts) = &self.stop_attempts {
+                attempts.fetch_add(1, Ordering::SeqCst);
+            }
+            self.running = false;
+            Ok(())
+        }
+
+        async fn pause_to(&mut self, checkpoint_dir: &Path) -> Result<FullStateSnapshot> {
+            match self.mode {
+                PauseRollbackMode::Ordinary => {
+                    self.block_state_writes()?;
+                    bail!("simulated ordinary snapshot failure")
+                }
+                PauseRollbackMode::Partial => {
+                    self.running = false;
+                    Err(FullStatePauseError::source_resume_failed(
+                        Self::snapshot(),
+                        false,
+                        "simulated partial snapshot failure",
+                        "simulated first resume failure",
+                    )
+                    .into())
+                }
+                PauseRollbackMode::Commit | PauseRollbackMode::CommitAmbiguousRestore => {
+                    std::fs::write(checkpoint_dir.join("memory.bin"), b"memory")?;
+                    std::fs::write(checkpoint_dir.join("vmstate.bin"), b"vmstate")?;
+                    std::fs::write(checkpoint_dir.join("rootfs.ext4"), b"rootfs")?;
+                    let staging_name = checkpoint_dir
+                        .file_name()
+                        .and_then(|name| name.to_str())
+                        .context("missing checkpoint staging name")?;
+                    let checkpoint_id = staging_name
+                        .strip_prefix(".staging-")
+                        .context("invalid checkpoint staging name")?;
+                    std::fs::create_dir(checkpoint_dir.parent().unwrap().join(checkpoint_id))?;
+                    self.running = false;
+                    Ok(Self::snapshot())
+                }
+            }
+        }
+
+        async fn retry_full_state_resume(&mut self) -> Result<()> {
+            self.running = true;
+            self.block_state_writes()
+        }
+
+        async fn restore_from(
+            &mut self,
+            _checkpoint_dir: &Path,
+            _snapshot: &FullStateSnapshot,
+        ) -> Result<()> {
+            if matches!(self.mode, PauseRollbackMode::CommitAmbiguousRestore) {
+                self.running = false;
+                return Err(FullStateTerminationError {
+                    process_may_be_running: true,
+                    detail: "simulated ambiguous cleanup after rollback restore".to_string(),
+                }
+                .into());
+            }
+            self.running = true;
+            self.block_state_writes()
+        }
+
+        fn name(&self) -> &str {
+            &self.name
+        }
+
+        fn backend_type(&self) -> BackendType {
+            BackendType::Firecracker
+        }
+
+        fn is_running(&self) -> bool {
+            self.running
+        }
+
+        async fn write_file_unchecked(&mut self, _path: &str, _content: &[u8]) -> Result<()> {
+            Ok(())
+        }
+
+        async fn read_file_unchecked(&mut self, _path: &str) -> Result<Vec<u8>> {
+            Ok(Vec::new())
+        }
+
+        async fn remove_file_unchecked(&mut self, _path: &str) -> Result<()> {
+            Ok(())
+        }
+
+        async fn mkdir_unchecked(&mut self, _path: &str, _recursive: bool) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    fn insert_pause_recovery(manager: &mut VmManager, name: &str) -> PathBuf {
+        let store = FullStateCheckpointStore::new(&manager.data_dir).unwrap();
+        let staging = store.begin().unwrap();
+        let id = staging.id().to_string();
+        let staging_path = staging.preserve();
+        let mut state = lifecycle_state(name);
+        state.backend = Some(BackendType::Firecracker);
+        state.paused_at = Some(chrono::Utc::now().to_rfc3339());
+        state.full_state_checkpoint = Some(id);
+        manager.sandboxes.insert(name.to_string(), state);
+        manager.pause_recovery.insert(
+            name.to_string(),
+            PendingFullStateRecovery {
+                sandbox: Some(Box::new(RecoverySandbox {
+                    name: name.to_string(),
+                    running: false,
+                    stop_attempts: None,
+                    stop_failures_before_success: 0,
+                })),
+                staging_path: staging_path.clone(),
+                completed_snapshot: None,
+            },
+        );
+        staging_path
+    }
+
+    #[cfg(feature = "enterprise")]
+    #[test]
+    fn pause_recovery_owned_runtime_counts_toward_running_quota() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut manager = new_test_manager(&temp_dir);
+        insert_pause_recovery(&mut manager, "quota-recovery");
+
+        assert!(manager.is_running("quota-recovery"));
+        let subject = crate::quota::QuotaSubject {
+            user_id: "anonymous".to_string(),
+            org_id: "default".to_string(),
+        };
+        let quota = crate::quota::QuotaController::new(crate::config::ResourceQuotaConfig {
+            enabled: true,
+            default_limits: crate::config::ResourceQuotaLimits {
+                max_running_sandboxes: Some(1),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        let status = quota.status(&manager, &subject);
+        assert_eq!(status.user.usage.running_sandboxes, 1);
+        let error = quota.check_create(&manager, &subject, 1, 512).unwrap_err();
+        assert!(error.to_string().contains("max_running_sandboxes"));
+    }
+
+    #[tokio::test]
+    async fn recovery_pending_resume_retries_live_source_and_cleans_staging() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut manager = new_test_manager(&temp_dir);
+        let staging_path = insert_pause_recovery(&mut manager, "recover-live");
+
+        manager.resume("recover-live").await.unwrap();
+
+        assert!(manager.pause_recovery.is_empty());
+        assert!(manager.is_running("recover-live"));
+        assert!(!staging_path.exists());
+        let state = manager.get_state("recover-live").unwrap();
+        assert!(state.paused_at.is_none());
+        assert!(state.full_state_checkpoint.is_none());
+        assert!(state.full_state_cleanup_pending.is_empty());
+    }
+
+    #[tokio::test]
+    async fn resumed_runtime_metadata_failure_is_retryable_without_a_second_vm() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut manager = new_test_manager(&temp_dir);
+        let staging_path = insert_pause_recovery(&mut manager, "resume-metadata-retry");
+        let sandboxes_dir = temp_dir.path().join("sandboxes");
+        std::fs::remove_dir(&sandboxes_dir).unwrap();
+        std::fs::write(&sandboxes_dir, b"blocks state directory").unwrap();
+
+        let error = manager.resume("resume-metadata-retry").await.unwrap_err();
+        assert!(error.to_string().contains("could not be persisted"));
+        assert!(manager.is_running("resume-metadata-retry"));
+        assert!(
+            manager
+                .resume_state_recovery
+                .contains_key("resume-metadata-retry")
+        );
+        assert!(staging_path.exists());
+
+        #[cfg(feature = "enterprise")]
+        {
+            let quota = crate::quota::QuotaController::new(crate::config::ResourceQuotaConfig {
+                enabled: true,
+                default_limits: crate::config::ResourceQuotaLimits {
+                    max_running_sandboxes: Some(1),
+                    ..Default::default()
+                },
+                ..Default::default()
+            });
+            quota
+                .check_start(&manager, "resume-metadata-retry")
+                .expect("metadata recovery must not consume a second running slot");
+        }
+
+        std::fs::remove_file(&sandboxes_dir).unwrap();
+        std::fs::create_dir(&sandboxes_dir).unwrap();
+        manager.resume("resume-metadata-retry").await.unwrap();
+
+        assert!(manager.is_running("resume-metadata-retry"));
+        assert!(manager.resume_state_recovery.is_empty());
+        assert!(!staging_path.exists());
+        assert!(
+            manager
+                .get_state("resume-metadata-retry")
+                .unwrap()
+                .paused_at
+                .is_none()
+        );
+    }
+
+    #[cfg(unix)]
+    async fn assert_failed_pause_rollback_is_metadata_retryable(
+        name: &str,
+        mode: PauseRollbackMode,
+    ) {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_dir = TempDir::new().unwrap();
+        let mut manager = new_test_manager(&temp_dir);
+        let state_directory = temp_dir.path().join("sandboxes");
+        let mut state = lifecycle_state(name);
+        state.backend = Some(BackendType::Firecracker);
+        manager.save_sandbox(&state).unwrap();
+        manager.sandboxes.insert(name.to_string(), state);
+        manager.running.insert(
+            name.to_string(),
+            Box::new(PauseRollbackSandbox {
+                name: name.to_string(),
+                running: true,
+                state_directory: state_directory.clone(),
+                mode,
+                stop_attempts: None,
+            }),
+        );
+
+        let error = manager.pause(name).await.unwrap_err();
+        assert!(error.to_string().contains("recovery ownership"));
+        assert!(manager.running.contains_key(name));
+        assert!(manager.resume_state_recovery.contains_key(name));
+        let paused = manager.get_state(name).unwrap();
+        assert!(paused.paused_at.is_some());
+        let checkpoint_id = paused.full_state_checkpoint.clone().unwrap();
+        let staging_path = FullStateCheckpointStore::new(&manager.data_dir)
+            .unwrap()
+            .staging_path(&checkpoint_id)
+            .unwrap();
+        assert!(staging_path.is_dir());
+
+        let persisted: SandboxState = serde_json::from_slice(
+            &std::fs::read(state_directory.join(format!("{name}.json"))).unwrap(),
+        )
+        .unwrap();
+        assert!(persisted.paused_at.is_some());
+        assert_eq!(
+            persisted.full_state_checkpoint.as_deref(),
+            Some(checkpoint_id.as_str())
+        );
+
+        let mut permissions = std::fs::metadata(&state_directory).unwrap().permissions();
+        permissions.set_mode(0o700);
+        std::fs::set_permissions(&state_directory, permissions).unwrap();
+        manager.resume(name).await.unwrap();
+
+        assert!(manager.running.contains_key(name));
+        assert!(!manager.resume_state_recovery.contains_key(name));
+        assert!(!staging_path.exists());
+        let running = manager.get_state(name).unwrap();
+        assert!(running.paused_at.is_none());
+        assert!(running.full_state_checkpoint.is_none());
+        assert!(running.full_state_cleanup_pending.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn ordinary_pause_failure_and_rollback_write_failure_retain_live_recovery() {
+        assert_failed_pause_rollback_is_metadata_retryable(
+            "ordinary-rollback-retry",
+            PauseRollbackMode::Ordinary,
+        )
+        .await;
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn partial_pause_failure_and_rollback_write_failure_retain_live_recovery() {
+        assert_failed_pause_rollback_is_metadata_retryable(
+            "partial-rollback-retry",
+            PauseRollbackMode::Partial,
+        )
+        .await;
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn commit_failure_and_rollback_write_failure_retain_live_recovery() {
+        assert_failed_pause_rollback_is_metadata_retryable(
+            "commit-rollback-retry",
+            PauseRollbackMode::Commit,
+        )
+        .await;
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn ambiguous_commit_rollback_retains_runtime_and_blocks_fork_until_reconciled() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut manager = new_test_manager(&temp_dir);
+        let name = "ambiguous-commit-rollback";
+        let mut state = lifecycle_state(name);
+        state.backend = Some(BackendType::Firecracker);
+        manager.save_sandbox(&state).unwrap();
+        manager.sandboxes.insert(name.to_string(), state);
+        let stop_attempts = Arc::new(AtomicUsize::new(0));
+        manager.running.insert(
+            name.to_string(),
+            Box::new(PauseRollbackSandbox {
+                name: name.to_string(),
+                running: true,
+                state_directory: temp_dir.path().join("sandboxes"),
+                mode: PauseRollbackMode::CommitAmbiguousRestore,
+                stop_attempts: Some(Arc::clone(&stop_attempts)),
+            }),
+        );
+
+        let pause_error = manager.pause(name).await.unwrap_err();
+        assert!(pause_error.to_string().contains("failed to resume source"));
+        let recovery = manager.pause_recovery.get(name).unwrap();
+        assert!(recovery.sandbox.is_some());
+        assert!(recovery.completed_snapshot.is_some());
+
+        let fork_error = manager
+            .fork_sandbox(name, "unsafe-child")
+            .await
+            .unwrap_err();
+        assert!(
+            fork_error
+                .to_string()
+                .contains("pending full-state recovery")
+        );
+        assert!(!manager.sandboxes.contains_key("unsafe-child"));
+
+        let checkpoint_id = manager
+            .get_state(name)
+            .unwrap()
+            .full_state_checkpoint
+            .clone()
+            .unwrap();
+        std::fs::remove_dir(
+            manager
+                .data_dir
+                .join("full-state-checkpoints")
+                .join(&checkpoint_id),
+        )
+        .unwrap();
+
+        // Reconciliation must stop the retained possibly-live runtime before
+        // publishing the checkpoint. Loading then fails on the mock host
+        // fingerprint, leaving the source safely paused and reusable.
+        assert!(manager.resume(name).await.is_err());
+        assert_eq!(stop_attempts.load(Ordering::SeqCst), 1);
+        assert!(!manager.pause_recovery.contains_key(name));
+        assert!(
+            FullStateCheckpointStore::new(&manager.data_dir)
+                .unwrap()
+                .contains(&checkpoint_id)
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn completed_recovery_reconfirms_termination_then_publishes() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut manager = new_test_manager(&temp_dir);
+        let store = FullStateCheckpointStore::new(&manager.data_dir).unwrap();
+        let staging = store.begin().unwrap();
+        let checkpoint_id = staging.id().to_string();
+        std::fs::write(staging.path().join("memory.bin"), b"memory").unwrap();
+        std::fs::write(staging.path().join("vmstate.bin"), b"vmstate").unwrap();
+        std::fs::write(staging.path().join("rootfs.ext4"), b"rootfs").unwrap();
+        let staging_path = staging.preserve();
+
+        let mut state = lifecycle_state("complete-recovery");
+        state.backend = Some(BackendType::Firecracker);
+        state.paused_at = Some(chrono::Utc::now().to_rfc3339());
+        state.full_state_checkpoint = Some(checkpoint_id.clone());
+        manager
+            .sandboxes
+            .insert("complete-recovery".to_string(), state);
+
+        let stop_attempts = Arc::new(AtomicUsize::new(0));
+        manager.pause_recovery.insert(
+            "complete-recovery".to_string(),
+            PendingFullStateRecovery {
+                sandbox: Some(Box::new(RecoverySandbox {
+                    name: "complete-recovery".to_string(),
+                    running: false,
+                    stop_attempts: Some(Arc::clone(&stop_attempts)),
+                    stop_failures_before_success: 1,
+                })),
+                staging_path: staging_path.clone(),
+                completed_snapshot: Some(FullStateSnapshot {
+                    firecracker_version: "1.16.1".to_string(),
+                    architecture: "incompatible-test-architecture".to_string(),
+                    host_kernel_release: "test-host-kernel".to_string(),
+                    host_identity_sha256: "test-host".to_string(),
+                    cpu_fingerprint_sha256: "test-cpu".to_string(),
+                    guest_kernel_release: "6.18.45-agentkernel".to_string(),
+                }),
+            },
+        );
+
+        let first_error = manager.resume("complete-recovery").await.unwrap_err();
+        assert!(first_error.to_string().contains("confirm termination"));
+        assert!(staging_path.exists());
+        assert!(!store.contains(&checkpoint_id).unwrap());
+        assert!(manager.pause_recovery.contains_key("complete-recovery"));
+
+        // The second termination probe succeeds. Restore then fails at the
+        // deliberately incompatible architecture, proving publication
+        // happened before any VMM was allowed to load the checkpoint.
+        assert!(manager.resume("complete-recovery").await.is_err());
+        assert_eq!(stop_attempts.load(Ordering::SeqCst), 2);
+        assert!(!staging_path.exists());
+        assert!(store.contains(&checkpoint_id).unwrap());
+        assert!(!manager.pause_recovery.contains_key("complete-recovery"));
+    }
+
+    #[test]
+    fn pending_checkpoint_cleanup_is_retried_and_persistently_cleared() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut manager = new_test_manager(&temp_dir);
+        let store = FullStateCheckpointStore::new(&manager.data_dir).unwrap();
+        let staging = store.begin().unwrap();
+        let checkpoint_id = staging.id().to_string();
+        let staging_path = staging.preserve();
+
+        let mut state = lifecycle_state("cleanup-retry");
+        state.full_state_cleanup_pending = vec![checkpoint_id];
+        manager.save_sandbox(&state).unwrap();
+        manager.sandboxes.insert("cleanup-retry".to_string(), state);
+
+        manager.reconcile_full_state_cleanup();
+
+        assert!(!staging_path.exists());
+        assert!(
+            manager
+                .get_state("cleanup-retry")
+                .unwrap()
+                .full_state_cleanup_pending
+                .is_empty()
+        );
+        let reloaded = VmManager::load_sandboxes(&temp_dir.path().join("sandboxes")).unwrap();
+        assert!(
+            reloaded["cleanup-retry"]
+                .full_state_cleanup_pending
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn removing_recovery_pending_source_discards_live_handle_and_staging() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut manager = new_test_manager(&temp_dir);
+        let staging_path = insert_pause_recovery(&mut manager, "remove-recovery");
+
+        manager.remove("remove-recovery").await.unwrap();
+
+        assert!(!manager.exists("remove-recovery"));
+        assert!(manager.pause_recovery.is_empty());
+        assert!(!staging_path.exists());
+    }
+
+    #[tokio::test]
+    async fn archived_or_dormant_paused_sandboxes_require_recovery_first() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut manager = new_test_manager(&temp_dir);
+
+        let mut archived = lifecycle_state("archived-pause");
+        archived.backend = Some(BackendType::Firecracker);
+        archived.paused_at = Some(chrono::Utc::now().to_rfc3339());
+        archived.full_state_checkpoint = Some(uuid::Uuid::new_v4().to_string());
+        archived.archived_at = Some(chrono::Utc::now().to_rfc3339());
+        manager
+            .sandboxes
+            .insert("archived-pause".to_string(), archived);
+        let resume_error = manager.resume("archived-pause").await.unwrap_err();
+        assert!(
+            resume_error
+                .to_string()
+                .contains("recover it before resuming")
+        );
+
+        let mut dormant = lifecycle_state("dormant-pause");
+        dormant.backend = Some(BackendType::Firecracker);
+        dormant.paused_at = Some(chrono::Utc::now().to_rfc3339());
+        dormant.full_state_checkpoint = Some(uuid::Uuid::new_v4().to_string());
+        dormant.dormant_at = Some(chrono::Utc::now().to_rfc3339());
+        manager
+            .sandboxes
+            .insert("dormant-pause".to_string(), dormant);
+        let fork_error = manager
+            .fork_sandbox("dormant-pause", "child")
+            .await
+            .unwrap_err();
+        assert!(fork_error.to_string().contains("recover it before forking"));
+    }
+
+    #[test]
+    fn paused_and_recovery_pending_sandboxes_reject_resource_changes() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut manager = new_test_manager(&temp_dir);
+
+        let mut paused = lifecycle_state("paused-resize");
+        paused.backend = Some(BackendType::Firecracker);
+        paused.paused_at = Some(chrono::Utc::now().to_rfc3339());
+        paused.full_state_checkpoint = Some(uuid::Uuid::new_v4().to_string());
+        manager
+            .sandboxes
+            .insert("paused-resize".to_string(), paused);
+        let error = manager
+            .update_resources("paused-resize", 8, 16_384)
+            .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("paused with a full-state checkpoint")
+        );
+        assert_eq!(manager.get_state("paused-resize").unwrap().vcpus, 1);
+
+        insert_pause_recovery(&mut manager, "recovery-resize");
+        let error = manager
+            .update_resources("recovery-resize", 8, 16_384)
+            .unwrap_err();
+        assert!(error.to_string().contains("pending full-state recovery"));
+        assert_eq!(manager.get_state("recovery-resize").unwrap().vcpus, 1);
+    }
+
+    #[tokio::test]
+    async fn ambiguous_fork_restore_owner_rejects_a_second_start() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut manager = new_test_manager(&temp_dir);
+        let name = "ambiguous-fork-child";
+        let mut state = lifecycle_state(name);
+        state.backend = Some(BackendType::Firecracker);
+        state.full_state_lineage = true;
+        manager.sandboxes.insert(name.to_string(), state);
+        manager.pause_recovery.insert(
+            name.to_string(),
+            PendingFullStateRecovery {
+                sandbox: Some(Box::new(RecoverySandbox {
+                    name: name.to_string(),
+                    running: false,
+                    stop_attempts: None,
+                    stop_failures_before_success: 0,
+                })),
+                staging_path: temp_dir.path().join("published-source-checkpoint"),
+                completed_snapshot: None,
+            },
+        );
+
+        let error = manager.start(name).await.unwrap_err();
+        assert!(error.to_string().contains("pending full-state recovery"));
+        assert!(manager.pause_recovery.contains_key(name));
+        assert!(!manager.running.contains_key(name));
+    }
+
+    #[tokio::test]
+    async fn full_state_lineage_rejects_lossy_ordinary_stop() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut manager = new_test_manager(&temp_dir);
+        let mut state = lifecycle_state("full-state-child");
+        state.backend = Some(BackendType::Firecracker);
+        state.full_state_lineage = true;
+        manager
+            .sandboxes
+            .insert("full-state-child".to_string(), state);
+        manager.running.insert(
+            "full-state-child".to_string(),
+            Box::new(RecoverySandbox {
+                name: "full-state-child".to_string(),
+                running: true,
+                stop_attempts: None,
+                stop_failures_before_success: 0,
+            }),
+        );
+
+        manager
+            .set_labels(
+                "full-state-child",
+                &HashMap::from([("team".to_string(), "sandbox".to_string())]),
+            )
+            .unwrap();
+        assert!(
+            manager
+                .get_state("full-state-child")
+                .unwrap()
+                .full_state_lineage
+        );
+
+        let error = manager.stop("full-state-child").await.unwrap_err();
+        assert!(error.to_string().contains("use full-state pause"));
+        assert!(manager.is_running("full-state-child"));
+    }
+
+    #[tokio::test]
+    async fn persisted_full_state_lineage_rejects_cold_start_after_manager_restart() {
+        let temp_dir = TempDir::new().unwrap();
+        let manager = new_test_manager(&temp_dir);
+        let name = "restarted-full-state-child";
+        let mut state = lifecycle_state(name);
+        state.backend = Some(BackendType::Firecracker);
+        state.full_state_lineage = true;
+        manager.save_sandbox(&state).unwrap();
+        drop(manager);
+
+        let persisted = VmManager::load_sandboxes(&temp_dir.path().join("sandboxes")).unwrap();
+        let mut restarted = new_test_manager(&temp_dir);
+        restarted.sandboxes = persisted;
+
+        let error = restarted.start(name).await.unwrap_err();
+        assert!(error.to_string().contains("cold start would lose"));
+        assert!(!restarted.running.contains_key(name));
+    }
+
+    #[tokio::test]
+    async fn ordinary_stop_retains_handle_when_typed_error_says_runtime_may_survive() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut manager = new_test_manager(&temp_dir);
+        let mut state = lifecycle_state("ambiguous-stop");
+        state.backend = Some(BackendType::Firecracker);
+        manager
+            .sandboxes
+            .insert("ambiguous-stop".to_string(), state);
+        let stop_attempts = Arc::new(AtomicUsize::new(0));
+        manager.running.insert(
+            "ambiguous-stop".to_string(),
+            Box::new(RecoverySandbox {
+                name: "ambiguous-stop".to_string(),
+                // Simulate a best-effort process probe returning false even
+                // though the strict termination result remains ambiguous.
+                running: false,
+                stop_attempts: Some(Arc::clone(&stop_attempts)),
+                stop_failures_before_success: 1,
+            }),
+        );
+
+        let error = manager.stop("ambiguous-stop").await.unwrap_err();
+        assert!(error.to_string().contains("failed to stop sandbox"));
+        assert!(manager.running.contains_key("ambiguous-stop"));
+        assert_eq!(stop_attempts.load(Ordering::SeqCst), 1);
+
+        manager.stop("ambiguous-stop").await.unwrap();
+        assert!(!manager.running.contains_key("ambiguous-stop"));
+        assert_eq!(stop_attempts.load(Ordering::SeqCst), 2);
     }
 
     #[test]
@@ -4689,6 +6883,37 @@ mod tests {
         assert_eq!(
             manager.dormant_time("dormant-test").unwrap().to_rfc3339(),
             "2026-02-01T00:00:00+00:00"
+        );
+    }
+
+    #[test]
+    fn failed_lifecycle_policy_save_does_not_mutate_manager_state() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut manager = new_test_manager(&temp_dir);
+        manager.sandboxes.insert(
+            "policy-save-failure".to_string(),
+            lifecycle_state("policy-save-failure"),
+        );
+        let sandboxes_dir = temp_dir.path().join("sandboxes");
+        std::fs::remove_dir(&sandboxes_dir).unwrap();
+        std::fs::write(&sandboxes_dir, b"blocks state directory").unwrap();
+
+        let result = manager.set_lifecycle_policy(
+            "policy-save-failure",
+            Some(SandboxLifecyclePolicy {
+                auto_stop_after_seconds: None,
+                auto_archive_after_seconds: Some(0),
+                auto_delete_after_seconds: Some(0),
+            }),
+        );
+
+        assert!(result.is_err());
+        assert!(
+            manager
+                .get_state("policy-save-failure")
+                .unwrap()
+                .lifecycle_policy
+                .is_none()
         );
     }
 

--- a/tests/firecracker_full_state_contract.rs
+++ b/tests/firecracker_full_state_contract.rs
@@ -1,0 +1,118 @@
+use agentkernel::backend::{
+    ContainerRuntime, DockerSandbox, FullStateSnapshot, HyperlightSandbox, RemoteProvider,
+    RemoteSandbox, RemoteSandboxContext, Sandbox,
+};
+
+#[cfg(target_os = "macos")]
+use agentkernel::backend::AppleSandbox;
+#[cfg(feature = "kubernetes")]
+use agentkernel::backend::KubernetesSandbox;
+#[cfg(feature = "nomad")]
+use agentkernel::backend::NomadSandbox;
+#[cfg(any(feature = "kubernetes", feature = "nomad"))]
+use agentkernel::config::OrchestratorConfig;
+
+fn compatibility_metadata() -> FullStateSnapshot {
+    FullStateSnapshot {
+        firecracker_version: "1.16.1".to_string(),
+        architecture: "x86_64".to_string(),
+        host_kernel_release: "6.18.45-agentkernel".to_string(),
+        host_identity_sha256: "host-id".to_string(),
+        cpu_fingerprint_sha256: "cpu-id".to_string(),
+        guest_kernel_release: "6.18.45-agentkernel".to_string(),
+    }
+}
+
+fn assert_empty(directory: &std::path::Path) {
+    assert!(
+        std::fs::read_dir(directory).unwrap().next().is_none(),
+        "an unsupported full-state operation must not create artifacts"
+    );
+}
+
+async fn assert_full_state_unsupported(mut sandbox: Box<dyn Sandbox>) {
+    let backend = sandbox.backend_type().to_string();
+    let checkpoint = tempfile::tempdir().unwrap();
+    let expected = format!(
+        "Backend '{}' does not support full-state pause/resume",
+        backend
+    );
+
+    let pause_error = sandbox.pause_to(checkpoint.path()).await.unwrap_err();
+    assert_eq!(pause_error.to_string(), expected);
+    assert_empty(checkpoint.path());
+
+    let restore_error = sandbox
+        .restore_from(checkpoint.path(), &compatibility_metadata())
+        .await
+        .unwrap_err();
+    assert_eq!(restore_error.to_string(), expected);
+    assert_empty(checkpoint.path());
+}
+
+#[test]
+fn full_state_compatibility_metadata_has_a_stable_json_contract() {
+    let encoded = serde_json::to_value(compatibility_metadata()).unwrap();
+    assert_eq!(
+        encoded,
+        serde_json::json!({
+            "firecracker_version": "1.16.1",
+            "architecture": "x86_64",
+            "host_kernel_release": "6.18.45-agentkernel",
+            "host_identity_sha256": "host-id",
+            "cpu_fingerprint_sha256": "cpu-id",
+            "guest_kernel_release": "6.18.45-agentkernel"
+        })
+    );
+
+    let decoded: FullStateSnapshot = serde_json::from_value(encoded).unwrap();
+    assert_eq!(decoded, compatibility_metadata());
+}
+
+#[tokio::test]
+async fn non_firecracker_backends_reject_full_state_without_artifacts() {
+    let mut sandboxes: Vec<Box<dyn Sandbox>> = vec![
+        Box::new(DockerSandbox::new(
+            "full-state-docker-contract",
+            ContainerRuntime::Docker,
+        )),
+        Box::new(DockerSandbox::new(
+            "full-state-podman-contract",
+            ContainerRuntime::Podman,
+        )),
+        Box::new(HyperlightSandbox::new("full-state-hyperlight-contract")),
+    ];
+
+    for provider in [
+        RemoteProvider::Daytona,
+        RemoteProvider::Runloop,
+        RemoteProvider::E2B,
+        RemoteProvider::Modal,
+        RemoteProvider::AgentComputer,
+    ] {
+        sandboxes.push(Box::new(RemoteSandbox::new(
+            provider,
+            &format!("full-state-{provider}-contract"),
+            RemoteSandboxContext::default(),
+        )));
+    }
+
+    #[cfg(target_os = "macos")]
+    sandboxes.push(Box::new(AppleSandbox::new("full-state-apple-contract")));
+
+    #[cfg(feature = "kubernetes")]
+    sandboxes.push(Box::new(KubernetesSandbox::new(
+        "full-state-kubernetes-contract",
+        &OrchestratorConfig::default(),
+    )));
+
+    #[cfg(feature = "nomad")]
+    sandboxes.push(Box::new(NomadSandbox::new(
+        "full-state-nomad-contract",
+        &OrchestratorConfig::default(),
+    )));
+
+    for sandbox in sandboxes {
+        assert_full_state_unsupported(sandbox).await;
+    }
+}

--- a/tests/firecracker_kvm_smoke.rs
+++ b/tests/firecracker_kvm_smoke.rs
@@ -5,13 +5,8 @@
 
 use agentkernel::backend::firecracker::FirecrackerSandbox;
 use agentkernel::backend::{Sandbox, SandboxConfig};
-use agentkernel::firecracker_client::{
-    FirecrackerClient, SnapshotCreateParams, SnapshotLoadParams, VsockOverride,
-};
-use agentkernel::vsock::VsockClient;
-use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
-use std::time::Duration;
+use std::path::PathBuf;
+use std::process::Command;
 
 fn required_path(name: &str) -> PathBuf {
     let path = std::env::var_os(name)
@@ -19,27 +14,6 @@ fn required_path(name: &str) -> PathBuf {
         .unwrap_or_else(|| panic!("{name} must point to a prepared smoke-test asset"));
     assert!(path.is_file(), "{name} does not exist: {}", path.display());
     path
-}
-
-async fn wait_for_path(path: &Path) {
-    for _ in 0..100 {
-        if path.exists() {
-            return;
-        }
-        tokio::time::sleep(Duration::from_millis(100)).await;
-    }
-    panic!("timed out waiting for {}", path.display());
-}
-
-async fn wait_for_vsock(path: &Path) -> VsockClient {
-    let client = VsockClient::for_firecracker(path.to_path_buf());
-    for _ in 0..100 {
-        if client.ping().await.unwrap_or(false) {
-            return client;
-        }
-        tokio::time::sleep(Duration::from_millis(100)).await;
-    }
-    panic!("timed out waiting for restored vsock {}", path.display());
 }
 
 #[tokio::test]
@@ -88,73 +62,90 @@ async fn firecracker_lifecycle_exec_network_vsock_snapshot_recovery() {
         .write_file("/tmp/snapshot-marker", b"survived-restore")
         .await
         .expect("write snapshot marker over vsock");
+    let background = sandbox
+        .exec(&[
+            "sh",
+            "-c",
+            "nohup sh -c 'while :; do sleep 60; done' >/dev/null 2>&1 & echo $! >/tmp/snapshot-process.pid",
+        ])
+        .await
+        .expect("start process whose memory state must survive");
+    assert_eq!(background.exit_code, 0, "{}", background.stderr);
 
     let snapshot_dir = tempfile::tempdir().expect("create snapshot directory");
-    let mem_path = snapshot_dir.path().join("microvm.mem");
-    let state_path = snapshot_dir.path().join("microvm.state");
-    let original_socket = PathBuf::from(format!("/tmp/agentkernel-{name}.sock"));
-    let original_rootfs = sandbox
-        .prepared_rootfs_path()
-        .expect("started sandbox has a private rootfs")
-        .to_path_buf();
-    let rootfs_backup = snapshot_dir.path().join("rootfs.ext4");
-    let client = FirecrackerClient::new(&original_socket);
-    client.pause().await.expect("pause microVM for snapshot");
-    client
-        .create_snapshot(&SnapshotCreateParams {
-            mem_file_path: mem_path.to_string_lossy().into_owned(),
-            snapshot_path: state_path.to_string_lossy().into_owned(),
-            snapshot_type: "Full".to_string(),
-        })
+    let source_api = sandbox.api_socket_path().to_path_buf();
+    let source_vsock = sandbox.vsock_socket_path().to_path_buf();
+    let snapshot = sandbox
+        .pause_to(snapshot_dir.path())
         .await
-        .expect("create full Firecracker snapshot");
-    std::fs::copy(&original_rootfs, &rootfs_backup).expect("preserve snapshot rootfs");
-    sandbox.stop().await.expect("stop original microVM");
-    std::fs::create_dir_all(original_rootfs.parent().expect("rootfs has a parent"))
-        .expect("recreate rootfs artifact directory");
-    std::fs::copy(&rootfs_backup, &original_rootfs).expect("restore snapshot rootfs path");
+        .expect("pause microVM into full-state checkpoint");
+    assert_eq!(snapshot.firecracker_version, "1.16.1");
+    assert!(!sandbox.is_running());
+    assert!(!source_api.exists());
+    assert!(!source_vsock.exists());
+    for artifact in ["memory.bin", "vmstate.bin", "rootfs.ext4"] {
+        assert!(snapshot_dir.path().join(artifact).is_file(), "{artifact}");
+    }
 
-    let restored_socket = snapshot_dir.path().join("restored-api.sock");
-    let restored_vsock = snapshot_dir.path().join("restored-vsock.sock");
-    let mut restored = Command::new(&firecracker)
-        .arg("--api-sock")
-        .arg(&restored_socket)
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("start Firecracker for snapshot recovery");
-    wait_for_path(&restored_socket).await;
+    let mut first = FirecrackerSandbox::new(&format!("{name}-fork-a"))
+        .expect("create first restored Firecracker sandbox");
+    let mut second = FirecrackerSandbox::new(&format!("{name}-fork-b"))
+        .expect("create second restored Firecracker sandbox");
+    assert_ne!(first.api_socket_path(), second.api_socket_path());
+    assert_ne!(first.vsock_socket_path(), second.vsock_socket_path());
+    assert_ne!(first.api_socket_path(), source_api);
+    assert_ne!(second.vsock_socket_path(), source_vsock);
 
-    let restored_client = FirecrackerClient::new(&restored_socket);
-    restored_client
-        .load_snapshot(&SnapshotLoadParams {
-            mem_file_path: mem_path.to_string_lossy().into_owned(),
-            snapshot_path: state_path.to_string_lossy().into_owned(),
-            resume_vm: true,
-            vsock_override: VsockOverride {
-                uds_path: restored_vsock.to_string_lossy().into_owned(),
-            },
-        })
-        .await
-        .expect("load and resume Firecracker snapshot");
-
-    let restored_vsock_client = wait_for_vsock(&restored_vsock).await;
-    let marker = restored_vsock_client
-        .run_command(&["cat".to_string(), "/tmp/snapshot-marker".to_string()])
-        .await
-        .expect("execute after snapshot recovery");
-    assert_eq!(marker.exit_code, 0, "{}", marker.stderr);
-    assert_eq!(marker.stdout, "survived-restore");
-
-    let _ = restored_client.send_ctrl_alt_del().await;
-    tokio::time::sleep(Duration::from_millis(500)).await;
-    let _ = restored.kill();
-    let _ = restored.wait();
-    let _ = std::fs::remove_file(&original_rootfs);
-    let _ = std::fs::remove_dir(
-        original_rootfs
-            .parent()
-            .expect("rootfs has a parent after restore"),
+    let (first_restore, second_restore) = tokio::join!(
+        first.restore_from(snapshot_dir.path(), &snapshot),
+        second.restore_from(snapshot_dir.path(), &snapshot),
     );
+    first_restore.expect("restore and resume first fork");
+    second_restore.expect("restore and resume second fork");
+    assert!(first.is_running());
+    assert!(second.is_running());
+
+    for fork in [&mut first, &mut second] {
+        let marker = fork
+            .exec(&["cat", "/tmp/snapshot-marker"])
+            .await
+            .expect("execute after snapshot recovery");
+        assert_eq!(marker.exit_code, 0, "{}", marker.stderr);
+        assert_eq!(marker.stdout, "survived-restore");
+        let process = fork
+            .exec(&["sh", "-c", "kill -0 $(cat /tmp/snapshot-process.pid)"])
+            .await
+            .expect("check restored guest process");
+        assert_eq!(process.exit_code, 0, "{}", process.stderr);
+    }
+
+    first
+        .write_file("/tmp/fork-a-only", b"fork-a")
+        .await
+        .expect("write first fork marker");
+    second
+        .write_file("/tmp/fork-b-only", b"fork-b")
+        .await
+        .expect("write second fork marker");
+    let first_isolated = first
+        .exec(&[
+            "sh",
+            "-c",
+            "test -f /tmp/fork-a-only && test ! -e /tmp/fork-b-only",
+        ])
+        .await
+        .expect("check first fork disk isolation");
+    let second_isolated = second
+        .exec(&[
+            "sh",
+            "-c",
+            "test -f /tmp/fork-b-only && test ! -e /tmp/fork-a-only",
+        ])
+        .await
+        .expect("check second fork disk isolation");
+    assert_eq!(first_isolated.exit_code, 0, "{}", first_isolated.stderr);
+    assert_eq!(second_isolated.exit_code, 0, "{}", second_isolated.stderr);
+
+    first.stop().await.expect("stop first restored microVM");
+    second.stop().await.expect("stop second restored microVM");
 }


### PR DESCRIPTION
## Summary

- add preview full-state `pause`, `resume`, and reusable `fork` for Firecracker 1.16.1 on same-host x86_64 Linux/KVM
- persist immutable, hashed VM-state, memory, compatibility, and rootfs artifacts; give every restore an independent CoW disk and unique API/vsock endpoints
- make pause/recovery transactional and fail closed around ambiguous runtime ownership, corrupt artifacts, incompatible hosts, quotas, and partial cleanup
- expose one lifecycle contract through CLI, HTTP, MCP, OpenAPI, and all maintained SDK types
- route short-lived CLI/MCP lifecycle operations to the long-lived daemon that owns Firecracker processes, preserving guest exit status and tenant authorization
- document the preview topology, compatibility boundary, operational recovery, and explicitly unsupported backends

## Safety and validation

- checkpoint paths, manifests, hashes, permissions, symlinks, recovery markers, capacity headroom, and concurrent fork isolation have regression coverage
- disk-only daemon refresh, one-shot start manifest integrity, JWT-only authentication, cross-tenant mutation denial, quota recovery accounting, HTTP timeouts, and structured guest failures have regression coverage
- unsupported full-state operations return explicit capability errors and never fall back silently to filesystem snapshots

Validated on the rebased commit:

- `cargo test --locked --all-targets`
- `cargo clippy --locked -- -D warnings`
- `cargo check --locked --no-default-features --all-targets`
- Firecracker full-state contract tests and native smoke compilation
- Go, Rust, Swift, Node, and Python SDK test/typecheck/lint gates
- OpenAPI YAML parse, `cargo fmt`, and `git diff --check`

## Preview boundary

This is not yet a production-readiness claim. The macOS development host cannot expose KVM. The native lifecycle smoke compiles and is intentionally ignored unless explicitly run on an approved x86_64 Linux/KVM host. Bead `agentkernel-ni6p` tracks the required end-to-end proof of RAM-only process continuity, resume, two divergent forks, vsock reconnection, corrupt-artifact failure, and cleanup.

Additional hardening is tracked separately for crash-resilient supervision, host-proxy rehydration, durable writable-disk lineage, per-tenant storage GC, file/interactive routing, TLS or Unix-socket local delegation, immutable UUID binding, and manifest cleanup.
